### PR TITLE
[google_sign_in] Support Dart-based configuration and `serverClientId`

### DIFF
--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.4.0
+
+* Adds support for configuring `serverClientId` through `GoogleSignIn` constructor.
+* Adds support for Dart-based configuration as alternative to `GoogleService-Info.plist` for iOS.
+
 ## 5.3.3
 
 * Updates references to the obsolete master branch.

--- a/packages/google_sign_in/google_sign_in/README.md
+++ b/packages/google_sign_in/google_sign_in/README.md
@@ -65,6 +65,22 @@ This plugin requires iOS 9.0 or higher.
 <!-- End of the Google Sign-in Section -->
 ```
 
+As an alternative to adding `GoogleService-Info.plist` to your Xcode project, you can instead
+configure your app in Dart code. In this case, skip steps 3-6 and pass `clientId` and
+`serverClientId` to the `GoogleSignIn` constructor:
+
+```dart
+GoogleSignIn _googleSignIn = GoogleSignIn(
+  ...
+  // The OAuth client id of your app. This is required.
+  clientId: ...,
+  // If you need to authenticate to a backend server, specify its OAuth client. This is optional.
+  serverClientId: ...,
+);
+```
+
+Note that step 7 is still required.
+
 #### iOS additional requirement
 
 Note that according to

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -12,6 +12,7 @@ import 'src/common.dart';
 
 export 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart'
     show SignInOption;
+
 export 'src/common.dart';
 export 'widgets.dart';
 
@@ -183,6 +184,7 @@ class GoogleSignIn {
     this.scopes = const <String>[],
     this.hostedDomain,
     this.clientId,
+    this.serverClientId,
   });
 
   /// Factory for creating default sign in user experience.
@@ -228,8 +230,28 @@ class GoogleSignIn {
   /// Domain to restrict sign-in to.
   final String? hostedDomain;
 
-  /// Client ID being used to connect to google sign-in. Only supported on web.
+  /// Client ID being used to connect to google sign-in.
+  ///
+  /// This option is not supported on all platforms (e.g. Android). It is
+  /// optional if file-based configuration is used.
+  ///
+  /// The value specified here has precedence over a value from a configuration
+  /// file.
   final String? clientId;
+
+  /// Client ID of the backend server to which the app needs to authenticate
+  /// itself.
+  ///
+  /// Optional and not supported on all platforms (e.g. web). By default, it
+  /// is initialized from a configuration file if available.
+  ///
+  /// The value specified here has precedence over a value from a configuration
+  /// file.
+  ///
+  /// [GoogleSignInAuthentication.idToken] and
+  /// [GoogleSignInAccount.serverAuthCode] will be specific to the backend
+  /// server.
+  final String? serverClientId;
 
   final StreamController<GoogleSignInAccount?> _currentUserController =
       StreamController<GoogleSignInAccount?>.broadcast();
@@ -260,15 +282,18 @@ class GoogleSignIn {
   }
 
   Future<void> _ensureInitialized() {
-    return _initialization ??= GoogleSignInPlatform.instance.init(
+    return _initialization ??=
+        GoogleSignInPlatform.instance.initWithParams(SignInInitParameters(
       signInOption: signInOption,
       scopes: scopes,
       hostedDomain: hostedDomain,
       clientId: clientId,
-    )..catchError((dynamic _) {
-        // Invalidate initialization if it errors out.
-        _initialization = null;
-      });
+      serverClientId: serverClientId,
+    ))
+          ..catchError((dynamic _) {
+            // Invalidate initialization if it errors out.
+            _initialization = null;
+          });
   }
 
   /// The most recently scheduled method call.

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.3.3
+version: 5.4.0
 
 
 environment:
@@ -23,9 +23,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in_android: ^5.2.5
-  google_sign_in_ios: ^5.2.5
-  google_sign_in_platform_interface: ^2.1.0
+  google_sign_in_android: ^6.0.0
+  google_sign_in_ios: ^5.4.0
+  google_sign_in_platform_interface: ^2.2.0
   google_sign_in_web: ^0.10.0
 
 dev_dependencies:


### PR DESCRIPTION
This PR removes the requirement to add a `GoogleService-Info.plist` file for iOS apps and instead allows for configuration though Dart. 

To this end, a new parameter (`serverClientId`) is added to the `GoogleSignIn` constructor. <strike>This necessitates a breaking change in `google_sign_in_platform_interface`. </strike>

While working on this PR, I noticed that on Android `clientId` was interpreted as a server client ID as opposed to an app client ID, like on iOS and Web. On Android, app client IDs are not required/supported. To provide an API that is consistent across platforms, passing a non-null value for `clientId` now <strike>throws</strike> logs a warning on Android and `serverClientId` is used as `clientId` was previously.

Closes https://github.com/flutter/flutter/issues/96391
Fixes https://github.com/flutter/flutter/issues/57945

## Todo

- [x] Add `serverClientId` parameter to platform interface `init` method (spin-out from this PR)
       https://github.com/flutter/plugins/pull/5256
- [x] Update platform implementations (spin-out from this PR)
       #6034
- [ ] Update frontend API and endorsed platform implementation versions (this PR)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
