### PR TITLE
[google_sign_in_platform_interface] Add support for `serverClientId`

### DIFF
--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Adds support for the `serverClientId` parameter.
+
 ## 2.1.3
 
 * Enables mocking models by changing overridden operator == parameter type from `dynamic` to `Object`.

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/method_channel_google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/method_channel_google_sign_in.dart
@@ -39,6 +39,7 @@ class MethodChannelGoogleSignIn extends GoogleSignInPlatform {
       'scopes': params.scopes,
       'hostedDomain': params.hostedDomain,
       'clientId': params.clientId,
+      'serverClientId': params.serverClientId,
       'forceCodeForRefreshToken': params.forceCodeForRefreshToken,
     });
   }

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -55,6 +55,10 @@ class SignInInitParameters {
   /// The default is null, which means that the client ID will be sourced from a
   /// configuration file, if required on the current platform. A value specified
   /// here takes precedence over a value specified in a configuration file.
+  /// See also:
+  ///
+  ///   * [Platform Integration](https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in#platform-integration),
+  ///     where you can find the details about the configuration files.
   final String? clientId;
 
   /// The OAuth client ID of the backend server.
@@ -63,6 +67,11 @@ class SignInInitParameters {
   /// from a configuration file, if available and supported on the current
   /// platform. A value specified here takes precedence over a value specified
   /// in a configuration file.
+  ///
+  /// See also:
+  ///
+  ///   * [Platform Integration](https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in#platform-integration),
+  ///     where you can find the details about the configuration files.
   final String? serverClientId;
 
   /// If true, ensures the authorization code can be exchanged for an access

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -35,6 +35,7 @@ class SignInInitParameters {
     this.signInOption = SignInOption.standard,
     this.hostedDomain,
     this.clientId,
+    this.serverClientId,
     this.forceCodeForRefreshToken = false,
   });
 
@@ -49,8 +50,20 @@ class SignInInitParameters {
   /// By default, the list of accounts will not be restricted.
   final String? hostedDomain;
 
-  /// The client ID to use when signing in.
+  /// The OAuth client ID of the app.
+  ///
+  /// The default is null, which means that the client ID will be sourced from a
+  /// configuration file, if required on the current platform. A value specified
+  /// here takes precedence over a value specified in a configuration file.
   final String? clientId;
+
+  /// The OAuth client ID of the backend server.
+  ///
+  /// The default is null, which means that the server client ID will be sourced
+  /// from a configuration file, if available and supported on the current
+  /// platform. A value specified here takes precedence over a value specified
+  /// in a configuration file.
+  final String? serverClientId;
 
   /// If true, ensures the authorization code can be exchanged for an access
   /// token.

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.3
+version: 2.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/method_channel_google_sign_in_test.dart
@@ -107,6 +107,7 @@ void main() {
           'scopes': <String>['two', 'scopes'],
           'signInOption': 'SignInOption.games',
           'clientId': 'fakeClientId',
+          'serverClientId': null,
           'forceCodeForRefreshToken': false,
         }),
         () {
@@ -144,6 +145,7 @@ void main() {
           scopes: <String>['two', 'scopes'],
           signInOption: SignInOption.games,
           clientId: 'fakeClientId',
+          serverClientId: 'fakeServerClientId',
           forceCodeForRefreshToken: true));
       expect(log, <Matcher>[
         isMethodCall('init', arguments: <String, dynamic>{
@@ -151,6 +153,7 @@ void main() {
           'scopes': <String>['two', 'scopes'],
           'signInOption': 'SignInOption.games',
           'clientId': 'fakeClientId',
+          'serverClientId': 'fakeServerClientId',
           'forceCodeForRefreshToken': true,
         }),
       ]);


### PR DESCRIPTION
This PR is a prerequisite for implementing https://github.com/flutter/plugins/pull/5250.
It adds support for passing a server client ID to platform implementations when initializing them.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
