### PR TITLE
[image_picker] Fix pickMultiImage throwing an error on iOS 13 and below.

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.4+12
+
+* Fixes `pickMultiImage` throwing an exception on iOS 13 and below.
+
 ## 0.8.4+11
 
 * Splits from `image_picker` as a federated implementation.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -178,6 +178,7 @@
 
   OCMVerify(times(1),
             [mockUIImagePicker setSourceType:UIImagePickerControllerSourceTypePhotoLibrary]);
+  XCTAssertEqual([plugin getMaxImagesAllowed], 0);
 }
 
 #pragma mark - Test camera devices, no op on simulators

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -73,8 +73,8 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 
-- (int) getMaxImagesAllowed {
-    return self.maxImagesAllowed;
+- (int)getMaxImagesAllowed {
+  return self.maxImagesAllowed;
 }
 
 - (UIImagePickerController *)createImagePickerController {
@@ -189,13 +189,13 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
         [self launchUIImagePickerWithSource:imageSource multiImage:false];
       }
     } else {
-        [self launchUIImagePickerWithSource:imageSource multiImage:false];
+      [self launchUIImagePickerWithSource:imageSource multiImage:false];
     }
   } else if ([@"pickMultiImage" isEqualToString:call.method]) {
     if (@available(iOS 14, *)) {
       [self pickImageWithPHPicker:0];
     } else {
-        [self launchUIImagePickerWithSource:SOURCE_GALLERY multiImage:true];
+      [self launchUIImagePickerWithSource:SOURCE_GALLERY multiImage:true];
     }
   } else if ([@"pickVideo" isEqualToString:call.method]) {
     UIImagePickerController *imagePickerController = [self createImagePickerController];

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -28,7 +28,7 @@
 - (void)handleSavedPathList:(NSArray *)pathList;
 
 /** The property to keep track of how many images are allowed to be picked */
-- (int) getMaxImagesAllowed;
+- (int)getMaxImagesAllowed;
 
 /**
  * Tells the delegate that the user cancelled the pick operation.

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -27,6 +27,9 @@
  */
 - (void)handleSavedPathList:(NSArray *)pathList;
 
+/** The property to keep track of how many images are allowed to be picked */
+- (int) getMaxImagesAllowed;
+
 /**
  * Tells the delegate that the user cancelled the pick operation.
  *

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the video_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+11
+version: 0.8.4+12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
`pickMultiImage` currently throws an exception on iOS 13 and below, due to it returning a string rather than a list of strings as it should. This PR fixes this behaviour. 

Relevant issue:
 - flutter/flutter#100132
 
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.