### PR TITLE
[flutter_plugin_tools] Run pub get for custom-test

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,10 +1,11 @@
-## NEXT
+## 0.8.2+1
 
 - Adds a new `readme-check` command.
 - Updates `publish-plugin` command documentation.
 - Fixes `all-plugins-app` to preserve the original application's Dart SDK
   version to avoid changing language feature opt-ins that the template may
   rely on.
+- Fixes `custom-test` to run `pub get` before running Dart test scripts.
 
 ## 0.8.2
 

--- a/script/tool/lib/src/custom_test_command.dart
+++ b/script/tool/lib/src/custom_test_command.dart
@@ -43,10 +43,19 @@ class CustomTestCommand extends PackageLoopingCommand {
 
     // Run the custom Dart script if presest.
     if (script.existsSync()) {
-      final int exitCode = await processRunner.runAndStream(
+      // Ensure that dependencies are available.
+      final int pubGetExitCode = await processRunner.runAndStream(
+          'dart', <String>['pub', 'get'],
+          workingDir: package.directory);
+      if (pubGetExitCode != 0) {
+        return PackageResult.fail(
+            <String>['Unable to get script dependencies']);
+      }
+
+      final int testExitCode = await processRunner.runAndStream(
           'dart', <String>['run', 'tool/$_scriptName'],
           workingDir: package.directory);
-      if (exitCode != 0) {
+      if (testExitCode != 0) {
         return PackageResult.fail();
       }
       ranTests = true;

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.8.2
+version: 0.8.2+1
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
When running a Dart test script for `custom-test`, `pub get` needs to be
run first in order for it to work in a clean environment such as CI.

This will unblock enabling Pigeon's Dart tests in flutter/packages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
