### PR TITLE
[local_auth] Fix deviceSupportsBiometrics returning false on iOS when present biometric hardware is not enrolled.

### DIFF
--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.0.4
 
-* Fix `deviceSupportsBiometrics` to return true when biometric hardware 
+* Fixes `deviceSupportsBiometrics` to return true when biometric hardware 
   is available but not enrolled.
 
 ## 1.0.3

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.4
+
+* Fix `deviceSupportsBiometrics` to return true when biometric hardware 
+  is available but not enrolled.
+
 ## 1.0.3
 
 * Adopts `Object.hash`.

--- a/packages/local_auth/local_auth_ios/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/local_auth/local_auth_ios/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -231,11 +231,13 @@
 				TargetAttributes = {
 					3398D2CC26163948005A052F = {
 						CreatedOnToolsVersion = 12.4;
+						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 97C146ED1CF9000F007C117D;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = 7624MWN53C;
 					};
 				};
 			};
@@ -410,6 +412,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -434,6 +437,7 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -557,6 +561,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -578,6 +583,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/local_auth/local_auth_ios/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/local_auth/local_auth_ios/example/ios/Runner.xcodeproj/project.pbxproj
@@ -231,13 +231,11 @@
 				TargetAttributes = {
 					3398D2CC26163948005A052F = {
 						CreatedOnToolsVersion = 12.4;
-						DevelopmentTeam = 7624MWN53C;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 97C146ED1CF9000F007C117D;
 					};
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
-						DevelopmentTeam = 7624MWN53C;
 					};
 				};
 			};
@@ -412,7 +410,6 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -437,7 +434,6 @@
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = RunnerTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
@@ -561,7 +557,6 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -583,7 +578,6 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				DEVELOPMENT_TEAM = 7624MWN53C;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/packages/local_auth/local_auth_ios/example/ios/RunnerTests/FLTLocalAuthPluginTests.m
+++ b/packages/local_auth/local_auth_ios/example/ios/RunnerTests/FLTLocalAuthPluginTests.m
@@ -292,7 +292,7 @@ static const NSTimeInterval kTimeout = 30.0;
 }
 
 - (void)testDeviceSupportsBiometrics_withNonEnrolledHardware_iOS11 {
-  if (@available(iOS 11.0.1, *)) {
+  if (@available(iOS 11, *)) {
     FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
     id mockAuthContext = OCMClassMock([LAContext class]);
     plugin.authContextOverrides = @[ mockAuthContext ];
@@ -325,40 +325,6 @@ static const NSTimeInterval kTimeout = 30.0;
 
     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
   }
-}
-
-- (void)testDeviceSupportsBiometrics_withNonEnrolledTouchID {
-  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
-  id mockAuthContext = OCMClassMock([LAContext class]);
-  plugin.authContextOverrides = @[ mockAuthContext ];
-
-  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
-  void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
-    // Write error
-    NSError *__autoreleasing *authError;
-    [invocation getArgument:&authError atIndex:3];
-    *authError = [NSError errorWithDomain:@"error" code:LAErrorTouchIDNotEnrolled userInfo:nil];
-    // Write return value
-    BOOL returnValue = NO;
-    NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
-    [invocation setReturnValue:&nsReturnValue];
-  };
-  OCMStub([mockAuthContext canEvaluatePolicy:policy
-                                       error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
-      .andDo(canEvaluatePolicyHandler);
-
-  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"deviceSupportsBiometrics"
-                                                              arguments:@{}];
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
-  [plugin handleMethodCall:call
-                    result:^(id _Nullable result) {
-                      XCTAssertTrue([NSThread isMainThread]);
-                      XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
-                      XCTAssertTrue([result boolValue]);
-                      [expectation fulfill];
-                    }];
-
-  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
 }
 
 - (void)testDeviceSupportsBiometrics_withNoBiometricHardware {
@@ -396,7 +362,7 @@ static const NSTimeInterval kTimeout = 30.0;
 }
 
 - (void)testGetEnrolledBiometrics_withFaceID_iOS11 {
-  if (@available(iOS 11.0.1, *)) {
+  if (@available(iOS 11, *)) {
     FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
     id mockAuthContext = OCMClassMock([LAContext class]);
     plugin.authContextOverrides = @[ mockAuthContext ];
@@ -422,7 +388,7 @@ static const NSTimeInterval kTimeout = 30.0;
 }
 
 - (void)testGetEnrolledBiometrics_withTouchID_iOS11 {
-  if (@available(iOS 11.0.1, *)) {
+  if (@available(iOS 11, *)) {
     FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
     id mockAuthContext = OCMClassMock([LAContext class]);
     plugin.authContextOverrides = @[ mockAuthContext ];
@@ -448,7 +414,7 @@ static const NSTimeInterval kTimeout = 30.0;
 }
 
 - (void)testGetEnrolledBiometrics_withTouchID_preIOS11 {
-  if (@available(iOS 11.0.1, *)) {
+  if (@available(iOS 11, *)) {
     return;
   }
   FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
@@ -474,7 +440,7 @@ static const NSTimeInterval kTimeout = 30.0;
 }
 
 - (void)testGetEnrolledBiometrics_withoutEnrolledHardware_iOS11 {
-  if (@available(iOS 11.0.1, *)) {
+  if (@available(iOS 11, *)) {
     FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
     id mockAuthContext = OCMClassMock([LAContext class]);
     plugin.authContextOverrides = @[ mockAuthContext ];
@@ -508,42 +474,4 @@ static const NSTimeInterval kTimeout = 30.0;
     [self waitForExpectationsWithTimeout:kTimeout handler:nil];
   }
 }
-
-- (void)testGetEnrolledBiometrics_withoutEnrolledTouchID_preIOS11 {
-  if (@available(iOS 11.0.1, *)) {
-    return;
-  }
-  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
-  id mockAuthContext = OCMClassMock([LAContext class]);
-  plugin.authContextOverrides = @[ mockAuthContext ];
-
-  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
-  void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
-    // Write error
-    NSError *__autoreleasing *authError;
-    [invocation getArgument:&authError atIndex:3];
-    *authError = [NSError errorWithDomain:@"error" code:LAErrorTouchIDNotEnrolled userInfo:nil];
-    // Write return value
-    BOOL returnValue = NO;
-    NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
-    [invocation setReturnValue:&nsReturnValue];
-  };
-  OCMStub([mockAuthContext canEvaluatePolicy:policy
-                                       error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
-      .andDo(canEvaluatePolicyHandler);
-
-  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
-                                                              arguments:@{}];
-  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
-  [plugin handleMethodCall:call
-                    result:^(id _Nullable result) {
-                      XCTAssertTrue([NSThread isMainThread]);
-                      XCTAssertTrue([result isKindOfClass:[NSArray class]]);
-                      XCTAssertEqual([result count], 0);
-                      [expectation fulfill];
-                    }];
-
-  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
-}
-
 @end

--- a/packages/local_auth/local_auth_ios/example/ios/RunnerTests/FLTLocalAuthPluginTests.m
+++ b/packages/local_auth/local_auth_ios/example/ios/RunnerTests/FLTLocalAuthPluginTests.m
@@ -269,4 +269,281 @@ static const NSTimeInterval kTimeout = 30.0;
   [self waitForExpectationsWithTimeout:kTimeout handler:nil];
 }
 
+- (void)testDeviceSupportsBiometrics_withEnrolledHardware {
+  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+  id mockAuthContext = OCMClassMock([LAContext class]);
+  plugin.authContextOverrides = @[ mockAuthContext ];
+
+  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  OCMStub([mockAuthContext canEvaluatePolicy:policy error:[OCMArg setTo:nil]]).andReturn(YES);
+
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"deviceSupportsBiometrics"
+                                                              arguments:@{}];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
+                      XCTAssertTrue([result boolValue]);
+                      [expectation fulfill];
+                    }];
+
+  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testDeviceSupportsBiometrics_withNonEnrolledHardware_iOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+    id mockAuthContext = OCMClassMock([LAContext class]);
+    plugin.authContextOverrides = @[ mockAuthContext ];
+
+    const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+      // Write error
+      NSError *__autoreleasing *authError;
+      [invocation getArgument:&authError atIndex:3];
+      *authError = [NSError errorWithDomain:@"error" code:LAErrorBiometryNotEnrolled userInfo:nil];
+      // Write return value
+      BOOL returnValue = NO;
+      NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
+      [invocation setReturnValue:&nsReturnValue];
+    };
+    OCMStub([mockAuthContext canEvaluatePolicy:policy
+                                         error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
+        .andDo(canEvaluatePolicyHandler);
+
+    FlutterMethodCall *call =
+        [FlutterMethodCall methodCallWithMethodName:@"deviceSupportsBiometrics" arguments:@{}];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [plugin handleMethodCall:call
+                      result:^(id _Nullable result) {
+                        XCTAssertTrue([NSThread isMainThread]);
+                        XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
+                        XCTAssertTrue([result boolValue]);
+                        [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+  }
+}
+
+- (void)testDeviceSupportsBiometrics_withNonEnrolledTouchID {
+  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+  id mockAuthContext = OCMClassMock([LAContext class]);
+  plugin.authContextOverrides = @[ mockAuthContext ];
+
+  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    // Write error
+    NSError *__autoreleasing *authError;
+    [invocation getArgument:&authError atIndex:3];
+    *authError = [NSError errorWithDomain:@"error" code:LAErrorTouchIDNotEnrolled userInfo:nil];
+    // Write return value
+    BOOL returnValue = NO;
+    NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
+    [invocation setReturnValue:&nsReturnValue];
+  };
+  OCMStub([mockAuthContext canEvaluatePolicy:policy
+                                       error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
+      .andDo(canEvaluatePolicyHandler);
+
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"deviceSupportsBiometrics"
+                                                              arguments:@{}];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
+                      XCTAssertTrue([result boolValue]);
+                      [expectation fulfill];
+                    }];
+
+  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testDeviceSupportsBiometrics_withNoBiometricHardware {
+  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+  id mockAuthContext = OCMClassMock([LAContext class]);
+  plugin.authContextOverrides = @[ mockAuthContext ];
+
+  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    // Write error
+    NSError *__autoreleasing *authError;
+    [invocation getArgument:&authError atIndex:3];
+    *authError = [NSError errorWithDomain:@"error" code:0 userInfo:nil];
+    // Write return value
+    BOOL returnValue = NO;
+    NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
+    [invocation setReturnValue:&nsReturnValue];
+  };
+  OCMStub([mockAuthContext canEvaluatePolicy:policy
+                                       error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
+      .andDo(canEvaluatePolicyHandler);
+
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"deviceSupportsBiometrics"
+                                                              arguments:@{}];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertTrue([result isKindOfClass:[NSNumber class]]);
+                      XCTAssertFalse([result boolValue]);
+                      [expectation fulfill];
+                    }];
+
+  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testGetEnrolledBiometrics_withFaceID_iOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+    id mockAuthContext = OCMClassMock([LAContext class]);
+    plugin.authContextOverrides = @[ mockAuthContext ];
+
+    const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    OCMStub([mockAuthContext canEvaluatePolicy:policy error:[OCMArg setTo:nil]]).andReturn(YES);
+    OCMStub([mockAuthContext biometryType]).andReturn(LABiometryTypeFaceID);
+
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
+                                                                arguments:@{}];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [plugin handleMethodCall:call
+                      result:^(id _Nullable result) {
+                        XCTAssertTrue([NSThread isMainThread]);
+                        XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+                        XCTAssertEqual([result count], 1);
+                        XCTAssertEqualObjects(result[0], @"face");
+                        [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+  }
+}
+
+- (void)testGetEnrolledBiometrics_withTouchID_iOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+    id mockAuthContext = OCMClassMock([LAContext class]);
+    plugin.authContextOverrides = @[ mockAuthContext ];
+
+    const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    OCMStub([mockAuthContext canEvaluatePolicy:policy error:[OCMArg setTo:nil]]).andReturn(YES);
+    OCMStub([mockAuthContext biometryType]).andReturn(LABiometryTypeTouchID);
+
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
+                                                                arguments:@{}];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [plugin handleMethodCall:call
+                      result:^(id _Nullable result) {
+                        XCTAssertTrue([NSThread isMainThread]);
+                        XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+                        XCTAssertEqual([result count], 1);
+                        XCTAssertEqualObjects(result[0], @"fingerprint");
+                        [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+  }
+}
+
+- (void)testGetEnrolledBiometrics_withTouchID_preIOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    return;
+  }
+  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+  id mockAuthContext = OCMClassMock([LAContext class]);
+  plugin.authContextOverrides = @[ mockAuthContext ];
+
+  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  OCMStub([mockAuthContext canEvaluatePolicy:policy error:[OCMArg setTo:nil]]).andReturn(YES);
+
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
+                                                              arguments:@{}];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+                      XCTAssertEqual([result count], 1);
+                      XCTAssertEqualObjects(result[0], @"fingerprint");
+                      [expectation fulfill];
+                    }];
+
+  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
+- (void)testGetEnrolledBiometrics_withoutEnrolledHardware_iOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+    id mockAuthContext = OCMClassMock([LAContext class]);
+    plugin.authContextOverrides = @[ mockAuthContext ];
+
+    const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+    void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+      // Write error
+      NSError *__autoreleasing *authError;
+      [invocation getArgument:&authError atIndex:3];
+      *authError = [NSError errorWithDomain:@"error" code:LAErrorBiometryNotEnrolled userInfo:nil];
+      // Write return value
+      BOOL returnValue = NO;
+      NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
+      [invocation setReturnValue:&nsReturnValue];
+    };
+    OCMStub([mockAuthContext canEvaluatePolicy:policy
+                                         error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
+        .andDo(canEvaluatePolicyHandler);
+
+    FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
+                                                                arguments:@{}];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+    [plugin handleMethodCall:call
+                      result:^(id _Nullable result) {
+                        XCTAssertTrue([NSThread isMainThread]);
+                        XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+                        XCTAssertEqual([result count], 0);
+                        [expectation fulfill];
+                      }];
+
+    [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+  }
+}
+
+- (void)testGetEnrolledBiometrics_withoutEnrolledTouchID_preIOS11 {
+  if (@available(iOS 11.0.1, *)) {
+    return;
+  }
+  FLTLocalAuthPlugin *plugin = [[FLTLocalAuthPlugin alloc] init];
+  id mockAuthContext = OCMClassMock([LAContext class]);
+  plugin.authContextOverrides = @[ mockAuthContext ];
+
+  const LAPolicy policy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
+  void (^canEvaluatePolicyHandler)(NSInvocation *) = ^(NSInvocation *invocation) {
+    // Write error
+    NSError *__autoreleasing *authError;
+    [invocation getArgument:&authError atIndex:3];
+    *authError = [NSError errorWithDomain:@"error" code:LAErrorTouchIDNotEnrolled userInfo:nil];
+    // Write return value
+    BOOL returnValue = NO;
+    NSValue *nsReturnValue = [NSValue valueWithBytes:&returnValue objCType:@encode(BOOL)];
+    [invocation setReturnValue:&nsReturnValue];
+  };
+  OCMStub([mockAuthContext canEvaluatePolicy:policy
+                                       error:(NSError * __autoreleasing *)[OCMArg anyPointer]])
+      .andDo(canEvaluatePolicyHandler);
+
+  FlutterMethodCall *call = [FlutterMethodCall methodCallWithMethodName:@"getEnrolledBiometrics"
+                                                              arguments:@{}];
+  XCTestExpectation *expectation = [self expectationWithDescription:@"Result is called"];
+  [plugin handleMethodCall:call
+                    result:^(id _Nullable result) {
+                      XCTAssertTrue([NSThread isMainThread]);
+                      XCTAssertTrue([result isKindOfClass:[NSArray class]]);
+                      XCTAssertEqual([result count], 0);
+                      [expectation fulfill];
+                    }];
+
+  [self waitForExpectationsWithTimeout:kTimeout handler:nil];
+}
+
 @end

--- a/packages/local_auth/local_auth_ios/example/lib/main.dart
+++ b/packages/local_auth/local_auth_ios/example/lib/main.dart
@@ -25,7 +25,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   _SupportState _supportState = _SupportState.unknown;
   bool? _canCheckBiometrics;
-  List<BiometricType>? _availableBiometrics;
+  List<BiometricType>? _enrolledBiometrics;
   String _authorized = 'Not Authorized';
   bool _isAuthenticating = false;
 
@@ -40,12 +40,12 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _checkBiometrics() async {
-    late bool canCheckBiometrics;
+    late bool deviceSupportsBiometrics;
     try {
-      canCheckBiometrics =
-          (await LocalAuthPlatform.instance.getEnrolledBiometrics()).isNotEmpty;
+      deviceSupportsBiometrics =
+          await LocalAuthPlatform.instance.deviceSupportsBiometrics();
     } on PlatformException catch (e) {
-      canCheckBiometrics = false;
+      deviceSupportsBiometrics = false;
       print(e);
     }
     if (!mounted) {
@@ -53,17 +53,17 @@ class _MyAppState extends State<MyApp> {
     }
 
     setState(() {
-      _canCheckBiometrics = canCheckBiometrics;
+      _canCheckBiometrics = deviceSupportsBiometrics;
     });
   }
 
   Future<void> _getEnrolledBiometrics() async {
-    late List<BiometricType> availableBiometrics;
+    late List<BiometricType> enrolledBiometrics;
     try {
-      availableBiometrics =
+      enrolledBiometrics =
           await LocalAuthPlatform.instance.getEnrolledBiometrics();
     } on PlatformException catch (e) {
-      availableBiometrics = <BiometricType>[];
+      enrolledBiometrics = <BiometricType>[];
       print(e);
     }
     if (!mounted) {
@@ -71,7 +71,7 @@ class _MyAppState extends State<MyApp> {
     }
 
     setState(() {
-      _availableBiometrics = availableBiometrics;
+      _enrolledBiometrics = enrolledBiometrics;
     });
   }
 
@@ -173,13 +173,13 @@ class _MyAppState extends State<MyApp> {
                 else
                   const Text('This device is not supported'),
                 const Divider(height: 100),
-                Text('Can check biometrics: $_canCheckBiometrics\n'),
+                Text('Device supports biometrics: $_canCheckBiometrics\n'),
                 ElevatedButton(
                   child: const Text('Check biometrics'),
                   onPressed: _checkBiometrics,
                 ),
                 const Divider(height: 100),
-                Text('Available biometrics: $_availableBiometrics\n'),
+                Text('Enrolled biometrics: $_enrolledBiometrics\n'),
                 ElevatedButton(
                   child: const Text('Get available biometrics'),
                   onPressed: _getEnrolledBiometrics,

--- a/packages/local_auth/local_auth_ios/example/lib/main.dart
+++ b/packages/local_auth/local_auth_ios/example/lib/main.dart
@@ -181,7 +181,7 @@ class _MyAppState extends State<MyApp> {
                 const Divider(height: 100),
                 Text('Enrolled biometrics: $_enrolledBiometrics\n'),
                 ElevatedButton(
-                  child: const Text('Get available biometrics'),
+                  child: const Text('Get enrolled biometrics'),
                   onPressed: _getEnrolledBiometrics,
                 ),
                 const Divider(height: 100),

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -108,13 +108,12 @@
   }
   // If not, check if it is because no biometrics are enrolled (but still present).
   if (authError != nil) {
-    if (@available(iOS 11.0.1, *)) {
+    if (@available(iOS 11, *)) {
       if (authError.code == LAErrorBiometryNotEnrolled) {
         result(@YES);
         return;
       }
-    }
-    if (authError.code == LAErrorTouchIDNotEnrolled) {
+    } else if (authError.code == LAErrorTouchIDNotEnrolled) {
       result(@YES);
       return;
     }
@@ -130,7 +129,7 @@
   if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
                            error:&authError]) {
     if (authError == nil) {
-      if (@available(iOS 11.0.1, *)) {
+      if (@available(iOS 11, *)) {
         if (context.biometryType == LABiometryTypeFaceID) {
           [biometrics addObject:@"face"];
         } else if (context.biometryType == LABiometryTypeTouchID) {

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -140,14 +140,6 @@
         [biometrics addObject:@"fingerprint"];
       }
     }
-  } else if (authError.code == LAErrorTouchIDNotEnrolled) {
-    [biometrics addObject:@"undefined"];
-  } else {
-    if (@available(iOS 11.0.1, *)) {
-      if (authError != nil && authError.code == LAErrorBiometryNotEnrolled) {
-        [biometrics addObject:@"undefined"];
-      }
-    }
   }
   result(biometrics);
 }

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -35,8 +35,10 @@
     } else {
       [self authenticate:call.arguments withFlutterResult:result];
     }
-  } else if ([@"getAvailableBiometrics" isEqualToString:call.method]) {
-    [self getAvailableBiometrics:result];
+  } else if ([@"getEnrolledBiometrics" isEqualToString:call.method]) {
+    [self getEnrolledBiometrics:result];
+  } else if ([@"deviceSupportsBiometrics" isEqualToString:call.method]) {
+    [self deviceSupportsBiometrics:result];
   } else if ([@"isDeviceSupported" isEqualToString:call.method]) {
     result(@YES);
   } else {
@@ -93,7 +95,36 @@
                                                                                    completion:nil];
 }
 
-- (void)getAvailableBiometrics:(FlutterResult)result {
+- (void)deviceSupportsBiometrics:(FlutterResult)result {
+  LAContext *context = self.createAuthContext;
+  NSError *authError = nil;
+  // Check if authentication with biometrics is possible.
+  if ([context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
+                           error:&authError]) {
+    if (authError == nil) {
+      result(@YES);
+      return;
+    }
+  }
+  // If not, check if it is because no biometrics are enrolled (but still present).
+  if (authError != nil) {
+      if (@available(iOS 11.0.1, *)) {
+        if (authError.code == LAErrorBiometryNotEnrolled) {
+          result(@YES);
+          return;
+        }
+      }
+    if (authError.code == LAErrorTouchIDNotEnrolled) {
+      result(@YES);
+      return;
+    }
+    
+  }
+
+  result(@NO);
+}
+
+- (void)getEnrolledBiometrics:(FlutterResult)result  {
   LAContext *context = self.createAuthContext;
   NSError *authError = nil;
   NSMutableArray<NSString *> *biometrics = [[NSMutableArray<NSString *> alloc] init];
@@ -112,6 +143,12 @@
     }
   } else if (authError.code == LAErrorTouchIDNotEnrolled) {
     [biometrics addObject:@"undefined"];
+  } else {
+    if (@available(iOS 11.0.1, *)) {
+      if (authError != nil && authError.code == LAErrorBiometryNotEnrolled) {
+        [biometrics addObject:@"undefined"];
+      }
+    }
   }
   result(biometrics);
 }

--- a/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
+++ b/packages/local_auth/local_auth_ios/ios/Classes/FLTLocalAuthPlugin.m
@@ -108,23 +108,22 @@
   }
   // If not, check if it is because no biometrics are enrolled (but still present).
   if (authError != nil) {
-      if (@available(iOS 11.0.1, *)) {
-        if (authError.code == LAErrorBiometryNotEnrolled) {
-          result(@YES);
-          return;
-        }
+    if (@available(iOS 11.0.1, *)) {
+      if (authError.code == LAErrorBiometryNotEnrolled) {
+        result(@YES);
+        return;
       }
+    }
     if (authError.code == LAErrorTouchIDNotEnrolled) {
       result(@YES);
       return;
     }
-    
   }
 
   result(@NO);
 }
 
-- (void)getEnrolledBiometrics:(FlutterResult)result  {
+- (void)getEnrolledBiometrics:(FlutterResult)result {
   LAContext *context = self.createAuthContext;
   NSError *authError = nil;
   NSMutableArray<NSString *> *biometrics = [[NSMutableArray<NSString *> alloc] init];

--- a/packages/local_auth/local_auth_ios/lib/local_auth_ios.dart
+++ b/packages/local_auth/local_auth_ios/lib/local_auth_ios.dart
@@ -49,13 +49,14 @@ class LocalAuthIOS extends LocalAuthPlatform {
 
   @override
   Future<bool> deviceSupportsBiometrics() async {
-    return (await getEnrolledBiometrics()).isNotEmpty;
+    return (await _channel.invokeMethod<bool>('deviceSupportsBiometrics')) ??
+        false;
   }
 
   @override
   Future<List<BiometricType>> getEnrolledBiometrics() async {
     final List<String> result = (await _channel.invokeListMethod<String>(
-          'getAvailableBiometrics',
+          'getEnrolledBiometrics',
         )) ??
         <String>[];
     final List<BiometricType> biometrics = <BiometricType>[];
@@ -69,8 +70,6 @@ class LocalAuthIOS extends LocalAuthPlatform {
           break;
         case 'iris':
           biometrics.add(BiometricType.iris);
-          break;
-        case 'undefined':
           break;
       }
     }

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_ios
 description: iOS implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth/local_auth_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.3
+version: 1.0.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth_ios/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth_ios/test/local_auth_test.dart
@@ -24,7 +24,7 @@ void main() {
       channel.setMockMethodCallHandler((MethodCall methodCall) {
         log.add(methodCall);
         switch (methodCall.method) {
-          case 'getAvailableBiometrics':
+          case 'getEnrolledBiometrics':
             return Future<List<String>>.value(
                 <String>['face', 'fingerprint', 'iris', 'undefined']);
           default:
@@ -35,13 +35,13 @@ void main() {
       log.clear();
     });
 
-    test('deviceSupportsBiometrics calls getEnrolledBiometrics', () async {
+    test('deviceSupportsBiometrics calls platform', () async {
       final bool result = await localAuthentication.deviceSupportsBiometrics();
 
       expect(
         log,
         <Matcher>[
-          isMethodCall('getAvailableBiometrics', arguments: null),
+          isMethodCall('deviceSupportsBiometrics', arguments: null),
         ],
       );
       expect(result, true);
@@ -54,7 +54,7 @@ void main() {
       expect(
         log,
         <Matcher>[
-          isMethodCall('getAvailableBiometrics', arguments: null),
+          isMethodCall('getEnrolledBiometrics', arguments: null),
         ],
       );
       expect(result, <BiometricType>[


### PR DESCRIPTION
This PR adds a custom implementation for `deviceSupportsBiometrics` to return true  when biometric hardware is present, but not enrolled, as per the current documentation. 

Additionally, it removes the confusing `undefined` value from `getEnrolledBiometrics`.

These are the same changes that happened for `local_auth_android` in:
- #5309

Semi-related to flutter/flutter#45497.

Relevant discussion: https://github.com/flutter/plugins/pull/5309#discussion_r854476644

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.