### PR TITLE
[url_launcher] Add canLaunch fallback for web on Android

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.0.16
 
-* Add fallback querying for `canLaunch` with web URLs, to avoid false negatives
+* Adds fallback querying for `canLaunch` with web URLs, to avoid false negatives
   when there is a custom scheme handler.
 
 ## 6.0.15

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.0.16
+
+* Add fallback querying for `canLaunch` with web URLs, to avoid false negatives
+  when there is a custom scheme handler.
+
 ## 6.0.15
 
 * Switches to an in-package method channel implementation.

--- a/packages/url_launcher/url_launcher_android/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_android/example/lib/main.dart
@@ -35,73 +35,74 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
+  bool _hasCallSupport = false;
   Future<void>? _launched;
   String _phone = '';
 
+  @override
+  void initState() {
+    super.initState();
+    // Check for phone call support.
+    launcher.canLaunch('tel:123').then((bool result) {
+      setState(() {
+        _hasCallSupport = result;
+      });
+    });
+  }
+
   Future<void> _launchInBrowser(String url) async {
-    final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
-    if (await launcher.canLaunch(url)) {
-      await launcher.launch(
-        url,
-        useSafariVC: false,
-        useWebView: false,
-        enableJavaScript: false,
-        enableDomStorage: false,
-        universalLinksOnly: false,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
-      );
-    } else {
+    if (!await launcher.launch(
+      url,
+      useSafariVC: false,
+      useWebView: false,
+      enableJavaScript: false,
+      enableDomStorage: false,
+      universalLinksOnly: false,
+      headers: <String, String>{},
+    )) {
       throw 'Could not launch $url';
     }
   }
 
-  Future<void> _launchInWebViewOrVC(String url) async {
-    final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
-    if (await launcher.canLaunch(url)) {
-      await launcher.launch(
-        url,
-        useSafariVC: true,
-        useWebView: true,
-        enableJavaScript: false,
-        enableDomStorage: false,
-        universalLinksOnly: false,
-        headers: <String, String>{'my_header_key': 'my_header_value'},
-      );
-    } else {
+  Future<void> _launchInWebView(String url) async {
+    if (!await launcher.launch(
+      url,
+      useSafariVC: true,
+      useWebView: true,
+      enableJavaScript: false,
+      enableDomStorage: false,
+      universalLinksOnly: false,
+      headers: <String, String>{'my_header_key': 'my_header_value'},
+    )) {
       throw 'Could not launch $url';
     }
   }
 
   Future<void> _launchInWebViewWithJavaScript(String url) async {
-    final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
-    if (await launcher.canLaunch(url)) {
-      await launcher.launch(
-        url,
-        useSafariVC: true,
-        useWebView: true,
-        enableJavaScript: true,
-        enableDomStorage: false,
-        universalLinksOnly: false,
-        headers: <String, String>{},
-      );
-    } else {
+    if (!await launcher.launch(
+      url,
+      useSafariVC: true,
+      useWebView: true,
+      enableJavaScript: true,
+      enableDomStorage: false,
+      universalLinksOnly: false,
+      headers: <String, String>{},
+    )) {
       throw 'Could not launch $url';
     }
   }
 
   Future<void> _launchInWebViewWithDomStorage(String url) async {
-    final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
-    if (await launcher.canLaunch(url)) {
-      await launcher.launch(
-        url,
-        useSafariVC: true,
-        useWebView: true,
-        enableJavaScript: false,
-        enableDomStorage: true,
-        universalLinksOnly: false,
-        headers: <String, String>{},
-      );
-    } else {
+    if (!await launcher.launch(
+      url,
+      useSafariVC: true,
+      useWebView: true,
+      enableJavaScript: false,
+      enableDomStorage: true,
+      universalLinksOnly: false,
+      headers: <String, String>{},
+    )) {
       throw 'Could not launch $url';
     }
   }
@@ -114,25 +115,30 @@ class _MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  Future<void> _makePhoneCall(String url) async {
-    final UrlLauncherPlatform launcher = UrlLauncherPlatform.instance;
-    if (await launcher.canLaunch(url)) {
-      await launcher.launch(
-        url,
-        useSafariVC: false,
-        useWebView: false,
-        enableJavaScript: false,
-        enableDomStorage: false,
-        universalLinksOnly: true,
-        headers: <String, String>{},
-      );
-    } else {
-      throw 'Could not launch $url';
-    }
+  Future<void> _makePhoneCall(String phoneNumber) async {
+    // Use `Uri` to ensure that `phoneNumber` is properly URL-encoded.
+    // Just using 'tel:$phoneNumber' would create invalid URLs in some cases,
+    // such as spaces in the input, which would cause `launch` to fail on some
+    // platforms.
+    final Uri launchUri = Uri(
+      scheme: 'tel',
+      path: phoneNumber,
+    );
+    await launcher.launch(
+      launchUri.toString(),
+      useSafariVC: false,
+      useWebView: false,
+      enableJavaScript: false,
+      enableDomStorage: false,
+      universalLinksOnly: true,
+      headers: <String, String>{},
+    );
   }
 
   @override
   Widget build(BuildContext context) {
+    // onPressed calls using this URL are not gated on a 'canLaunch' check
+    // because the assumption is that every device can launch a web URL.
     const String toLaunch = 'https://www.cylog.org/headers/';
     return Scaffold(
       appBar: AppBar(
@@ -151,10 +157,14 @@ class _MyHomePageState extends State<MyHomePage> {
                         hintText: 'Input the phone number to launch')),
               ),
               ElevatedButton(
-                onPressed: () => setState(() {
-                  _launched = _makePhoneCall('tel:$_phone');
-                }),
-                child: const Text('Make phone call'),
+                onPressed: _hasCallSupport
+                    ? () => setState(() {
+                          _launched = _makePhoneCall(_phone);
+                        })
+                    : null,
+                child: _hasCallSupport
+                    ? const Text('Make phone call')
+                    : const Text('Calling not supported'),
               ),
               const Padding(
                 padding: EdgeInsets.all(16.0),
@@ -169,7 +179,7 @@ class _MyHomePageState extends State<MyHomePage> {
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebViewOrVC(toLaunch);
+                  _launched = _launchInWebView(toLaunch);
                 }),
                 child: const Text('Launch in app'),
               ),
@@ -177,21 +187,21 @@ class _MyHomePageState extends State<MyHomePage> {
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithJavaScript(toLaunch);
                 }),
-                child: const Text('Launch in app(JavaScript ON)'),
+                child: const Text('Launch in app (JavaScript ON)'),
               ),
               ElevatedButton(
                 onPressed: () => setState(() {
                   _launched = _launchInWebViewWithDomStorage(toLaunch);
                 }),
-                child: const Text('Launch in app(DOM storage ON)'),
+                child: const Text('Launch in app (DOM storage ON)'),
               ),
               const Padding(padding: EdgeInsets.all(16.0)),
               ElevatedButton(
                 onPressed: () => setState(() {
-                  _launched = _launchInWebViewOrVC(toLaunch);
+                  _launched = _launchInWebView(toLaunch);
                   Timer(const Duration(seconds: 5), () {
                     print('Closing WebView after 5 seconds...');
-                    UrlLauncherPlatform.instance.closeWebView();
+                    launcher.closeWebView();
                   });
                 }),
                 child: const Text('Launch in app + close after 5 seconds'),

--- a/packages/url_launcher/url_launcher_android/lib/url_launcher_android.dart
+++ b/packages/url_launcher/url_launcher_android/lib/url_launcher_android.dart
@@ -22,7 +22,24 @@ class UrlLauncherAndroid extends UrlLauncherPlatform {
   final LinkDelegate? linkDelegate = null;
 
   @override
-  Future<bool> canLaunch(String url) {
+  Future<bool> canLaunch(String url) async {
+    final bool canLaunchSpecificUrl = await _canLaunchUrl(url);
+    if (!canLaunchSpecificUrl) {
+      final String scheme = _getUrlScheme(url);
+      // canLaunch can return false when a custom application is registered to
+      // handle a web URL, but this application doesn't have permission to see
+      // what that handler is. If that happens, try a web URL (with the same
+      // scheme variant, to be safe) that should not have a custom handler. If
+      // that returns true, then there is a browser, which means that there is
+      // at least one handler for the original URL.
+      if (scheme == 'http' || scheme == 'https') {
+        return await _canLaunchUrl('$scheme://flutter.dev');
+      }
+    }
+    return canLaunchSpecificUrl;
+  }
+
+  Future<bool> _canLaunchUrl(String url) {
     return _channel.invokeMethod<bool>(
       'canLaunch',
       <String, Object>{'url': url},
@@ -56,5 +73,17 @@ class UrlLauncherAndroid extends UrlLauncherPlatform {
         'headers': headers,
       },
     ).then((bool? value) => value ?? false);
+  }
+
+  // Returns the part of [url] up to the first ':', or an empty string if there
+  // is no ':'. This deliberately does not use [Uri] to extract the scheme
+  // so that it works on strings that aren't actually valid URLs, since Android
+  // is very lenient about what it accepts for launching.
+  String _getUrlScheme(String url) {
+    final int schemeEnd = url.indexOf(':');
+    if (schemeEnd == -1) {
+      return '';
+    }
+    return url.substring(0, schemeEnd);
   }
 }

--- a/packages/url_launcher/url_launcher_android/lib/url_launcher_android.dart
+++ b/packages/url_launcher/url_launcher_android/lib/url_launcher_android.dart
@@ -27,10 +27,10 @@ class UrlLauncherAndroid extends UrlLauncherPlatform {
     if (!canLaunchSpecificUrl) {
       final String scheme = _getUrlScheme(url);
       // canLaunch can return false when a custom application is registered to
-      // handle a web URL, but this application doesn't have permission to see
-      // what that handler is. If that happens, try a web URL (with the same
-      // scheme variant, to be safe) that should not have a custom handler. If
-      // that returns true, then there is a browser, which means that there is
+      // handle a web URL, but the caller doesn't have permission to see what
+      // that handler is. If that happens, try a web URL (with the same scheme
+      // variant, to be safe) that should not have a custom handler. If that
+      // returns true, then there is a browser, which means that there is
       // at least one handler for the original URL.
       if (scheme == 'http' || scheme == 'https') {
         return await _canLaunchUrl('$scheme://flutter.dev');

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.15
+version: 6.0.16
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_android/test/url_launcher_android_test.dart
+++ b/packages/url_launcher/url_launcher_android/test/url_launcher_android_test.dart
@@ -10,10 +10,12 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  group('$UrlLauncherAndroid', () {
-    const MethodChannel channel =
-        MethodChannel('plugins.flutter.io/url_launcher_android');
-    final List<MethodCall> log = <MethodCall>[];
+  const MethodChannel channel =
+      MethodChannel('plugins.flutter.io/url_launcher_android');
+  late List<MethodCall> log;
+
+  setUp(() {
+    log = <MethodCall>[];
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       log.add(methodCall);
 
@@ -21,17 +23,15 @@ void main() {
       // returned by the method channel if no return statement is specified.
       return null;
     });
+  });
 
-    tearDown(() {
-      log.clear();
-    });
+  test('registers instance', () {
+    UrlLauncherAndroid.registerWith();
+    expect(UrlLauncherPlatform.instance, isA<UrlLauncherAndroid>());
+  });
 
-    test('registers instance', () {
-      UrlLauncherAndroid.registerWith();
-      expect(UrlLauncherPlatform.instance, isA<UrlLauncherAndroid>());
-    });
-
-    test('canLaunch', () async {
+  group('canLaunch', () {
+    test('calls through', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.canLaunch('http://example.com/');
       expect(
@@ -44,14 +44,16 @@ void main() {
       );
     });
 
-    test('canLaunch should return false if platform returns null', () async {
+    test('returns false if platform returns null', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       final bool canLaunch = await launcher.canLaunch('http://example.com/');
 
       expect(canLaunch, false);
     });
+  });
 
-    test('launch', () async {
+  group('launch', () {
+    test('calls through', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -77,7 +79,7 @@ void main() {
       );
     });
 
-    test('launch with headers', () async {
+    test('passes headers', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -103,7 +105,7 @@ void main() {
       );
     });
 
-    test('launch universal links only', () async {
+    test('handles universal links only', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -129,7 +131,7 @@ void main() {
       );
     });
 
-    test('launch force WebView', () async {
+    test('handles force WebView', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -155,7 +157,7 @@ void main() {
       );
     });
 
-    test('launch force WebView enable javascript', () async {
+    test('handles force WebView with javascript', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -181,7 +183,7 @@ void main() {
       );
     });
 
-    test('launch force WebView enable DOM storage', () async {
+    test('handles force WebView with DOM storage', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.launch(
         'http://example.com/',
@@ -207,7 +209,7 @@ void main() {
       );
     });
 
-    test('launch should return false if platform returns null', () async {
+    test('returns false if platform returns null', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       final bool launched = await launcher.launch(
         'http://example.com/',
@@ -221,8 +223,10 @@ void main() {
 
       expect(launched, false);
     });
+  });
 
-    test('closeWebView default behavior', () async {
+  group('closeWebView', () {
+    test('calls through', () async {
       final UrlLauncherAndroid launcher = UrlLauncherAndroid();
       await launcher.closeWebView();
       expect(


### PR DESCRIPTION
[url_launcher] Add canLaunch fallback for web on Android

If `canLaunch` returns false for a web URL on Android, re-queries with a
generic URL, since this can happen if there is a custom handler for the
queried URL (e.g,. YouTube or Google Maps urls), but the plugin client
application doesn't have permission to see that application.

Fixes https://github.com/flutter/flutter/issues/93765

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
