### PR TITLE
[video_player] Fix XCUITest based on the new tooltip accessibility label

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.3
+
+* Fix XCUITest based on the new voice over announcement for tooltips.
+  See: https://github.com/flutter/flutter/pull/87684
+
 ## 2.3.2
 
 * Applies the standardized transform for videos with different orientations.

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -37,8 +37,8 @@
     // We try to find the button if the old accessibility value is used.
     // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
     // https://github.com/flutter/flutter/issues/102771
-    playbackSpeed1x = app.staticTexts[@"Playback speed\n1.0x\n"];
-    foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:30.0];
+    playbackSpeed1x = app.staticTexts[@"Playback speed\n1.0x"];
+    foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:2.0];
   }
   XCTAssertTrue(foundPlaybackSpeed1x);
   [playbackSpeed1x tap];
@@ -55,7 +55,7 @@
     // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
     // https://github.com/flutter/flutter/issues/102771
     playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x\n"];
-    foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:30.0];
+    foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:2.0];
   }
   XCTAssertTrue(foundPlaybackSpeed5x);
   [playbackSpeed5x tap];

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -30,16 +30,35 @@
   XCTAssertTrue([playButton waitForExistenceWithTimeout:30.0]);
   [playButton tap];
 
-  XCUIElement *playbackSpeed1x = app.staticTexts[@"Playback speed\n1.0x"];
-  XCTAssertTrue([playbackSpeed1x waitForExistenceWithTimeout:30.0]);
+  XCUIElement *playbackSpeed1x = app.staticTexts[@"1.0x\nPlayback speed"];
+  BOOL foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:30.0];
+  if (!foundPlaybackSpeed1x) {
+    // Some old flutter version uses a different accessibility value for tooltips.
+    // We try to find the button if the old accessibility value is used.
+    // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
+    // https://github.com/flutter/flutter/issues/102771
+    playbackSpeed1x = app.staticTexts[@"Playback speed\n1.0x\n"];
+    foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:30.0];
+  }
+  XCTAssertTrue(foundPlaybackSpeed1x);
   [playbackSpeed1x tap];
 
   XCUIElement *playbackSpeed5xButton = app.buttons[@"5.0x"];
   XCTAssertTrue([playbackSpeed5xButton waitForExistenceWithTimeout:30.0]);
   [playbackSpeed5xButton tap];
 
-  XCUIElement *playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x"];
-  XCTAssertTrue([playbackSpeed5x waitForExistenceWithTimeout:30.0]);
+  XCUIElement *playbackSpeed5x = app.staticTexts[@"5.0x\nPlayback speed"];
+  BOOL foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:30.0];
+  if (!foundPlaybackSpeed5x) {
+    // Some old flutter version uses a different accessibility value for tooltips.
+    // We try to find the button if the old accessibility value is used.
+    // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
+    // https://github.com/flutter/flutter/issues/102771
+    playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x\n"];
+    foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:30.0];
+  }
+  XCTAssertTrue(foundPlaybackSpeed5x);
+  [playbackSpeed5x tap];
 
   // Cycle through tabs.
   for (NSString *tabName in @[ @"Asset", @"Remote" ]) {

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -54,7 +54,7 @@
     // We try to find the button if the old accessibility value is used.
     // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
     // https://github.com/flutter/flutter/issues/102771
-    playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x\n"];
+    playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x"];
     foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:2.0];
   }
   XCTAssertTrue(foundPlaybackSpeed5x);

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -31,7 +31,7 @@
   [playButton tap];
 
   NSPredicate *find1xButton = [NSPredicate predicateWithFormat:@"label CONTAINS '1.0x'"];
-  XCUIElement *playbackSpeed1x = [app.staticTexts containingPredicate:find1xButton].element;
+  XCUIElement *playbackSpeed1x = [app.staticTexts elementMatchingPredicate:find1xButton];
   BOOL foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:30.0];
   XCTAssertTrue(foundPlaybackSpeed1x);
   [playbackSpeed1x tap];
@@ -41,7 +41,7 @@
   [playbackSpeed5xButton tap];
 
   NSPredicate *find5xButton = [NSPredicate predicateWithFormat:@"label CONTAINS '5.0x'"];
-  XCUIElement *playbackSpeed5x = [app.staticTexts containingPredicate:find5xButton].element;
+  XCUIElement *playbackSpeed5x = [app.staticTexts elementMatchingPredicate:find5xButton];
   BOOL foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:30.0];
   XCTAssertTrue(foundPlaybackSpeed5x);
 

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -30,16 +30,9 @@
   XCTAssertTrue([playButton waitForExistenceWithTimeout:30.0]);
   [playButton tap];
 
-  XCUIElement *playbackSpeed1x = app.staticTexts[@"1.0x\nPlayback speed"];
+  NSPredicate *find1xButton = [NSPredicate predicateWithFormat:@"label CONTAINS '1.0x'"];
+  XCUIElement *playbackSpeed1x = [app.staticTexts containingPredicate:find1xButton].element;
   BOOL foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:30.0];
-  if (!foundPlaybackSpeed1x) {
-    // Some old flutter version uses a different accessibility value for tooltips.
-    // We try to find the button if the old accessibility value is used.
-    // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
-    // https://github.com/flutter/flutter/issues/102771
-    playbackSpeed1x = app.staticTexts[@"Playback speed\n1.0x"];
-    foundPlaybackSpeed1x = [playbackSpeed1x waitForExistenceWithTimeout:2.0];
-  }
   XCTAssertTrue(foundPlaybackSpeed1x);
   [playbackSpeed1x tap];
 
@@ -47,18 +40,10 @@
   XCTAssertTrue([playbackSpeed5xButton waitForExistenceWithTimeout:30.0]);
   [playbackSpeed5xButton tap];
 
-  XCUIElement *playbackSpeed5x = app.staticTexts[@"5.0x\nPlayback speed"];
+  NSPredicate *find5xButton = [NSPredicate predicateWithFormat:@"label CONTAINS '5.0x'"];
+  XCUIElement *playbackSpeed5x = [app.staticTexts containingPredicate:find5xButton].element;
   BOOL foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:30.0];
-  if (!foundPlaybackSpeed5x) {
-    // Some old flutter version uses a different accessibility value for tooltips.
-    // We try to find the button if the old accessibility value is used.
-    // TODO(cyanglaz): Remove this when the new accessibility value is supported on flutter/stable
-    // https://github.com/flutter/flutter/issues/102771
-    playbackSpeed5x = app.staticTexts[@"Playback speed\n5.0x"];
-    foundPlaybackSpeed5x = [playbackSpeed5x waitForExistenceWithTimeout:2.0];
-  }
   XCTAssertTrue(foundPlaybackSpeed5x);
-  [playbackSpeed5x tap];
 
   // Cycle through tabs.
   for (NSString *tabName in @[ @"Asset", @"Remote" ]) {

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.2
+version: 2.3.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
The accessibility label for tool tip seems change in one of the recent flutter updates(https://github.com/flutter/flutter/pull/87684), which results failure in this particular XCUITest. This is blocking the flutter to plugins roll.

Fixes: https://github.com/flutter/flutter/issues/102698

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
