### PR TITLE
Add dependabot for Gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,139 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/packages/flutter_plugin_android_lifecycle/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/path_provider/path_provider/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/path_provider/path_provider_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/webview_flutter/webview_flutter/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/connectivity/connectivity/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_sign_in/google_sign_in/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_sign_in/google_sign_in_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/camera/camera/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/local_auth/local_auth_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/local_auth/local_auth/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/video_player/video_player_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/url_launcher/url_launcher_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/url_launcher/url_launcher/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_maps_flutter/google_maps_flutter/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/in_app_purchase/in_app_purchase_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/in_app_purchase/in_app_purchase/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/image_picker/image_picker/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/quick_actions/quick_actions_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/quick_actions/quick_actions/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/shared_preferences/shared_preferences/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/shared_preferences/shared_preferences_android/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/espresso/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/espresso/example/android/app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,139 +1,257 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
-    directory: "/packages/flutter_plugin_android_lifecycle/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/path_provider/path_provider/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/path_provider/path_provider_android/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/webview_flutter/webview_flutter/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/connectivity/connectivity/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/google_sign_in/google_sign_in/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/google_sign_in/google_sign_in_android/example/android/app"
+    directory: "/packages/camera/camera/android"
+    commit-message:
+      prefix: "[camera]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/camera/camera/example/android/app"
+    commit-message:
+      prefix: "[camera]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/local_auth/local_auth_android/example/android/app"
+    directory: "/packages/espresso/example/android/app"
+    commit-message:
+      prefix: "[espresso]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/local_auth/local_auth/example/android/app"
+    directory: "/packages/flutter_plugin_android_lifecycle/android"
+    commit-message:
+      prefix: "[flutter_plugin_android_lifecycle]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/video_player/video_player_android/example/android/app"
+    directory: "/packages/flutter_plugin_android_lifecycle/example/android/app"
+    commit-message:
+      prefix: "[flutter_plugin_android_lifecycle]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/url_launcher/url_launcher_android/example/android/app"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/url_launcher/url_launcher/example/android/app"
+    directory: "/packages/google_maps_flutter/google_maps_flutter/android"
+    commit-message:
+      prefix: "[google_maps_flutter]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/google_maps_flutter/google_maps_flutter/example/android/app"
+    commit-message:
+      prefix: "[google_maps_flutter]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_sign_in/google_sign_in/example/android/app"
+    commit-message:
+      prefix: "[google_sign_in]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_sign_in/google_sign_in_android/android"
+    commit-message:
+      prefix: "[google_sign_in_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/google_sign_in/google_sign_in_android/example/android/app"
+    commit-message:
+      prefix: "[google_sign_in_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/in_app_purchase/in_app_purchase_android/android"
+    commit-message:
+      prefix: "[in_app_purchase_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/in_app_purchase/in_app_purchase_android/example/android/app"
+    commit-message:
+      prefix: "[in_app_purchase_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/in_app_purchase/in_app_purchase/example/android/app"
+    commit-message:
+      prefix: "[in_app_purchase]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/image_picker/image_picker/example/android/app"
+    commit-message:
+      prefix: "[image_picker]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/local_auth/local_auth_android/android"
+    commit-message:
+      prefix: "[local_auth_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/local_auth/local_auth_android/example/android/app"
+    commit-message:
+      prefix: "[local_auth_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/local_auth/local_auth/example/android/app"
+    commit-message:
+      prefix: "[local_auth]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/path_provider/path_provider/example/android/app"
+    commit-message:
+      prefix: "[path_provider]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/path_provider/path_provider_android/example/android/app"
+    commit-message:
+      prefix: "[path_provider_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/quick_actions/quick_actions_android/android"
+    commit-message:
+      prefix: "[quick_actions_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/quick_actions/quick_actions_android/example/android/app"
+    commit-message:
+      prefix: "[quick_actions_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/quick_actions/quick_actions/example/android/app"
+    commit-message:
+      prefix: "[quick_actions]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/shared_preferences/shared_preferences/example/android/app"
+    commit-message:
+      prefix: "[shared_preferences]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/shared_preferences/shared_preferences_android/example/android/app"
+    commit-message:
+      prefix: "[shared_preferences_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/espresso/example/android/app"
+    directory: "/packages/url_launcher/url_launcher_android/android"
+    commit-message:
+      prefix: "[url_launcher_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
-    directory: "/packages/espresso/example/android/app"
+    directory: "/packages/url_launcher/url_launcher_android/example/android/app"
+    commit-message:
+      prefix: "[url_launcher_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/url_launcher/url_launcher/example/android/app"
+    commit-message:
+      prefix: "[url_launcher]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/video_player/video_player_android/android"
+    commit-message:
+      prefix: "[video_player_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/video_player/video_player_android/example/android/app"
+    commit-message:
+      prefix: "[video_player_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/webview_flutter/webview_flutter/example/android/app"
+    commit-message:
+      prefix: "[webview_flutter]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/webview_flutter/webview_flutter_android/android"
+    commit-message:
+      prefix: "[webview_flutter_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/webview_flutter/webview_flutter_android/example/android"
+    commit-message:
+      prefix: "[webview_flutter_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,137 +3,137 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/packages/flutter_plugin_android_lifecycle/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/path_provider/path_provider/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/path_provider/path_provider_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/webview_flutter/webview_flutter/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/connectivity/connectivity/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/google_sign_in/google_sign_in/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/google_sign_in/google_sign_in_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/camera/camera/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/local_auth/local_auth_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/local_auth/local_auth/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/video_player/video_player_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/url_launcher/url_launcher_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/url_launcher/url_launcher/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/google_maps_flutter/google_maps_flutter/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/in_app_purchase/in_app_purchase_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/in_app_purchase/in_app_purchase/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/image_picker/image_picker/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/quick_actions/quick_actions_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/quick_actions/quick_actions/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/shared_preferences/shared_preferences/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/shared_preferences/shared_preferences_android/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/espresso/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
     directory: "/packages/espresso/example/android/app"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,14 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
+    directory: "/packages/espresso/android"
+    commit-message:
+      prefix: "[espresso]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
     directory: "/packages/espresso/example/android/app"
     commit-message:
       prefix: "[espresso]"
@@ -113,6 +121,22 @@ updates:
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gradle"
+    directory: "/packages/image_picker/image_picker_android/android"
+    commit-message:
+      prefix: "[image_picker_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/image_picker/image_picker_android/example/android/app"
+    commit-message:
+      prefix: "[image_picker_android]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
     directory: "/packages/local_auth/local_auth_android/android"
     commit-message:
       prefix: "[local_auth_android]"
@@ -140,6 +164,14 @@ updates:
     directory: "/packages/path_provider/path_provider/example/android/app"
     commit-message:
       prefix: "[path_provider]"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/path_provider/path_provider_android/android"
+    commit-message:
+      prefix: "[path_provider_android]"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Adds dependabot for Gradle dependencies.

Unfortunately, dependabot doesn't support globs patterns in directory.

cc @stuartmorgan 
