### PR TITLE
[tools] Remove single-example RepositoryPackage method

### DIFF
--- a/script/tool/lib/src/common/repository_package.dart
+++ b/script/tool/lib/src/common/repository_package.dart
@@ -112,13 +112,4 @@ class RepositoryPackage {
         .map((FileSystemEntity entity) =>
             RepositoryPackage(entity as Directory));
   }
-
-  /// Returns the example directory, assuming there is only one.
-  ///
-  /// DO NOT USE THIS METHOD. It exists only to easily find code that was
-  /// written to use a single example and needs to be restructured to handle
-  /// multiple examples. New code should always use [getExamples].
-  // TODO(stuartmorgan): Eliminate all uses of this.
-  RepositoryPackage getSingleExampleDeprecated() =>
-      RepositoryPackage(directory.childDirectory('example'));
 }

--- a/script/tool/lib/src/drive_examples_command.dart
+++ b/script/tool/lib/src/drive_examples_command.dart
@@ -125,8 +125,7 @@ class DriveExamplesCommand extends PackageLoopingCommand {
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
     final bool isPlugin = isFlutterPlugin(package);
 
-    if (package.isPlatformInterface &&
-        !package.getSingleExampleDeprecated().directory.existsSync()) {
+    if (package.isPlatformInterface && package.getExamples().isEmpty) {
       // Platform interface packages generally aren't intended to have
       // examples, and don't need integration tests, so skip rather than fail.
       return PackageResult.skip(

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -119,7 +119,32 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
-    final RepositoryPackage example = package.getSingleExampleDeprecated();
+    final List<PackageResult> results = <PackageResult>[];
+    for (final RepositoryPackage example in package.getExamples()) {
+      results.add(await _runForExample(example, package: package));
+    }
+
+    // If all results skipped, report skip overall.
+    if (results
+        .every((PackageResult result) => result.state == RunState.skipped)) {
+      return PackageResult.skip('No examples support Android.');
+    }
+    // Otherwise, report failure if there were any failures.
+    final List<String> allErrors = results
+        .map((PackageResult result) =>
+            result.state == RunState.failed ? result.details : <String>[])
+        .expand((List<String> list) => list)
+        .toList();
+    return allErrors.isEmpty
+        ? PackageResult.success()
+        : PackageResult.fail(allErrors);
+  }
+
+  /// Runs the test for the given example of [package].
+  Future<PackageResult> _runForExample(
+    RepositoryPackage example, {
+    required RepositoryPackage package,
+  }) async {
     final Directory androidDirectory =
         example.directory.childDirectory('android');
     if (!androidDirectory.existsSync()) {
@@ -163,7 +188,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     // Used within the loop to ensure a unique GCS output location for each
     // test file's run.
     int resultsCounter = 0;
-    for (final File test in _findIntegrationTestFiles(package)) {
+    for (final File test in _findIntegrationTestFiles(example)) {
       final String testName =
           getRelativePosixPath(test, from: package.directory);
       print('Testing $testName...');
@@ -175,7 +200,8 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
       final String buildId = getStringArg('build-id');
       final String testRunId = getStringArg('test-run-id');
       final String resultsDir =
-          'plugins_android_test/${package.displayName}/$buildId/$testRunId/${resultsCounter++}/';
+          'plugins_android_test/${package.displayName}/$buildId/$testRunId/'
+          '${example.directory.basename}/${resultsCounter++}/';
 
       // Automatically retry failures; there is significant flake with these
       // tests whose cause isn't yet understood, and having to re-run the
@@ -299,12 +325,10 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     return true;
   }
 
-  /// Finds and returns all integration test files for [package].
-  Iterable<File> _findIntegrationTestFiles(RepositoryPackage package) sync* {
-    final Directory integrationTestDir = package
-        .getSingleExampleDeprecated()
-        .directory
-        .childDirectory('integration_test');
+  /// Finds and returns all integration test files for [example].
+  Iterable<File> _findIntegrationTestFiles(RepositoryPackage example) sync* {
+    final Directory integrationTestDir =
+        example.directory.childDirectory('integration_test');
 
     if (!integrationTestDir.existsSync()) {
       return;


### PR DESCRIPTION
Eliminates the remaining uses of the deprecated method for returning the
example for a package that assumed there must be only one example,
migrating the remaining uses to support multi-example.

Fixes one unit test that was accidentally testing the wrong failure case
due to a copy/paste mistake, noticed while updating tests for this
change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
