### PR TITLE
[tools] Convert test utils to RepositoryPackage

### DIFF
--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -30,6 +30,10 @@ const String platformWindows = 'windows';
 /// Key for enable experiment.
 const String kEnableExperiment = 'enable-experiment';
 
+/// Target platforms supported by Flutter.
+// ignore: public_member_api_docs
+enum FlutterPlatform { android, ios, linux, macos, web, windows }
+
 /// Returns whether the given directory is a Dart package.
 bool isPackage(FileSystemEntity entity) {
   if (entity is! Directory) {

--- a/script/tool/lib/src/common/core.dart
+++ b/script/tool/lib/src/common/core.dart
@@ -39,9 +39,13 @@ bool isPackage(FileSystemEntity entity) {
   if (entity is! Directory) {
     return false;
   }
-  // Per https://dart.dev/guides/libraries/create-library-packages#what-makes-a-library-package
-  return entity.childFile('pubspec.yaml').existsSync() &&
-      entity.childDirectory('lib').existsSync();
+  // According to
+  // https://dart.dev/guides/libraries/create-library-packages#what-makes-a-library-package
+  // a package must also have a `lib/` directory, but in practice that's not
+  // always true. flutter/plugins has some special cases (espresso, some
+  // federated implementation packages) that don't have any source, so this
+  // deliberately doesn't check that there's a lib directory.
+  return entity.childFile('pubspec.yaml').existsSync();
 }
 
 /// Prints `successMessage` in green.

--- a/script/tool/lib/src/common/gradle.dart
+++ b/script/tool/lib/src/common/gradle.dart
@@ -6,6 +6,7 @@ import 'package:file/file.dart';
 import 'package:platform/platform.dart';
 
 import 'process_runner.dart';
+import 'repository_package.dart';
 
 const String _gradleWrapperWindows = 'gradlew.bat';
 const String _gradleWrapperNonWindows = 'gradlew';
@@ -21,7 +22,7 @@ class GradleProject {
   });
 
   /// The directory of a Flutter project to run Gradle commands in.
-  final Directory flutterProject;
+  final RepositoryPackage flutterProject;
 
   /// The [ProcessRunner] used to run commands. Overridable for testing.
   final ProcessRunner processRunner;
@@ -30,7 +31,8 @@ class GradleProject {
   final Platform platform;
 
   /// The project's 'android' directory.
-  Directory get androidDirectory => flutterProject.childDirectory('android');
+  Directory get androidDirectory =>
+      flutterProject.platformDirectory(FlutterPlatform.android);
 
   /// The path to the Gradle wrapper file for the project.
   File get gradleWrapper => androidDirectory.childFile(

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -368,7 +368,7 @@ abstract class PluginCommand extends Command<void> {
       await for (final FileSystemEntity entity
           in dir.list(followLinks: false)) {
         // A top-level Dart package is a plugin package.
-        if (_isDartPackage(entity)) {
+        if (isPackage(entity)) {
           if (packages.isEmpty || packages.contains(p.basename(entity.path))) {
             yield PackageEnumerationEntry(
                 RepositoryPackage(entity as Directory),
@@ -378,7 +378,7 @@ abstract class PluginCommand extends Command<void> {
           // Look for Dart packages under this top-level directory.
           await for (final FileSystemEntity subdir
               in entity.list(followLinks: false)) {
-            if (_isDartPackage(subdir)) {
+            if (isPackage(subdir)) {
               // There are three ways for a federated plugin to match:
               // - package name (path_provider_android)
               // - fully specified name (path_provider/path_provider_android)
@@ -427,9 +427,9 @@ abstract class PluginCommand extends Command<void> {
       {bool filterExcluded = true}) async* {
     yield* package.directory
         .list(recursive: true, followLinks: false)
-        .where(_isDartPackage)
+        .where(isPackage)
         .map((FileSystemEntity directory) =>
-            // _isDartPackage guarantees that this cast is valid.
+            // isPackage guarantees that this cast is valid.
             RepositoryPackage(directory as Directory));
   }
 
@@ -446,12 +446,6 @@ abstract class PluginCommand extends Command<void> {
         .list(recursive: true, followLinks: false)
         .where((FileSystemEntity entity) => entity is File)
         .cast<File>();
-  }
-
-  /// Returns whether the specified entity is a directory containing a
-  /// `pubspec.yaml` file.
-  bool _isDartPackage(FileSystemEntity entity) {
-    return entity is Directory && entity.childFile('pubspec.yaml').existsSync();
   }
 
   /// Retrieve an instance of [GitVersionFinder] based on `_baseShaArg` and [gitDir].

--- a/script/tool/lib/src/common/repository_package.dart
+++ b/script/tool/lib/src/common/repository_package.dart
@@ -9,6 +9,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 import 'core.dart';
 
 export 'package:pubspec_parse/pubspec_parse.dart' show Pubspec;
+export 'core.dart' show FlutterPlatform;
 
 /// A package in the repository.
 //
@@ -52,6 +53,44 @@ class RepositoryPackage {
 
   /// The package's top-level README.
   File get readmeFile => directory.childFile('README.md');
+
+  /// The package's top-level README.
+  File get changelogFile => directory.childFile('CHANGELOG.md');
+
+  /// The package's top-level README.
+  File get authorsFile => directory.childFile('AUTHORS');
+
+  /// The lib directory containing the package's code.
+  Directory get libDirectory => directory.childDirectory('lib');
+
+  /// The test directory containing the package's Dart tests.
+  Directory get testDirectory => directory.childDirectory('test');
+
+  /// Returns the directory containing support for [platform].
+  Directory platformDirectory(FlutterPlatform platform) {
+    late final String directoryName;
+    switch (platform) {
+      case FlutterPlatform.android:
+        directoryName = 'android';
+        break;
+      case FlutterPlatform.ios:
+        directoryName = 'ios';
+        break;
+      case FlutterPlatform.linux:
+        directoryName = 'linux';
+        break;
+      case FlutterPlatform.macos:
+        directoryName = 'macos';
+        break;
+      case FlutterPlatform.web:
+        directoryName = 'web';
+        break;
+      case FlutterPlatform.windows:
+        directoryName = 'windows';
+        break;
+    }
+    return directory.childDirectory(directoryName);
+  }
 
   late final Pubspec _parsedPubspec =
       Pubspec.parse(pubspecFile.readAsStringSync());

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -146,7 +146,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     required RepositoryPackage package,
   }) async {
     final Directory androidDirectory =
-        example.directory.childDirectory('android');
+        example.platformDirectory(FlutterPlatform.android);
     if (!androidDirectory.existsSync()) {
       return PackageResult.skip(
           '${example.displayName} does not support Android.');
@@ -171,7 +171,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     }
 
     // Ensures that gradle wrapper exists
-    final GradleProject project = GradleProject(example.directory,
+    final GradleProject project = GradleProject(example,
         processRunner: processRunner, platform: platform);
     if (!await _ensureGradleWrapperExists(project)) {
       return PackageResult.fail(<String>['Unable to build example apk']);

--- a/script/tool/lib/src/lint_android_command.dart
+++ b/script/tool/lib/src/lint_android_command.dart
@@ -40,7 +40,7 @@ class LintAndroidCommand extends PackageLoopingCommand {
 
     bool failed = false;
     for (final RepositoryPackage example in package.getExamples()) {
-      final GradleProject project = GradleProject(example.directory,
+      final GradleProject project = GradleProject(example,
           processRunner: processRunner, platform: platform);
 
       if (!project.isConfigured()) {

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -178,7 +178,7 @@ dependency_overrides:
       for (final String packageName in packagesToOverride) {
         // Find the relative path from the common base to the local package.
         final List<String> repoRelativePathComponents = path.split(
-            path.relative(localDependencies[packageName]!.directory.path,
+            path.relative(localDependencies[packageName]!.path,
                 from: commonBasePath));
         newPubspecContents += '''
   $packageName:

--- a/script/tool/lib/src/native_test_command.dart
+++ b/script/tool/lib/src/native_test_command.dart
@@ -198,22 +198,22 @@ this command.
   Future<_PlatformResult> _testAndroid(
       RepositoryPackage plugin, _TestMode mode) async {
     bool exampleHasUnitTests(RepositoryPackage example) {
-      return example.directory
-              .childDirectory('android')
+      return example
+              .platformDirectory(FlutterPlatform.android)
               .childDirectory('app')
               .childDirectory('src')
               .childDirectory('test')
               .existsSync() ||
-          example.directory.parent
-              .childDirectory('android')
+          plugin
+              .platformDirectory(FlutterPlatform.android)
               .childDirectory('src')
               .childDirectory('test')
               .existsSync();
     }
 
     bool exampleHasNativeIntegrationTests(RepositoryPackage example) {
-      final Directory integrationTestDirectory = example.directory
-          .childDirectory('android')
+      final Directory integrationTestDirectory = example
+          .platformDirectory(FlutterPlatform.android)
           .childDirectory('app')
           .childDirectory('src')
           .childDirectory('androidTest');
@@ -269,7 +269,7 @@ this command.
       _printRunningExampleTestsMessage(example, 'Android');
 
       final GradleProject project = GradleProject(
-        example.directory,
+        example,
         processRunner: processRunner,
         platform: platform,
       );

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -246,12 +246,12 @@ HTTP response: ${pubVersionFinderResponse.httpResponse.body}
 
   bool _passesAuthorsCheck(RepositoryPackage package) {
     final List<String> pathComponents =
-        package.directory.fileSystem.path.split(package.directory.path);
+        package.directory.fileSystem.path.split(package.path);
     if (pathComponents.contains('third_party')) {
       // Third-party packages aren't required to have an AUTHORS file.
       return true;
     }
-    return package.directory.childFile('AUTHORS').existsSync();
+    return package.authorsFile.existsSync();
   }
 
   void _printImportantStatusMessage(String message, {required bool isError}) {

--- a/script/tool/lib/src/test_command.dart
+++ b/script/tool/lib/src/test_command.dart
@@ -41,7 +41,7 @@ class TestCommand extends PackageLoopingCommand {
 
   @override
   Future<PackageResult> runForPackage(RepositoryPackage package) async {
-    if (!package.directory.childDirectory('test').existsSync()) {
+    if (!package.testDirectory.existsSync()) {
       return PackageResult.skip('No test/ directory.');
     }
 

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -384,7 +384,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     final Version fromPubspec = pubspec.version!;
 
     // get first version from CHANGELOG
-    final File changelog = package.directory.childFile('CHANGELOG.md');
+    final File changelog = package.changelogFile;
     final List<String> lines = changelog.readAsLinesSync();
     String? firstLineWithText;
     final Iterator<String> iterator = lines.iterator;

--- a/script/tool/test/analyze_command_test.dart
+++ b/script/tool/test/analyze_command_test.dart
@@ -37,45 +37,45 @@ void main() {
   });
 
   test('analyzes all packages', () async {
-    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
-    final Directory plugin2Dir = createFakePlugin('b', packagesDir);
+    final RepositoryPackage plugin1 = createFakePlugin('a', packagesDir);
+    final RepositoryPackage plugin2 = createFakePlugin('b', packagesDir);
 
     await runCapturingPrint(runner, <String>['analyze']);
 
     expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin1Dir.path),
-          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              plugin1Dir.path),
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin2Dir.path),
-          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              plugin2Dir.path),
+          ProcessCall('flutter', const <String>['pub', 'get'], plugin1.path),
+          ProcessCall(
+              'dart', const <String>['analyze', '--fatal-infos'], plugin1.path),
+          ProcessCall('flutter', const <String>['pub', 'get'], plugin2.path),
+          ProcessCall(
+              'dart', const <String>['analyze', '--fatal-infos'], plugin2.path),
         ]));
   });
 
   test('skips flutter pub get for examples', () async {
-    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
+    final RepositoryPackage plugin1 = createFakePlugin('a', packagesDir);
 
     await runCapturingPrint(runner, <String>['analyze']);
 
     expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin1Dir.path),
-          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              plugin1Dir.path),
+          ProcessCall('flutter', const <String>['pub', 'get'], plugin1.path),
+          ProcessCall(
+              'dart', const <String>['analyze', '--fatal-infos'], plugin1.path),
         ]));
   });
 
   test('runs flutter pub get for non-example subpackages', () async {
-    final Directory mainPackageDir = createFakePackage('a', packagesDir);
-    final Directory otherPackages =
-        mainPackageDir.childDirectory('other_packages');
-    final Directory subpackage1 =
-        createFakePackage('subpackage1', otherPackages);
-    final Directory subpackage2 =
-        createFakePackage('subpackage2', otherPackages);
+    final RepositoryPackage mainPackage = createFakePackage('a', packagesDir);
+    final Directory otherPackagesDir =
+        mainPackage.directory.childDirectory('other_packages');
+    final RepositoryPackage subpackage1 =
+        createFakePackage('subpackage1', otherPackagesDir);
+    final RepositoryPackage subpackage2 =
+        createFakePackage('subpackage2', otherPackagesDir);
 
     await runCapturingPrint(runner, <String>['analyze']);
 
@@ -83,36 +83,36 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(
-              'flutter', const <String>['pub', 'get'], mainPackageDir.path),
+              'flutter', const <String>['pub', 'get'], mainPackage.path),
           ProcessCall(
               'flutter', const <String>['pub', 'get'], subpackage1.path),
           ProcessCall(
               'flutter', const <String>['pub', 'get'], subpackage2.path),
           ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              mainPackageDir.path),
+              mainPackage.path),
         ]));
   });
 
   test('don\'t elide a non-contained example package', () async {
-    final Directory plugin1Dir = createFakePlugin('a', packagesDir);
-    final Directory plugin2Dir = createFakePlugin('example', packagesDir);
+    final RepositoryPackage plugin1 = createFakePlugin('a', packagesDir);
+    final RepositoryPackage plugin2 = createFakePlugin('example', packagesDir);
 
     await runCapturingPrint(runner, <String>['analyze']);
 
     expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin1Dir.path),
-          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              plugin1Dir.path),
-          ProcessCall('flutter', const <String>['pub', 'get'], plugin2Dir.path),
-          ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-              plugin2Dir.path),
+          ProcessCall('flutter', const <String>['pub', 'get'], plugin1.path),
+          ProcessCall(
+              'dart', const <String>['analyze', '--fatal-infos'], plugin1.path),
+          ProcessCall('flutter', const <String>['pub', 'get'], plugin2.path),
+          ProcessCall(
+              'dart', const <String>['analyze', '--fatal-infos'], plugin2.path),
         ]));
   });
 
   test('uses a separate analysis sdk', () async {
-    final Directory pluginDir = createFakePlugin('a', packagesDir);
+    final RepositoryPackage plugin = createFakePlugin('a', packagesDir);
 
     await runCapturingPrint(
         runner, <String>['analyze', '--analysis-sdk', 'foo/bar/baz']);
@@ -123,12 +123,12 @@ void main() {
         ProcessCall(
           'flutter',
           const <String>['pub', 'get'],
-          pluginDir.path,
+          plugin.path,
         ),
         ProcessCall(
           'foo/bar/baz/bin/dart',
           const <String>['analyze', '--fatal-infos'],
-          pluginDir.path,
+          plugin.path,
         ),
       ]),
     );
@@ -180,7 +180,7 @@ void main() {
     });
 
     test('takes an allow list', () async {
-      final Directory pluginDir = createFakePlugin('foo', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('foo', packagesDir,
           extraFiles: <String>['analysis_options.yaml']);
 
       await runCapturingPrint(
@@ -189,15 +189,14 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(
-                'flutter', const <String>['pub', 'get'], pluginDir.path),
+            ProcessCall('flutter', const <String>['pub', 'get'], plugin.path),
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-                pluginDir.path),
+                plugin.path),
           ]));
     });
 
     test('takes an allow config file', () async {
-      final Directory pluginDir = createFakePlugin('foo', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('foo', packagesDir,
           extraFiles: <String>['analysis_options.yaml']);
       final File allowFile = packagesDir.childFile('custom.yaml');
       allowFile.writeAsStringSync('- foo');
@@ -208,10 +207,9 @@ void main() {
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
-            ProcessCall(
-                'flutter', const <String>['pub', 'get'], pluginDir.path),
+            ProcessCall('flutter', const <String>['pub', 'get'], plugin.path),
             ProcessCall('dart', const <String>['analyze', '--fatal-infos'],
-                pluginDir.path),
+                plugin.path),
           ]));
     });
 
@@ -280,7 +278,7 @@ void main() {
   // modify the script above, as it is run from source, but out-of-repo.
   // Contact stuartmorgan or devoncarew for assistance.
   test('Dart repo analyze command works', () async {
-    final Directory pluginDir = createFakePlugin('foo', packagesDir,
+    final RepositoryPackage plugin = createFakePlugin('foo', packagesDir,
         extraFiles: <String>['analysis_options.yaml']);
     final File allowFile = packagesDir.childFile('custom.yaml');
     allowFile.writeAsStringSync('- foo');
@@ -300,12 +298,12 @@ void main() {
         ProcessCall(
           'flutter',
           const <String>['pub', 'get'],
-          pluginDir.path,
+          plugin.path,
         ),
         ProcessCall(
           'foo/bar/baz/bin/dart',
           const <String>['analyze', '--fatal-infos'],
-          pluginDir.path,
+          plugin.path,
         ),
       ]),
     );

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -134,13 +134,12 @@ void main() {
 
     test('building for iOS', () async {
       mockPlatform.isMacOS = true;
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformIOS: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner,
           <String>['build-examples', '--ios', '--enable-experiment=exp1']);
@@ -191,13 +190,12 @@ void main() {
 
     test('building for Linux', () async {
       mockPlatform.isLinux = true;
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformLinux: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--linux']);
@@ -240,13 +238,12 @@ void main() {
 
     test('building for macOS', () async {
       mockPlatform.isMacOS = true;
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformMacOS: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--macos']);
@@ -286,13 +283,12 @@ void main() {
     });
 
     test('building for web', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformWeb: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['build-examples', '--web']);
@@ -336,13 +332,12 @@ void main() {
 
     test('building for Windows', () async {
       mockPlatform.isWindows = true;
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformWindows: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['build-examples', '--windows']);
@@ -386,13 +381,12 @@ void main() {
     });
 
     test('building for Android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'build-examples',
@@ -415,13 +409,12 @@ void main() {
     });
 
     test('enable-experiment flag for Android', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       await runCapturingPrint(runner,
           <String>['build-examples', '--apk', '--enable-experiment=exp1']);
@@ -437,13 +430,12 @@ void main() {
     });
 
     test('enable-experiment flag for ios', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformIOS: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       await runCapturingPrint(runner,
           <String>['build-examples', '--ios', '--enable-experiment=exp1']);
@@ -481,7 +473,7 @@ void main() {
 
     group('packages', () {
       test('builds when requested platform is supported by example', () async {
-        final Directory packageDirectory = createFakePackage(
+        final RepositoryPackage package = createFakePackage(
             'package', packagesDir, isFlutter: true, extraFiles: <String>[
           'example/ios/Runner.xcodeproj/project.pbxproj'
         ]);
@@ -507,7 +499,7 @@ void main() {
                     'ios',
                     '--no-codesign',
                   ],
-                  packageDirectory.childDirectory('example').path),
+                  getExampleDir(package).path),
             ]));
       });
 
@@ -567,7 +559,7 @@ void main() {
       });
 
       test('logs skipped platforms when only some are supported', () async {
-        final Directory packageDirectory = createFakePackage(
+        final RepositoryPackage package = createFakePackage(
             'package', packagesDir,
             isFlutter: true,
             extraFiles: <String>['example/linux/CMakeLists.txt']);
@@ -590,21 +582,20 @@ void main() {
               ProcessCall(
                   getFlutterCommand(mockPlatform),
                   const <String>['build', 'linux'],
-                  packageDirectory.childDirectory('example').path),
+                  getExampleDir(package).path),
             ]));
       });
     });
 
     test('The .pluginToolsConfig.yaml file', () async {
       mockPlatform.isLinux = true;
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformLinux: const PlatformDetails(PlatformSupport.inline),
             platformMacOS: const PlatformDetails(PlatformSupport.inline),
           });
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final File pluginExampleConfigFile =
           pluginExampleDirectory.childFile('.pluginToolsConfig.yaml');

--- a/script/tool/test/common/gradle_test.dart
+++ b/script/tool/test/common/gradle_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   group('isConfigured', () {
     test('reports true when configured on Windows', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('reports true when configured on non-Windows', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
@@ -49,7 +49,7 @@ void main() {
     });
 
     test('reports false when not configured on Windows', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/foo']);
       final GradleProject project = GradleProject(
@@ -62,7 +62,7 @@ void main() {
     });
 
     test('reports true when configured on non-Windows', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/foo']);
       final GradleProject project = GradleProject(
@@ -75,9 +75,9 @@ void main() {
     });
   });
 
-  group('runXcodeBuild', () {
+  group('runCommand', () {
     test('runs without arguments', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
@@ -93,16 +93,19 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                plugin.childDirectory('android').childFile('gradlew').path,
+                plugin
+                    .platformDirectory(FlutterPlatform.android)
+                    .childFile('gradlew')
+                    .path,
                 const <String>[
                   'foo',
                 ],
-                plugin.childDirectory('android').path),
+                plugin.platformDirectory(FlutterPlatform.android).path),
           ]));
     });
 
     test('runs with arguments', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew']);
       final GradleProject project = GradleProject(
@@ -121,18 +124,21 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                plugin.childDirectory('android').childFile('gradlew').path,
+                plugin
+                    .platformDirectory(FlutterPlatform.android)
+                    .childFile('gradlew')
+                    .path,
                 const <String>[
                   'foo',
                   '--bar',
                   '--baz',
                 ],
-                plugin.childDirectory('android').path),
+                plugin.platformDirectory(FlutterPlatform.android).path),
           ]));
     });
 
     test('runs with the correct wrapper on Windows', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(
@@ -148,16 +154,19 @@ void main() {
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
             ProcessCall(
-                plugin.childDirectory('android').childFile('gradlew.bat').path,
+                plugin
+                    .platformDirectory(FlutterPlatform.android)
+                    .childFile('gradlew.bat')
+                    .path,
                 const <String>[
                   'foo',
                 ],
-                plugin.childDirectory('android').path),
+                plugin.platformDirectory(FlutterPlatform.android).path),
           ]));
     });
 
     test('returns error codes', () async {
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin', fileSystem.directory('/'),
           extraFiles: <String>['android/gradlew.bat']);
       final GradleProject project = GradleProject(

--- a/script/tool/test/common/plugin_command_test.dart
+++ b/script/tool/test/common/plugin_command_test.dart
@@ -62,18 +62,24 @@ void main() {
 
   group('plugin iteration', () {
     test('all plugins from file system', () async {
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
       await runCapturingPrint(runner, <String>['sample']);
       expect(command.plugins,
           unorderedEquals(<String>[plugin1.path, plugin2.path]));
     });
 
     test('includes both plugins and packages', () async {
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-      final Directory package3 = createFakePackage('package3', packagesDir);
-      final Directory package4 = createFakePackage('package4', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage package3 =
+          createFakePackage('package3', packagesDir);
+      final RepositoryPackage package4 =
+          createFakePackage('package4', packagesDir);
       await runCapturingPrint(runner, <String>['sample']);
       expect(
           command.plugins,
@@ -86,9 +92,11 @@ void main() {
     });
 
     test('all plugins includes third_party/packages', () async {
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
-      final Directory plugin3 =
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin3 =
           createFakePlugin('plugin3', thirdPartyPackagesDir);
       await runCapturingPrint(runner, <String>['sample']);
       expect(command.plugins,
@@ -96,10 +104,12 @@ void main() {
     });
 
     test('--packages limits packages', () async {
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir);
       createFakePackage('package3', packagesDir);
-      final Directory package4 = createFakePackage('package4', packagesDir);
+      final RepositoryPackage package4 =
+          createFakePackage('package4', packagesDir);
       await runCapturingPrint(
           runner, <String>['sample', '--packages=plugin1,package4']);
       expect(
@@ -111,10 +121,12 @@ void main() {
     });
 
     test('--plugins acts as an alias to --packages', () async {
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir);
       createFakePackage('package3', packagesDir);
-      final Directory package4 = createFakePackage('package4', packagesDir);
+      final RepositoryPackage package4 =
+          createFakePackage('package4', packagesDir);
       await runCapturingPrint(
           runner, <String>['sample', '--plugins=plugin1,package4']);
       expect(
@@ -127,7 +139,8 @@ void main() {
 
     test('exclude packages when packages flag is specified', () async {
       createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
       await runCapturingPrint(runner, <String>[
         'sample',
         '--packages=plugin1,plugin2',
@@ -146,7 +159,8 @@ void main() {
 
     test('exclude federated plugins when packages flag is specified', () async {
       createFakePlugin('plugin1', packagesDir.childDirectory('federated'));
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
       await runCapturingPrint(runner, <String>[
         'sample',
         '--packages=federated/plugin1,plugin2',
@@ -158,7 +172,8 @@ void main() {
     test('exclude entire federated plugins when packages flag is specified',
         () async {
       createFakePlugin('plugin1', packagesDir.childDirectory('federated'));
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
       await runCapturingPrint(runner, <String>[
         'sample',
         '--packages=federated/plugin1,plugin2',
@@ -189,11 +204,11 @@ packages/plugin1/plugin1/plugin1.dart
 '''),
       ];
       final Directory pluginGroup = packagesDir.childDirectory('plugin1');
-      final Directory appFacingPackage =
+      final RepositoryPackage appFacingPackage =
           createFakePlugin('plugin1', pluginGroup);
-      final Directory platformInterfacePackage =
+      final RepositoryPackage platformInterfacePackage =
           createFakePlugin('plugin1_platform_interface', pluginGroup);
-      final Directory implementationPackage =
+      final RepositoryPackage implementationPackage =
           createFakePlugin('plugin1_web', pluginGroup);
 
       await runCapturingPrint(
@@ -217,7 +232,7 @@ packages/plugin1/plugin1/plugin1.dart
 '''),
       ];
       final Directory pluginGroup = packagesDir.childDirectory('plugin1');
-      final Directory appFacingPackage =
+      final RepositoryPackage appFacingPackage =
           createFakePlugin('plugin1', pluginGroup);
       createFakePlugin('plugin1_platform_interface', pluginGroup);
       createFakePlugin('plugin1_web', pluginGroup);
@@ -239,7 +254,7 @@ packages/plugin1/plugin1/plugin1.dart
       final Directory pluginGroup = packagesDir.childDirectory('plugin1');
 
       createFakePlugin('plugin1', pluginGroup);
-      final Directory platformInterfacePackage =
+      final RepositoryPackage platformInterfacePackage =
           createFakePlugin('plugin1_platform_interface', pluginGroup);
       createFakePlugin('plugin1_web', pluginGroup);
 
@@ -265,14 +280,15 @@ packages/plugin1/plugin1/plugin1.dart
           CommandRunner<void>('common_command', 'subpackage testing');
       localRunner.addCommand(localCommand);
 
-      final Directory package = createFakePackage('apackage', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('apackage', packagesDir);
 
       await runCapturingPrint(localRunner, <String>['sample']);
       expect(
           localCommand.plugins,
           containsAllInOrder(<String>[
             package.path,
-            package.childDirectory('example').path,
+            getExampleDir(package).path,
           ]));
     });
 
@@ -340,8 +356,10 @@ packages/plugin1/plugin1/plugin1.dart
 
     group('test run-on-changed-packages', () {
       test('all plugins should be tested if there are no changes.', () async {
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -355,8 +373,10 @@ packages/plugin1/plugin1/plugin1.dart
         processRunner.mockProcessesForExecutable['git-diff'] = <Process>[
           MockProcess(stdout: 'AUTHORS'),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -371,8 +391,10 @@ packages/plugin1/plugin1/plugin1.dart
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -387,8 +409,10 @@ packages/plugin1/CHANGELOG
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -404,8 +428,10 @@ packages/plugin1/CHANGELOG
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -421,8 +447,10 @@ script/tool_runner.sh
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -438,8 +466,10 @@ analysis_options.yaml
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -455,8 +485,10 @@ packages/plugin1/CHANGELOG
 packages/plugin1/CHANGELOG
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
@@ -468,7 +500,8 @@ packages/plugin1/CHANGELOG
         processRunner.mockProcessesForExecutable['git-diff'] = <Process>[
           MockProcess(stdout: 'packages/plugin1/plugin1.dart'),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
         createFakePlugin('plugin2', packagesDir);
         final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
@@ -491,7 +524,8 @@ packages/plugin1/plugin1.dart
 packages/plugin1/ios/plugin1.m
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
         createFakePlugin('plugin2', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
@@ -507,8 +541,10 @@ packages/plugin1/plugin1.dart
 packages/plugin2/ios/plugin2.m
 '''),
         ];
-        final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-        final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+        final RepositoryPackage plugin1 =
+            createFakePlugin('plugin1', packagesDir);
+        final RepositoryPackage plugin2 =
+            createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
         await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
@@ -527,7 +563,7 @@ packages/plugin1/plugin1_platform_interface/plugin1_platform_interface.dart
 packages/plugin1/plugin1_web/plugin1_web.dart
 '''),
         ];
-        final Directory plugin1 =
+        final RepositoryPackage plugin1 =
             createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
@@ -545,7 +581,7 @@ packages/plugin1/plugin1_web/plugin1_web.dart
 packages/plugin1/plugin1/plugin1.dart
 '''),
         ];
-        final Directory plugin1 =
+        final RepositoryPackage plugin1 =
             createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin1_platform_interface',
             packagesDir.childDirectory('plugin1'));
@@ -564,7 +600,7 @@ packages/plugin2/ios/plugin2.m
 packages/plugin3/plugin3.dart
 '''),
         ];
-        final Directory plugin1 =
+        final RepositoryPackage plugin1 =
             createFakePlugin('plugin1', packagesDir.childDirectory('plugin1'));
         createFakePlugin('plugin2', packagesDir);
         createFakePlugin('plugin3', packagesDir);
@@ -624,7 +660,8 @@ script/tool_runner.sh
         processRunner.mockProcessesForExecutable['git-diff'] = <Process>[
           MockProcess(stdout: 'packages/a_package/lib/a_package.dart'),
         ];
-        final Directory packageA = createFakePackage('a_package', packagesDir);
+        final RepositoryPackage packageA =
+            createFakePackage('a_package', packagesDir);
         createFakePlugin('b_package', packagesDir);
         final List<String> output = await runCapturingPrint(
             runner, <String>['sample', '--run-on-dirty-packages']);
@@ -647,8 +684,10 @@ packages/a_package/lib/a_package.dart
 packages/b_package/lib/src/foo.dart
 '''),
         ];
-        final Directory packageA = createFakePackage('a_package', packagesDir);
-        final Directory packageB = createFakePackage('b_package', packagesDir);
+        final RepositoryPackage packageA =
+            createFakePackage('a_package', packagesDir);
+        final RepositoryPackage packageB =
+            createFakePackage('b_package', packagesDir);
         createFakePackage('c_package', packagesDir);
         await runCapturingPrint(
             runner, <String>['sample', '--run-on-dirty-packages']);
@@ -664,7 +703,8 @@ packages/a_package/lib/a_package.dart
 packages/b_package/lib/src/foo.dart
 '''),
         ];
-        final Directory packageA = createFakePackage('a_package', packagesDir);
+        final RepositoryPackage packageA =
+            createFakePackage('a_package', packagesDir);
         createFakePackage('b_package', packagesDir);
         createFakePackage('c_package', packagesDir);
         await runCapturingPrint(runner, <String>[
@@ -686,7 +726,8 @@ packages/b_package/lib/src/foo.dart
       processRunner.mockProcessesForExecutable['git-rev-parse'] = <Process>[
         MockProcess(stdout: 'a-branch'),
       ];
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       createFakePlugin('plugin2', packagesDir);
 
       final List<String> output = await runCapturingPrint(
@@ -707,8 +748,10 @@ packages/b_package/lib/src/foo.dart
       processRunner.mockProcessesForExecutable['git-rev-parse'] = <Process>[
         MockProcess(stdout: 'main'),
       ];
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['sample', '--packages-for-branch']);
@@ -729,8 +772,10 @@ packages/b_package/lib/src/foo.dart
       processRunner.mockProcessesForExecutable['git-rev-parse'] = <Process>[
         MockProcess(stdout: 'master'),
       ];
-      final Directory plugin1 = createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2 = createFakePlugin('plugin2', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin2', packagesDir);
 
       final List<String> output = await runCapturingPrint(
           runner, <String>['sample', '--packages-for-branch']);
@@ -770,18 +815,19 @@ packages/b_package/lib/src/foo.dart
 
   group('sharding', () {
     test('distributes evenly when evenly divisible', () async {
-      final List<List<Directory>> expectedShards = <List<Directory>>[
-        <Directory>[
+      final List<List<RepositoryPackage>> expectedShards =
+          <List<RepositoryPackage>>[
+        <RepositoryPackage>[
           createFakePackage('package1', packagesDir),
           createFakePackage('package2', packagesDir),
           createFakePackage('package3', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package4', packagesDir),
           createFakePackage('package5', packagesDir),
           createFakePackage('package6', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package7', packagesDir),
           createFakePackage('package8', packagesDir),
           createFakePackage('package9', packagesDir),
@@ -807,25 +853,26 @@ packages/b_package/lib/src/foo.dart
         expect(
             localCommand.plugins,
             unorderedEquals(expectedShards[i]
-                .map((Directory packageDir) => packageDir.path)
+                .map((RepositoryPackage package) => package.path)
                 .toList()));
       }
     });
 
     test('distributes as evenly as possible when not evenly divisible',
         () async {
-      final List<List<Directory>> expectedShards = <List<Directory>>[
-        <Directory>[
+      final List<List<RepositoryPackage>> expectedShards =
+          <List<RepositoryPackage>>[
+        <RepositoryPackage>[
           createFakePackage('package1', packagesDir),
           createFakePackage('package2', packagesDir),
           createFakePackage('package3', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package4', packagesDir),
           createFakePackage('package5', packagesDir),
           createFakePackage('package6', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package7', packagesDir),
           createFakePackage('package8', packagesDir),
         ],
@@ -850,7 +897,7 @@ packages/b_package/lib/src/foo.dart
         expect(
             localCommand.plugins,
             unorderedEquals(expectedShards[i]
-                .map((Directory packageDir) => packageDir.path)
+                .map((RepositoryPackage package) => package.path)
                 .toList()));
       }
     });
@@ -864,18 +911,19 @@ packages/b_package/lib/src/foo.dart
     // excluding some plugins from the later step shouldn't change what's tested
     // in each shard, as it may no longer align with what was built.
     test('counts excluded plugins when sharding', () async {
-      final List<List<Directory>> expectedShards = <List<Directory>>[
-        <Directory>[
+      final List<List<RepositoryPackage>> expectedShards =
+          <List<RepositoryPackage>>[
+        <RepositoryPackage>[
           createFakePackage('package1', packagesDir),
           createFakePackage('package2', packagesDir),
           createFakePackage('package3', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package4', packagesDir),
           createFakePackage('package5', packagesDir),
           createFakePackage('package6', packagesDir),
         ],
-        <Directory>[
+        <RepositoryPackage>[
           createFakePackage('package7', packagesDir),
         ],
       ];
@@ -903,7 +951,7 @@ packages/b_package/lib/src/foo.dart
         expect(
             localCommand.plugins,
             unorderedEquals(expectedShards[i]
-                .map((Directory packageDir) => packageDir.path)
+                .map((RepositoryPackage package) => package.path)
                 .toList()));
       }
     });

--- a/script/tool/test/common/plugin_command_test.dart
+++ b/script/tool/test/common/plugin_command_test.dart
@@ -91,6 +91,19 @@ void main() {
           ]));
     });
 
+    test('includes packages without source', () async {
+      final RepositoryPackage package =
+          createFakePackage('package', packagesDir);
+      package.libDirectory.deleteSync(recursive: true);
+
+      await runCapturingPrint(runner, <String>['sample']);
+      expect(
+          command.plugins,
+          unorderedEquals(<String>[
+            package.path,
+          ]));
+    });
+
     test('all plugins includes third_party/packages', () async {
       final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir);

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
 import 'package:flutter_plugin_tools/src/common/plugin_utils.dart';
-import 'package:flutter_plugin_tools/src/common/repository_package.dart';
 import 'package:test/test.dart';
 
 import '../util.dart';
@@ -22,8 +21,7 @@ void main() {
 
   group('pluginSupportsPlatform', () {
     test('no platforms', () async {
-      final RepositoryPackage plugin =
-          RepositoryPackage(createFakePlugin('plugin', packagesDir));
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir);
 
       expect(pluginSupportsPlatform(platformAndroid, plugin), isFalse);
       expect(pluginSupportsPlatform(platformIOS, plugin), isFalse);
@@ -34,8 +32,7 @@ void main() {
     });
 
     test('all platforms', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
-          'plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline),
             platformIOS: const PlatformDetails(PlatformSupport.inline),
@@ -43,7 +40,7 @@ void main() {
             platformMacOS: const PlatformDetails(PlatformSupport.inline),
             platformWeb: const PlatformDetails(PlatformSupport.inline),
             platformWindows: const PlatformDetails(PlatformSupport.inline),
-          }));
+          });
 
       expect(pluginSupportsPlatform(platformAndroid, plugin), isTrue);
       expect(pluginSupportsPlatform(platformIOS, plugin), isTrue);
@@ -54,13 +51,12 @@ void main() {
     });
 
     test('some platforms', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
-          'plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline),
             platformLinux: const PlatformDetails(PlatformSupport.inline),
             platformWeb: const PlatformDetails(PlatformSupport.inline),
-          }));
+          });
 
       expect(pluginSupportsPlatform(platformAndroid, plugin), isTrue);
       expect(pluginSupportsPlatform(platformIOS, plugin), isFalse);
@@ -71,8 +67,7 @@ void main() {
     });
 
     test('inline plugins are only detected as inline', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
-          'plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.inline),
             platformIOS: const PlatformDetails(PlatformSupport.inline),
@@ -80,7 +75,7 @@ void main() {
             platformMacOS: const PlatformDetails(PlatformSupport.inline),
             platformWeb: const PlatformDetails(PlatformSupport.inline),
             platformWindows: const PlatformDetails(PlatformSupport.inline),
-          }));
+          });
 
       expect(
           pluginSupportsPlatform(platformAndroid, plugin,
@@ -133,8 +128,7 @@ void main() {
     });
 
     test('federated plugins are only detected as federated', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
-          'plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           platformSupport: <String, PlatformDetails>{
             platformAndroid: const PlatformDetails(PlatformSupport.federated),
             platformIOS: const PlatformDetails(PlatformSupport.federated),
@@ -142,7 +136,7 @@ void main() {
             platformMacOS: const PlatformDetails(PlatformSupport.federated),
             platformWeb: const PlatformDetails(PlatformSupport.federated),
             platformWindows: const PlatformDetails(PlatformSupport.federated),
-          }));
+          });
 
       expect(
           pluginSupportsPlatform(platformAndroid, plugin,
@@ -197,19 +191,19 @@ void main() {
 
   group('pluginHasNativeCodeForPlatform', () {
     test('returns false for web', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
           platformWeb: const PlatformDetails(PlatformSupport.inline),
         },
-      ));
+      );
 
       expect(pluginHasNativeCodeForPlatform(platformWeb, plugin), isFalse);
     });
 
     test('returns false for a native-only plugin', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -217,7 +211,7 @@ void main() {
           platformMacOS: const PlatformDetails(PlatformSupport.inline),
           platformWindows: const PlatformDetails(PlatformSupport.inline),
         },
-      ));
+      );
 
       expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isTrue);
       expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isTrue);
@@ -225,7 +219,7 @@ void main() {
     });
 
     test('returns true for a native+Dart plugin', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -236,7 +230,7 @@ void main() {
           platformWindows: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: true, hasDartCode: true),
         },
-      ));
+      );
 
       expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isTrue);
       expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isTrue);
@@ -244,7 +238,7 @@ void main() {
     });
 
     test('returns false for a Dart-only plugin', () async {
-      final RepositoryPackage plugin = RepositoryPackage(createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -255,7 +249,7 @@ void main() {
           platformWindows: const PlatformDetails(PlatformSupport.inline,
               hasNativeCode: false, hasDartCode: true),
         },
-      ));
+      );
 
       expect(pluginHasNativeCodeForPlatform(platformLinux, plugin), isFalse);
       expect(pluginHasNativeCodeForPlatform(platformMacOS, plugin), isFalse);

--- a/script/tool/test/common/repository_package_test.dart
+++ b/script/tool/test/common/repository_package_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
-import 'package:flutter_plugin_tools/src/common/repository_package.dart';
 import 'package:test/test.dart';
 
 import '../util.dart';
@@ -97,107 +96,109 @@ void main() {
 
   group('getExamples', () {
     test('handles a single Flutter example', () async {
-      final Directory plugin = createFakePlugin('a_plugin', packagesDir);
+      final RepositoryPackage plugin =
+          createFakePlugin('a_plugin', packagesDir);
 
-      final List<RepositoryPackage> examples =
-          RepositoryPackage(plugin).getExamples().toList();
+      final List<RepositoryPackage> examples = plugin.getExamples().toList();
 
       expect(examples.length, 1);
-      expect(examples[0].path, plugin.childDirectory('example').path);
+      expect(examples[0].path, getExampleDir(plugin).path);
     });
 
     test('handles multiple Flutter examples', () async {
-      final Directory plugin = createFakePlugin('a_plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir,
           examples: <String>['example1', 'example2']);
 
-      final List<RepositoryPackage> examples =
-          RepositoryPackage(plugin).getExamples().toList();
+      final List<RepositoryPackage> examples = plugin.getExamples().toList();
 
       expect(examples.length, 2);
       expect(examples[0].path,
-          plugin.childDirectory('example').childDirectory('example1').path);
+          getExampleDir(plugin).childDirectory('example1').path);
       expect(examples[1].path,
-          plugin.childDirectory('example').childDirectory('example2').path);
+          getExampleDir(plugin).childDirectory('example2').path);
     });
 
     test('handles a single non-Flutter example', () async {
-      final Directory package = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      final List<RepositoryPackage> examples =
-          RepositoryPackage(package).getExamples().toList();
+      final List<RepositoryPackage> examples = package.getExamples().toList();
 
       expect(examples.length, 1);
-      expect(examples[0].path, package.childDirectory('example').path);
+      expect(examples[0].path, getExampleDir(package).path);
     });
 
     test('handles multiple non-Flutter examples', () async {
-      final Directory package = createFakePackage('a_package', packagesDir,
+      final RepositoryPackage package = createFakePackage(
+          'a_package', packagesDir,
           examples: <String>['example1', 'example2']);
 
-      final List<RepositoryPackage> examples =
-          RepositoryPackage(package).getExamples().toList();
+      final List<RepositoryPackage> examples = package.getExamples().toList();
 
       expect(examples.length, 2);
       expect(examples[0].path,
-          package.childDirectory('example').childDirectory('example1').path);
+          getExampleDir(package).childDirectory('example1').path);
       expect(examples[1].path,
-          package.childDirectory('example').childDirectory('example2').path);
+          getExampleDir(package).childDirectory('example2').path);
     });
   });
 
   group('federated plugin queries', () {
     test('all return false for a simple plugin', () {
-      final Directory plugin = createFakePlugin('a_plugin', packagesDir);
-      expect(RepositoryPackage(plugin).isFederated, false);
-      expect(RepositoryPackage(plugin).isAppFacing, false);
-      expect(RepositoryPackage(plugin).isPlatformInterface, false);
-      expect(RepositoryPackage(plugin).isFederated, false);
+      final RepositoryPackage plugin =
+          createFakePlugin('a_plugin', packagesDir);
+      expect(plugin.isFederated, false);
+      expect(plugin.isAppFacing, false);
+      expect(plugin.isPlatformInterface, false);
+      expect(plugin.isFederated, false);
     });
 
     test('handle app-facing packages', () {
-      final Directory plugin =
+      final RepositoryPackage plugin =
           createFakePlugin('a_plugin', packagesDir.childDirectory('a_plugin'));
-      expect(RepositoryPackage(plugin).isFederated, true);
-      expect(RepositoryPackage(plugin).isAppFacing, true);
-      expect(RepositoryPackage(plugin).isPlatformInterface, false);
-      expect(RepositoryPackage(plugin).isPlatformImplementation, false);
+      expect(plugin.isFederated, true);
+      expect(plugin.isAppFacing, true);
+      expect(plugin.isPlatformInterface, false);
+      expect(plugin.isPlatformImplementation, false);
     });
 
     test('handle platform interface packages', () {
-      final Directory plugin = createFakePlugin('a_plugin_platform_interface',
+      final RepositoryPackage plugin = createFakePlugin(
+          'a_plugin_platform_interface',
           packagesDir.childDirectory('a_plugin'));
-      expect(RepositoryPackage(plugin).isFederated, true);
-      expect(RepositoryPackage(plugin).isAppFacing, false);
-      expect(RepositoryPackage(plugin).isPlatformInterface, true);
-      expect(RepositoryPackage(plugin).isPlatformImplementation, false);
+      expect(plugin.isFederated, true);
+      expect(plugin.isAppFacing, false);
+      expect(plugin.isPlatformInterface, true);
+      expect(plugin.isPlatformImplementation, false);
     });
 
     test('handle platform implementation packages', () {
       // A platform interface can end with anything, not just one of the known
       // platform names, because of cases like webview_flutter_wkwebview.
-      final Directory plugin = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'a_plugin_foo', packagesDir.childDirectory('a_plugin'));
-      expect(RepositoryPackage(plugin).isFederated, true);
-      expect(RepositoryPackage(plugin).isAppFacing, false);
-      expect(RepositoryPackage(plugin).isPlatformInterface, false);
-      expect(RepositoryPackage(plugin).isPlatformImplementation, true);
+      expect(plugin.isFederated, true);
+      expect(plugin.isAppFacing, false);
+      expect(plugin.isPlatformInterface, false);
+      expect(plugin.isPlatformImplementation, true);
     });
   });
 
   group('pubspec', () {
     test('file', () async {
-      final Directory plugin = createFakePlugin('a_plugin', packagesDir);
+      final RepositoryPackage plugin =
+          createFakePlugin('a_plugin', packagesDir);
 
-      final File pubspecFile = RepositoryPackage(plugin).pubspecFile;
+      final File pubspecFile = plugin.pubspecFile;
 
-      expect(pubspecFile.path, plugin.childFile('pubspec.yaml').path);
+      expect(pubspecFile.path, plugin.directory.childFile('pubspec.yaml').path);
     });
 
     test('parsing', () async {
-      final Directory plugin = createFakePlugin('a_plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir,
           examples: <String>['example1', 'example2']);
 
-      final Pubspec pubspec = RepositoryPackage(plugin).parsePubspec();
+      final Pubspec pubspec = plugin.parsePubspec();
 
       expect(pubspec.name, 'a_plugin');
     });
@@ -205,15 +206,15 @@ void main() {
 
   group('requiresFlutter', () {
     test('returns true for Flutter package', () async {
-      final Directory package =
+      final RepositoryPackage package =
           createFakePackage('a_package', packagesDir, isFlutter: true);
-      expect(RepositoryPackage(package).requiresFlutter(), true);
+      expect(package.requiresFlutter(), true);
     });
 
     test('returns false for non-Flutter package', () async {
-      final Directory package =
+      final RepositoryPackage package =
           createFakePackage('a_package', packagesDir, isFlutter: false);
-      expect(RepositoryPackage(package).requiresFlutter(), false);
+      expect(package.requiresFlutter(), false);
     });
   });
 }

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -7,7 +7,6 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:flutter_plugin_tools/src/common/repository_package.dart';
 import 'package:flutter_plugin_tools/src/create_all_plugins_app_command.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
@@ -49,8 +48,7 @@ void main() {
       createFakePlugin('pluginc', packagesDir);
 
       await runCapturingPrint(runner, <String>['all-plugins-app']);
-      final List<String> pubspec =
-          command.appDirectory.childFile('pubspec.yaml').readAsLinesSync();
+      final List<String> pubspec = command.app.pubspecFile.readAsLinesSync();
 
       expect(
           pubspec,
@@ -67,8 +65,7 @@ void main() {
       createFakePlugin('pluginc', packagesDir);
 
       await runCapturingPrint(runner, <String>['all-plugins-app']);
-      final List<String> pubspec =
-          command.appDirectory.childFile('pubspec.yaml').readAsLinesSync();
+      final List<String> pubspec = command.app.pubspecFile.readAsLinesSync();
 
       expect(
           pubspec,
@@ -99,8 +96,7 @@ void main() {
       createFakePlugin('plugina', packagesDir);
 
       await runCapturingPrint(runner, <String>['all-plugins-app']);
-      final Pubspec generatedPubspec =
-          RepositoryPackage(command.appDirectory).parsePubspec();
+      final Pubspec generatedPubspec = command.app.parsePubspec();
 
       const String dartSdkKey = 'sdk';
       expect(generatedPubspec.environment?[dartSdkKey],
@@ -115,8 +111,8 @@ void main() {
       await runCapturingPrint(runner,
           <String>['all-plugins-app', '--output-dir=${customOutputDir.path}']);
 
-      expect(command.appDirectory.path,
-          customOutputDir.childDirectory('all_plugins').path);
+      expect(
+          command.app.path, customOutputDir.childDirectory('all_plugins').path);
     });
 
     test('logs exclusions', () async {

--- a/script/tool/test/custom_test_command_test.dart
+++ b/script/tool/test/custom_test_command_test.dart
@@ -39,7 +39,7 @@ void main() {
     });
 
     test('runs both new and legacy when both are present', () async {
-      final Directory package =
+      final RepositoryPackage package =
           createFakePlugin('a_package', packagesDir, extraFiles: <String>[
         'tool/run_tests.dart',
         'run_tests.sh',
@@ -51,7 +51,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           containsAll(<ProcessCall>[
-            ProcessCall(package.childFile('run_tests.sh').path,
+            ProcessCall(package.directory.childFile('run_tests.sh').path,
                 const <String>[], package.path),
             ProcessCall('dart', const <String>['run', 'tool/run_tests.dart'],
                 package.path),
@@ -65,7 +65,8 @@ void main() {
     });
 
     test('runs when only new is present', () async {
-      final Directory package = createFakePlugin('a_package', packagesDir,
+      final RepositoryPackage package = createFakePlugin(
+          'a_package', packagesDir,
           extraFiles: <String>['tool/run_tests.dart']);
 
       final List<String> output =
@@ -86,7 +87,8 @@ void main() {
     });
 
     test('runs pub get before running Dart test script', () async {
-      final Directory package = createFakePlugin('a_package', packagesDir,
+      final RepositoryPackage package = createFakePlugin(
+          'a_package', packagesDir,
           extraFiles: <String>['tool/run_tests.dart']);
 
       await runCapturingPrint(runner, <String>['custom-test']);
@@ -101,7 +103,8 @@ void main() {
     });
 
     test('runs when only legacy is present', () async {
-      final Directory package = createFakePlugin('a_package', packagesDir,
+      final RepositoryPackage package = createFakePlugin(
+          'a_package', packagesDir,
           extraFiles: <String>['run_tests.sh']);
 
       final List<String> output =
@@ -110,7 +113,7 @@ void main() {
       expect(
           processRunner.recordedCalls,
           containsAll(<ProcessCall>[
-            ProcessCall(package.childFile('run_tests.sh').path,
+            ProcessCall(package.directory.childFile('run_tests.sh').path,
                 const <String>[], package.path),
           ]));
 
@@ -189,14 +192,14 @@ void main() {
     });
 
     test('fails if legacy fails', () async {
-      final Directory package =
+      final RepositoryPackage package =
           createFakePlugin('a_package', packagesDir, extraFiles: <String>[
         'tool/run_tests.dart',
         'run_tests.sh',
       ]);
 
       processRunner.mockProcessesForExecutable[
-          package.childFile('run_tests.sh').path] = <io.Process>[
+          package.directory.childFile('run_tests.sh').path] = <io.Process>[
         MockProcess(exitCode: 1),
       ];
 
@@ -234,7 +237,7 @@ void main() {
     });
 
     test('runs new and skips old when both are present', () async {
-      final Directory package =
+      final RepositoryPackage package =
           createFakePlugin('a_package', packagesDir, extraFiles: <String>[
         'tool/run_tests.dart',
         'run_tests.sh',
@@ -258,7 +261,8 @@ void main() {
     });
 
     test('runs when only new is present', () async {
-      final Directory package = createFakePlugin('a_package', packagesDir,
+      final RepositoryPackage package = createFakePlugin(
+          'a_package', packagesDir,
           extraFiles: <String>['tool/run_tests.dart']);
 
       final List<String> output =

--- a/script/tool/test/drive_examples_command_test.dart
+++ b/script/tool/test/drive_examples_command_test.dart
@@ -188,7 +188,7 @@ void main() {
     });
 
     test('driving under folder "test_driver"', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -203,8 +203,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       setMockFlutterDevicesOutput();
       final List<String> output =
@@ -311,7 +310,7 @@ void main() {
     test(
         'driving under folder "test_driver" when targets are under "integration_test"',
         () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -328,8 +327,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       setMockFlutterDevicesOutput();
       final List<String> output =
@@ -401,7 +399,7 @@ void main() {
     });
 
     test('driving on a Linux plugin', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -414,8 +412,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -474,7 +471,7 @@ void main() {
     });
 
     test('driving on a macOS plugin', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -487,8 +484,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -546,7 +542,7 @@ void main() {
     });
 
     test('driving a web plugin', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -559,8 +555,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -596,7 +591,7 @@ void main() {
     });
 
     test('driving a web plugin with CHROME_EXECUTABLE', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -609,8 +604,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       mockPlatform.environment['CHROME_EXECUTABLE'] = '/path/to/chrome';
 
@@ -674,7 +668,7 @@ void main() {
     });
 
     test('driving on a Windows plugin', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -687,8 +681,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'drive-examples',
@@ -722,7 +715,7 @@ void main() {
     });
 
     test('driving on an Android plugin', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -735,8 +728,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       setMockFlutterDevicesOutput();
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -861,7 +853,7 @@ void main() {
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -876,8 +868,7 @@ void main() {
         },
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
 
       setMockFlutterDevicesOutput();
       await runCapturingPrint(runner, <String>[
@@ -1006,7 +997,7 @@ void main() {
     });
 
     test('reports test failures', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>[
@@ -1048,8 +1039,7 @@ void main() {
         ]),
       );
 
-      final Directory pluginExampleDirectory =
-          pluginDirectory.childDirectory('example');
+      final Directory pluginExampleDirectory = getExampleDir(plugin);
       expect(
           processRunner.recordedCalls,
           orderedEquals(<ProcessCall>[
@@ -1082,13 +1072,13 @@ void main() {
 
     group('packages', () {
       test('can be driven', () async {
-        final Directory package =
+        final RepositoryPackage package =
             createFakePackage('a_package', packagesDir, extraFiles: <String>[
           'example/integration_test/foo_test.dart',
           'example/test_driver/integration_test.dart',
           'example/web/index.html',
         ]);
-        final Directory exampleDirectory = package.childDirectory('example');
+        final Directory exampleDirectory = getExampleDir(package);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'drive-examples',
@@ -1150,7 +1140,8 @@ void main() {
       });
 
       test('drive only supported examples if there is more than one', () async {
-        final Directory package = createFakePackage('a_package', packagesDir,
+        final RepositoryPackage package = createFakePackage(
+            'a_package', packagesDir,
             isFlutter: true,
             examples: <String>[
               'with_web',
@@ -1164,7 +1155,7 @@ void main() {
               'example/without_web/test_driver/integration_test.dart',
             ]);
         final Directory supportedExampleDirectory =
-            package.childDirectory('example').childDirectory('with_web');
+            getExampleDir(package).childDirectory('with_web');
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'drive-examples',

--- a/script/tool/test/firebase_test_lab_command_test.dart
+++ b/script/tool/test/firebase_test_lab_command_test.dart
@@ -40,9 +40,10 @@ void main() {
       runner.addCommand(command);
     });
 
-    void _writeJavaTestFile(Directory pluginDir, String relativeFilePath,
+    void _writeJavaTestFile(RepositoryPackage plugin, String relativeFilePath,
         {String runnerClass = 'FlutterTestRunner'}) {
-      childFileWithSubcomponents(pluginDir, p.posix.split(relativeFilePath))
+      childFileWithSubcomponents(
+              plugin.directory, p.posix.split(relativeFilePath))
           .writeAsStringSync('''
 @DartIntegrationTest
 @RunWith($runnerClass.class)
@@ -60,13 +61,13 @@ public class MainActivityTest {
 
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -90,13 +91,13 @@ public class MainActivityTest {
 
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['firebase-test-lab']);
@@ -112,22 +113,22 @@ public class MainActivityTest {
     test('only runs gcloud configuration once', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory plugin1Dir =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
         'test/plugin_test.dart',
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(plugin1Dir, javaTestFileRelativePath);
-      final Directory plugin2Dir =
+      _writeJavaTestFile(plugin1, javaTestFileRelativePath);
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin2', packagesDir, extraFiles: <String>[
         'test/plugin_test.dart',
         'example/integration_test/bar_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(plugin2Dir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin2, javaTestFileRelativePath);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'firebase-test-lab',
@@ -197,7 +198,7 @@ public class MainActivityTest {
     test('runs integration tests', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'test/plugin_test.dart',
         'example/integration_test/bar_test.dart',
@@ -206,7 +207,7 @@ public class MainActivityTest {
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'firebase-test-lab',
@@ -275,7 +276,7 @@ public class MainActivityTest {
       const List<String> examples = <String>['example1', 'example2'];
       const String javaTestFileExampleRelativePath =
           'android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir = createFakePlugin('plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
           examples: examples,
           extraFiles: <String>[
             for (final String example in examples) ...<String>[
@@ -286,7 +287,7 @@ public class MainActivityTest {
           ]);
       for (final String example in examples) {
         _writeJavaTestFile(
-            pluginDir, 'example/$example/$javaTestFileExampleRelativePath');
+            plugin, 'example/$example/$javaTestFileExampleRelativePath');
       }
 
       final List<String> output = await runCapturingPrint(runner, <String>[
@@ -339,14 +340,14 @@ public class MainActivityTest {
     test('fails if a test fails twice', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/bar_test.dart',
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
         MockProcess(), // auth
@@ -385,14 +386,14 @@ public class MainActivityTest {
         () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/bar_test.dart',
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       processRunner.mockProcessesForExecutable['gcloud'] = <Process>[
         MockProcess(), // auth
@@ -454,12 +455,12 @@ public class MainActivityTest {
     test('fails for packages with no integration test files', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -490,7 +491,7 @@ public class MainActivityTest {
     test('fails for packages with no integration_test runner', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'test/plugin_test.dart',
         'example/integration_test/bar_test.dart',
@@ -500,7 +501,7 @@ public class MainActivityTest {
         javaTestFileRelativePath,
       ]);
       // Use the wrong @RunWith annotation.
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath,
+      _writeJavaTestFile(plugin, javaTestFileRelativePath,
           runnerClass: 'AndroidJUnit4.class');
 
       Error? commandError;
@@ -559,12 +560,12 @@ public class MainActivityTest {
     test('builds if gradlew is missing', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       final List<String> output = await runCapturingPrint(runner, <String>[
         'firebase-test-lab',
@@ -622,12 +623,12 @@ public class MainActivityTest {
     test('fails if building to generate gradlew fails', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       processRunner.mockProcessesForExecutable['flutter'] = <Process>[
         MockProcess(exitCode: 1) // flutter build
@@ -657,16 +658,17 @@ public class MainActivityTest {
     test('fails if assembleAndroidTest fails', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
-      final String gradlewPath = pluginDir
-          .childDirectory('example')
-          .childDirectory('android')
+      final String gradlewPath = plugin
+          .getExamples()
+          .first
+          .platformDirectory(FlutterPlatform.android)
           .childFile('gradlew')
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <Process>[
@@ -697,16 +699,17 @@ public class MainActivityTest {
     test('fails if assembleDebug fails', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
-      final String gradlewPath = pluginDir
-          .childDirectory('example')
-          .childDirectory('android')
+      final String gradlewPath = plugin
+          .getExamples()
+          .first
+          .platformDirectory(FlutterPlatform.android)
           .childFile('gradlew')
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <Process>[
@@ -741,13 +744,13 @@ public class MainActivityTest {
     test('experimental flag', () async {
       const String javaTestFileRelativePath =
           'example/android/app/src/androidTest/MainActivityTest.java';
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, extraFiles: <String>[
         'example/integration_test/foo_test.dart',
         'example/android/gradlew',
         javaTestFileRelativePath,
       ]);
-      _writeJavaTestFile(pluginDir, javaTestFileRelativePath);
+      _writeJavaTestFile(plugin, javaTestFileRelativePath);
 
       await runCapturingPrint(runner, <String>[
         'firebase-test-lab',

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -50,10 +50,10 @@ void main() {
   /// Returns a modified version of a list of [relativePaths] that are relative
   /// to [package] to instead be relative to [packagesDir].
   List<String> _getPackagesDirRelativePaths(
-      Directory packageDir, List<String> relativePaths) {
+      RepositoryPackage package, List<String> relativePaths) {
     final p.Context path = analyzeCommand.path;
     final String relativeBase =
-        path.relative(packageDir.path, from: packagesDir.path);
+        path.relative(package.path, from: packagesDir.path);
     return relativePaths
         .map((String relativePath) => path.join(relativeBase, relativePath))
         .toList();
@@ -86,7 +86,7 @@ void main() {
       'lib/src/b.dart',
       'lib/src/c.dart',
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: files,
@@ -101,7 +101,7 @@ void main() {
               getFlutterCommand(mockPlatform),
               <String>[
                 'format',
-                ..._getPackagesDirRelativePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(plugin, files)
               ],
               packagesDir.path),
         ]));
@@ -114,7 +114,7 @@ void main() {
       'lib/src/c.dart',
     ];
     const String unformattedFile = 'lib/src/d.dart';
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: <String>[
@@ -124,7 +124,8 @@ void main() {
     );
 
     final p.Context posixContext = p.posix;
-    childFileWithSubcomponents(pluginDir, posixContext.split(unformattedFile))
+    childFileWithSubcomponents(
+            plugin.directory, posixContext.split(unformattedFile))
         .writeAsStringSync(
             '// copyright bla bla\n// This file is hand-formatted.\ncode...');
 
@@ -137,7 +138,7 @@ void main() {
               getFlutterCommand(mockPlatform),
               <String>[
                 'format',
-                ..._getPackagesDirRelativePaths(pluginDir, formattedFiles)
+                ..._getPackagesDirRelativePaths(plugin, formattedFiles)
               ],
               packagesDir.path),
         ]));
@@ -172,7 +173,7 @@ void main() {
       'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
       'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: files,
@@ -190,7 +191,7 @@ void main() {
                 '-jar',
                 javaFormatPath,
                 '--replace',
-                ..._getPackagesDirRelativePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(plugin, files)
               ],
               packagesDir.path),
         ]));
@@ -252,7 +253,7 @@ void main() {
       'android/src/main/java/io/flutter/plugins/a_plugin/a.java',
       'android/src/main/java/io/flutter/plugins/a_plugin/b.java',
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: files,
@@ -270,7 +271,7 @@ void main() {
                 '-jar',
                 javaFormatPath,
                 '--replace',
-                ..._getPackagesDirRelativePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(plugin, files)
               ],
               packagesDir.path),
         ]));
@@ -285,7 +286,7 @@ void main() {
       'macos/Classes/Foo.mm',
       'windows/foo_plugin.cpp',
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: files,
@@ -302,7 +303,7 @@ void main() {
               <String>[
                 '-i',
                 '--style=file',
-                ..._getPackagesDirRelativePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(plugin, files)
               ],
               packagesDir.path),
         ]));
@@ -339,7 +340,7 @@ void main() {
     const List<String> files = <String>[
       'windows/foo_plugin.cpp',
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: files,
@@ -358,7 +359,7 @@ void main() {
               <String>[
                 '-i',
                 '--style=file',
-                ..._getPackagesDirRelativePaths(pluginDir, files)
+                ..._getPackagesDirRelativePaths(plugin, files)
               ],
               packagesDir.path),
         ]));
@@ -403,7 +404,7 @@ void main() {
     const List<String> javaFiles = <String>[
       'android/src/main/java/io/flutter/plugins/a_plugin/a.java'
     ];
-    final Directory pluginDir = createFakePlugin(
+    final RepositoryPackage plugin = createFakePlugin(
       'a_plugin',
       packagesDir,
       extraFiles: <String>[
@@ -426,14 +427,14 @@ void main() {
               <String>[
                 '-i',
                 '--style=file',
-                ..._getPackagesDirRelativePaths(pluginDir, clangFiles)
+                ..._getPackagesDirRelativePaths(plugin, clangFiles)
               ],
               packagesDir.path),
           ProcessCall(
               getFlutterCommand(mockPlatform),
               <String>[
                 'format',
-                ..._getPackagesDirRelativePaths(pluginDir, dartFiles)
+                ..._getPackagesDirRelativePaths(plugin, dartFiles)
               ],
               packagesDir.path),
           ProcessCall(
@@ -442,7 +443,7 @@ void main() {
                 '-jar',
                 javaFormatPath,
                 '--replace',
-                ..._getPackagesDirRelativePaths(pluginDir, javaFiles)
+                ..._getPackagesDirRelativePaths(plugin, javaFiles)
               ],
               packagesDir.path),
         ]));

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -40,7 +40,7 @@ void main() {
     });
 
     test('runs gradle lint', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
         'example/android/gradlew',
       ], platformSupport: <String, PlatformDetails>{
@@ -48,7 +48,7 @@ void main() {
       });
 
       final Directory androidDir =
-          pluginDir.childDirectory('example').childDirectory('android');
+          plugin.getExamples().first.platformDirectory(FlutterPlatform.android);
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['lint-android']);
@@ -74,7 +74,7 @@ void main() {
 
     test('runs on all examples', () async {
       final List<String> examples = <String>['example1', 'example2'];
-      final Directory pluginDir = createFakePlugin('plugin1', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('plugin1', packagesDir,
           examples: examples,
           extraFiles: <String>[
             'example/example1/android/gradlew',
@@ -84,11 +84,9 @@ void main() {
             platformAndroid: const PlatformDetails(PlatformSupport.inline)
           });
 
-      final Iterable<Directory> exampleAndroidDirs = examples.map(
-          (String example) => pluginDir
-              .childDirectory('example')
-              .childDirectory(example)
-              .childDirectory('android'));
+      final Iterable<Directory> exampleAndroidDirs = plugin.getExamples().map(
+          (RepositoryPackage example) =>
+              example.platformDirectory(FlutterPlatform.android));
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['lint-android']);
@@ -136,16 +134,17 @@ void main() {
     });
 
     test('fails if linting finds issues', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin1', packagesDir, extraFiles: <String>[
         'example/android/gradlew',
       ], platformSupport: <String, PlatformDetails>{
         platformAndroid: const PlatformDetails(PlatformSupport.inline)
       });
 
-      final String gradlewPath = pluginDir
-          .childDirectory('example')
-          .childDirectory('android')
+      final String gradlewPath = plugin
+          .getExamples()
+          .first
+          .platformDirectory(FlutterPlatform.android)
           .childFile('gradlew')
           .path;
       processRunner.mockProcessesForExecutable[gradlewPath] = <io.Process>[

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -65,7 +65,7 @@ void main() {
     });
 
     test('runs pod lib lint on a podspec', () async {
-      final Directory plugin1Dir = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin1',
         packagesDir,
         extraFiles: <String>[
@@ -91,8 +91,8 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                plugin1Dir
-                    .childDirectory('ios')
+                plugin
+                    .platformDirectory(FlutterPlatform.ios)
                     .childFile('plugin1.podspec')
                     .path,
                 '--configuration=Debug',
@@ -106,8 +106,8 @@ void main() {
               <String>[
                 'lib',
                 'lint',
-                plugin1Dir
-                    .childDirectory('ios')
+                plugin
+                    .platformDirectory(FlutterPlatform.ios)
                     .childFile('plugin1.podspec')
                     .path,
                 '--configuration=Debug',

--- a/script/tool/test/list_command_test.dart
+++ b/script/tool/test/list_command_test.dart
@@ -119,17 +119,11 @@ void main() {
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.
-      final Directory federatedPlugin = packagesDir.childDirectory('my_plugin')
-        ..createSync();
-      final Directory clientLibrary =
-          federatedPlugin.childDirectory('my_plugin')..createSync();
-      createFakePubspec(clientLibrary);
-      final Directory webLibrary =
-          federatedPlugin.childDirectory('my_plugin_web')..createSync();
-      createFakePubspec(webLibrary);
-      final Directory macLibrary =
-          federatedPlugin.childDirectory('my_plugin_macos')..createSync();
-      createFakePubspec(macLibrary);
+      final Directory federatedPluginDir =
+          packagesDir.childDirectory('my_plugin')..createSync();
+      createFakePlugin('my_plugin', federatedPluginDir);
+      createFakePlugin('my_plugin_web', federatedPluginDir);
+      createFakePlugin('my_plugin_macos', federatedPluginDir);
 
       // Test without specifying `--type`.
       final List<String> plugins =
@@ -151,17 +145,11 @@ void main() {
 
       // Create a federated plugin by creating a directory under the packages
       // directory with several packages underneath.
-      final Directory federatedPlugin = packagesDir.childDirectory('my_plugin')
-        ..createSync();
-      final Directory clientLibrary =
-          federatedPlugin.childDirectory('my_plugin')..createSync();
-      createFakePubspec(clientLibrary);
-      final Directory webLibrary =
-          federatedPlugin.childDirectory('my_plugin_web')..createSync();
-      createFakePubspec(webLibrary);
-      final Directory macLibrary =
-          federatedPlugin.childDirectory('my_plugin_macos')..createSync();
-      createFakePubspec(macLibrary);
+      final Directory federatedPluginDir =
+          packagesDir.childDirectory('my_plugin')..createSync();
+      createFakePlugin('my_plugin', federatedPluginDir);
+      createFakePlugin('my_plugin_web', federatedPluginDir);
+      createFakePlugin('my_plugin_macos', federatedPluginDir);
 
       List<String> plugins = await runCapturingPrint(
           runner, <String>['list', '--packages=plugin1']);

--- a/script/tool/test/publish_check_command_test.dart
+++ b/script/tool/test/publish_check_command_test.dart
@@ -44,9 +44,9 @@ void main() {
     });
 
     test('publish check all packages', () async {
-      final Directory plugin1Dir =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin_tools_test_package_a', packagesDir);
-      final Directory plugin2Dir =
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin_tools_test_package_b', packagesDir);
 
       await runCapturingPrint(runner, <String>['publish-check']);
@@ -57,11 +57,11 @@ void main() {
             ProcessCall(
                 'flutter',
                 const <String>['pub', 'publish', '--', '--dry-run'],
-                plugin1Dir.path),
+                plugin1.path),
             ProcessCall(
                 'flutter',
                 const <String>['pub', 'publish', '--', '--dry-run'],
-                plugin2Dir.path),
+                plugin2.path),
           ]));
     });
 
@@ -89,8 +89,8 @@ void main() {
     });
 
     test('fail on bad pubspec', () async {
-      final Directory dir = createFakePlugin('c', packagesDir);
-      await dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
+      final RepositoryPackage package = createFakePlugin('c', packagesDir);
+      await package.pubspecFile.writeAsString('bad-yaml');
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -108,8 +108,9 @@ void main() {
     });
 
     test('fails if AUTHORS is missing', () async {
-      final Directory package = createFakePackage('a_package', packagesDir);
-      package.childFile('AUTHORS').delete();
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
+      package.authorsFile.delete();
 
       Error? commandError;
       final List<String> output = await runCapturingPrint(
@@ -128,12 +129,12 @@ void main() {
     });
 
     test('does not require AUTHORS for third-party', () async {
-      final Directory package = createFakePackage(
+      final RepositoryPackage package = createFakePackage(
           'a_package',
           packagesDir.parent
               .childDirectory('third_party')
               .childDirectory('packages'));
-      package.childFile('AUTHORS').delete();
+      package.authorsFile.delete();
 
       final List<String> output =
           await runCapturingPrint(runner, <String>['publish-check']);
@@ -372,11 +373,11 @@ void main() {
       );
       runner.addCommand(command);
 
-      final Directory plugin1Dir =
+      final RepositoryPackage plugin =
           createFakePlugin('no_publish_a', packagesDir, version: '0.1.0');
       createFakePlugin('no_publish_b', packagesDir, version: '0.2.0');
 
-      await plugin1Dir.childFile('pubspec.yaml').writeAsString('bad-yaml');
+      await plugin.pubspecFile.writeAsString('bad-yaml');
 
       bool hasError = false;
       final List<String> output = await runCapturingPrint(

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -83,11 +83,11 @@ void main() {
 
   group('Initial validation', () {
     test('refuses to proceed with dirty files', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
 
       processRunner.mockProcessesForExecutable['git-status'] = <io.Process>[
-        MockProcess(stdout: '?? ${pluginDir.childFile('tmp').path}\n')
+        MockProcess(stdout: '?? ${plugin.directory.childFile('tmp').path}\n')
       ];
 
       Error? commandError;
@@ -183,7 +183,7 @@ void main() {
     });
 
     test('forwards --pub-publish-flags to pub publish', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
 
       await runCapturingPrint(commandRunner, <String>[
@@ -198,14 +198,14 @@ void main() {
           contains(ProcessCall(
               flutterCommand,
               const <String>['pub', 'publish', '--dry-run', '--server=bar'],
-              pluginDir.path)));
+              plugin.path)));
     });
 
     test(
         '--skip-confirmation flag automatically adds --force to --pub-publish-flags',
         () async {
       _createMockCredentialFile();
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
 
       await runCapturingPrint(commandRunner, <String>[
@@ -221,7 +221,7 @@ void main() {
           contains(ProcessCall(
               flutterCommand,
               const <String>['pub', 'publish', '--server=bar', '--force'],
-              pluginDir.path)));
+              plugin.path)));
     });
 
     test('throws if pub publish fails', () async {
@@ -249,7 +249,7 @@ void main() {
     });
 
     test('publish, dry run', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
 
       final List<String> output =
@@ -268,7 +268,7 @@ void main() {
           containsAllInOrder(<Matcher>[
             contains('=============== DRY RUN ==============='),
             contains('Running for foo'),
-            contains('Running `pub publish ` in ${pluginDir.path}...'),
+            contains('Running `pub publish ` in ${plugin.path}...'),
             contains('Tagging release foo-v0.0.1...'),
             contains('Pushing tag to upstream...'),
             contains('Published foo successfully!'),
@@ -386,7 +386,7 @@ void main() {
     });
 
     test('to upstream by default, dry run', () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('foo', packagesDir, examples: <String>[]);
 
       mockStdin.readLineOutput = 'y';
@@ -402,7 +402,7 @@ void main() {
           output,
           containsAllInOrder(<Matcher>[
             contains('=============== DRY RUN ==============='),
-            contains('Running `pub publish ` in ${pluginDir.path}...'),
+            contains('Running `pub publish ` in ${plugin.path}...'),
             contains('Tagging release foo-v0.0.1...'),
             contains('Pushing tag to upstream...'),
             contains('Published foo successfully!'),
@@ -447,16 +447,17 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 = createFakePlugin(
+      final RepositoryPackage plugin2 = createFakePlugin(
         'plugin2',
         packagesDir.childDirectory('plugin2'),
       );
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
       mockStdin.readLineOutput = 'y';
 
@@ -468,8 +469,8 @@ void main() {
           containsAllInOrder(<Matcher>[
             contains(
                 'Publishing all packages that have changed relative to "HEAD~"'),
-            contains('Running `pub publish ` in ${pluginDir1.path}...'),
-            contains('Running `pub publish ` in ${pluginDir2.path}...'),
+            contains('Running `pub publish ` in ${plugin1.path}...'),
+            contains('Running `pub publish ` in ${plugin2.path}...'),
             contains('plugin1 - \x1B[32mpublished\x1B[0m'),
             contains('plugin2/plugin2 - \x1B[32mpublished\x1B[0m'),
           ]));
@@ -503,9 +504,10 @@ void main() {
       // The existing plugin.
       createFakePlugin('plugin0', packagesDir);
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 =
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
 
       // Git results for plugin0 having been released already, and plugin1 and
@@ -515,8 +517,8 @@ void main() {
       ];
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
 
       mockStdin.readLineOutput = 'y';
@@ -527,8 +529,8 @@ void main() {
       expect(
           output,
           containsAllInOrder(<String>[
-            'Running `pub publish ` in ${pluginDir1.path}...\n',
-            'Running `pub publish ` in ${pluginDir2.path}...\n',
+            'Running `pub publish ` in ${plugin1.path}...\n',
+            'Running `pub publish ` in ${plugin2.path}...\n',
           ]));
       expect(
           processRunner.recordedCalls,
@@ -552,15 +554,16 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 =
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
       mockStdin.readLineOutput = 'y';
 
@@ -576,11 +579,11 @@ void main() {
           output,
           containsAllInOrder(<Matcher>[
             contains('=============== DRY RUN ==============='),
-            contains('Running `pub publish ` in ${pluginDir1.path}...'),
+            contains('Running `pub publish ` in ${plugin1.path}...'),
             contains('Tagging release plugin1-v0.0.1...'),
             contains('Pushing tag to upstream...'),
             contains('Published plugin1 successfully!'),
-            contains('Running `pub publish ` in ${pluginDir2.path}...'),
+            contains('Running `pub publish ` in ${plugin2.path}...'),
             contains('Tagging release plugin2-v0.0.1...'),
             contains('Pushing tag to upstream...'),
             contains('Published plugin2 successfully!'),
@@ -603,17 +606,17 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      final Directory pluginDir2 = createFakePlugin(
+      final RepositoryPackage plugin2 = createFakePlugin(
           'plugin2', packagesDir.childDirectory('plugin2'),
           version: '0.0.2');
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
 
       mockStdin.readLineOutput = 'y';
@@ -623,9 +626,9 @@ void main() {
       expect(
           output2,
           containsAllInOrder(<Matcher>[
-            contains('Running `pub publish ` in ${pluginDir1.path}...'),
+            contains('Running `pub publish ` in ${plugin1.path}...'),
             contains('Published plugin1 successfully!'),
-            contains('Running `pub publish ` in ${pluginDir2.path}...'),
+            contains('Running `pub publish ` in ${plugin2.path}...'),
             contains('Published plugin2 successfully!'),
           ]));
       expect(
@@ -652,17 +655,17 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      final Directory pluginDir2 =
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
-      pluginDir2.deleteSync(recursive: true);
+      plugin2.directory.deleteSync(recursive: true);
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
 
       mockStdin.readLineOutput = 'y';
@@ -672,7 +675,7 @@ void main() {
       expect(
           output2,
           containsAllInOrder(<Matcher>[
-            contains('Running `pub publish ` in ${pluginDir1.path}...'),
+            contains('Running `pub publish ` in ${plugin1.path}...'),
             contains('Published plugin1 successfully!'),
             contains(
                 'The pubspec file for plugin2/plugin2 does not exist, so no publishing will happen.\nSafe to ignore if the package is deleted in this commit.\n'),
@@ -698,17 +701,17 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      final Directory pluginDir2 = createFakePlugin(
+      final RepositoryPackage plugin2 = createFakePlugin(
           'plugin2', packagesDir.childDirectory('plugin2'),
           version: '0.0.2');
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
       processRunner.mockProcessesForExecutable['git-tag'] = <io.Process>[
         MockProcess(
@@ -748,17 +751,17 @@ void main() {
       };
 
       // Non-federated
-      final Directory pluginDir1 =
+      final RepositoryPackage plugin1 =
           createFakePlugin('plugin1', packagesDir, version: '0.0.2');
       // federated
-      final Directory pluginDir2 = createFakePlugin(
+      final RepositoryPackage plugin2 = createFakePlugin(
           'plugin2', packagesDir.childDirectory('plugin2'),
           version: '0.0.2');
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('pubspec.yaml').path}\n'
-                '${pluginDir2.childFile('pubspec.yaml').path}\n')
+            stdout: '${plugin1.pubspecFile.path}\n'
+                '${plugin2.pubspecFile.path}\n')
       ];
 
       Error? commandError;
@@ -785,15 +788,16 @@ void main() {
 
     test('No version change does not release any plugins', () async {
       // Non-federated
-      final Directory pluginDir1 = createFakePlugin('plugin1', packagesDir);
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin1', packagesDir);
       // federated
-      final Directory pluginDir2 =
+      final RepositoryPackage plugin2 =
           createFakePlugin('plugin2', packagesDir.childDirectory('plugin2'));
 
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
         MockProcess(
-            stdout: '${pluginDir1.childFile('plugin1.dart').path}\n'
-                '${pluginDir2.childFile('plugin2.dart').path}\n')
+            stdout: '${plugin1.libDirectory.childFile('plugin1.dart').path}\n'
+                '${plugin2.libDirectory.childFile('plugin2.dart').path}\n')
       ];
 
       final List<String> output = await runCapturingPrint(commandRunner,
@@ -812,10 +816,10 @@ void main() {
         'versions': <String>[],
       };
 
-      final Directory flutterPluginTools =
+      final RepositoryPackage flutterPluginTools =
           createFakePlugin('flutter_plugin_tools', packagesDir);
       processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
-        MockProcess(stdout: flutterPluginTools.childFile('pubspec.yaml').path)
+        MockProcess(stdout: flutterPluginTools.pubspecFile.path)
       ];
 
       final List<String> output = await runCapturingPrint(commandRunner,

--- a/script/tool/test/pubspec_check_command_test.dart
+++ b/script/tool/test/pubspec_check_command_test.dart
@@ -146,9 +146,9 @@ void main() {
     });
 
     test('passes for a plugin following conventions', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -157,10 +157,7 @@ ${_devDependenciesSection()}
 ${_falseSecretsSection()}
 ''');
 
-      pluginDirectory
-          .childDirectory('example')
-          .childFile('pubspec.yaml')
-          .writeAsStringSync('''
+      plugin.getExamples().first.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_example',
         publishable: false,
@@ -187,10 +184,10 @@ ${_flutterSection()}
     });
 
     test('passes for a Flutter package following conventions', () async {
-      final Directory packageDirectory =
+      final RepositoryPackage package =
           createFakePackage('a_package', packagesDir);
 
-      packageDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      package.pubspecFile.writeAsStringSync('''
 ${_headerSection('a_package')}
 ${_environmentSection()}
 ${_dependenciesSection()}
@@ -199,10 +196,7 @@ ${_flutterSection()}
 ${_falseSecretsSection()}
 ''');
 
-      packageDirectory
-          .childDirectory('example')
-          .childFile('pubspec.yaml')
-          .writeAsStringSync('''
+      package.getExamples().first.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'a_package',
         publishable: false,
@@ -229,10 +223,10 @@ ${_flutterSection()}
     });
 
     test('passes for a minimal package following conventions', () async {
-      final Directory packageDirectory = packagesDir.childDirectory('package');
-      packageDirectory.createSync(recursive: true);
+      final RepositoryPackage package =
+          createFakePackage('package', packagesDir, examples: <String>[]);
 
-      packageDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      package.pubspecFile.writeAsStringSync('''
 ${_headerSection('package')}
 ${_environmentSection()}
 ${_dependenciesSection()}
@@ -252,10 +246,10 @@ ${_dependenciesSection()}
     });
 
     test('fails when homepage is included', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, includeHomepage: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -280,10 +274,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when repository is missing', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, includeRepository: false)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -307,10 +301,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when homepage is given instead of repository', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, includeHomepage: true, includeRepository: false)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -335,10 +329,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when repository is incorrect', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, repositoryPackagesDirRelativePath: 'different_plugin')}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -362,10 +356,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when issue tracker is missing', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, includeIssueTracker: false)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -389,11 +383,11 @@ ${_devDependenciesSection()}
     });
 
     test('fails when description is too short', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'a_plugin', packagesDir.childDirectory('a_plugin'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, description: 'Too short')}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -420,10 +414,10 @@ ${_devDependenciesSection()}
     test(
         'allows short descriptions for non-app-facing parts of federated plugins',
         () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, description: 'Too short')}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -448,7 +442,7 @@ ${_devDependenciesSection()}
     });
 
     test('fails when description is too long', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
       const String description = 'This description is too long. It just goes '
@@ -456,7 +450,7 @@ ${_devDependenciesSection()}
           'there is just too much here. Someone shoul really cut this down to just '
           'the core description so that search results are more useful and the '
           'package does not lose pub points.';
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true, description: description)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -481,10 +475,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when environment section is out of order', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_flutterSection(isPlugin: true)}
 ${_dependenciesSection()}
@@ -509,10 +503,10 @@ ${_environmentSection()}
     });
 
     test('fails when flutter section is out of order', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_flutterSection(isPlugin: true)}
 ${_environmentSection()}
@@ -537,10 +531,10 @@ ${_devDependenciesSection()}
     });
 
     test('fails when dependencies section is out of order', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -565,9 +559,9 @@ ${_dependenciesSection()}
     });
 
     test('fails when dev_dependencies section is out of order', () async {
-      final Directory pluginDirectory = createFakePlugin('plugin', packagesDir);
+      final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_environmentSection()}
 ${_devDependenciesSection()}
@@ -592,10 +586,10 @@ ${_dependenciesSection()}
     });
 
     test('fails when false_secrets section is out of order', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin', isPlugin: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -622,11 +616,11 @@ ${_devDependenciesSection()}
 
     test('fails when an implemenation package is missing "implements"',
         () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a_foo', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin_a_foo', isPlugin: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true)}
@@ -651,11 +645,11 @@ ${_devDependenciesSection()}
 
     test('fails when an implemenation package has the wrong "implements"',
         () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a_foo', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin_a_foo', isPlugin: true)}
 ${_environmentSection()}
 ${_flutterSection(isPlugin: true, implementedPackage: 'plugin_a_foo')}
@@ -680,11 +674,11 @@ ${_devDependenciesSection()}
     });
 
     test('passes for a correct implemenation package', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a_foo', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_a_foo',
         isPlugin: true,
@@ -709,11 +703,11 @@ ${_devDependenciesSection()}
     });
 
     test('fails when a "default_package" looks incorrect', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_a',
         isPlugin: true,
@@ -749,11 +743,11 @@ ${_devDependenciesSection()}
     test(
         'fails when a "default_package" does not have a corresponding dependency',
         () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_a',
         isPlugin: true,
@@ -787,11 +781,11 @@ ${_devDependenciesSection()}
     });
 
     test('passes for an app-facing package without "implements"', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_a',
         isPlugin: true,
@@ -817,11 +811,11 @@ ${_devDependenciesSection()}
 
     test('passes for a platform interface package without "implements"',
         () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a_platform_interface', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin_a_platform_interface',
         isPlugin: true,
@@ -847,13 +841,13 @@ ${_devDependenciesSection()}
     });
 
     test('validates some properties even for unpublished packages', () async {
-      final Directory pluginDirectory = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
           'plugin_a_foo', packagesDir.childDirectory('plugin_a'),
           examples: <String>[]);
 
       // Environment section is in the wrong location.
       // Missing 'implements'.
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection('plugin_a_foo', isPlugin: true, publishable: false)}
 ${_flutterSection(isPlugin: true)}
 ${_dependenciesSection()}
@@ -879,12 +873,12 @@ ${_environmentSection()}
     });
 
     test('ignores some checks for unpublished packages', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, examples: <String>[]);
 
       // Missing metadata that is only useful for published packages, such as
       // repository and issue tracker.
-      pluginDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      plugin.pubspecFile.writeAsStringSync('''
 ${_headerSection(
         'plugin',
         isPlugin: true,
@@ -936,10 +930,10 @@ ${_devDependenciesSection()}
     });
 
     test('repository check works', () async {
-      final Directory packageDirectory =
+      final RepositoryPackage package =
           createFakePackage('package', packagesDir, examples: <String>[]);
 
-      packageDirectory.childFile('pubspec.yaml').writeAsStringSync('''
+      package.pubspecFile.writeAsStringSync('''
 ${_headerSection('package')}
 ${_environmentSection()}
 ${_dependenciesSection()}

--- a/script/tool/test/readme_check_command_test.dart
+++ b/script/tool/test/readme_check_command_test.dart
@@ -62,7 +62,7 @@ void main() {
       const String federatedPluginName = 'a_federated_plugin';
       final Directory federatedDir =
           packagesDir.childDirectory(federatedPluginName);
-      final List<Directory> packageDirectories = <Directory>[
+      final List<RepositoryPackage> packages = <RepositoryPackage>[
         // A non-plugin package.
         createFakePackage('a_package', packagesDir),
         // Non-app-facing parts of a federated plugin.
@@ -71,8 +71,8 @@ void main() {
         createFakePlugin('${federatedPluginName}_android', federatedDir),
       ];
 
-      for (final Directory package in packageDirectories) {
-        package.childFile('README.md').writeAsStringSync('''
+      for (final RepositoryPackage package in packages) {
+        package.readmeFile.writeAsStringSync('''
 A very useful package.
 ''');
       }
@@ -94,9 +94,10 @@ A very useful package.
 
     test('fails when non-federated plugin is missing an OS support table',
         () async {
-      final Directory pluginDir = createFakePlugin('a_plugin', packagesDir);
+      final RepositoryPackage plugin =
+          createFakePlugin('a_plugin', packagesDir);
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 ''');
 
@@ -118,10 +119,10 @@ A very useful plugin.
     test(
         'fails when app-facing part of a federated plugin is missing an OS support table',
         () async {
-      final Directory pluginDir =
+      final RepositoryPackage plugin =
           createFakePlugin('a_plugin', packagesDir.childDirectory('a_plugin'));
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 ''');
 
@@ -141,9 +142,10 @@ A very useful plugin.
     });
 
     test('fails the OS support table is missing the header', () async {
-      final Directory pluginDir = createFakePlugin('a_plugin', packagesDir);
+      final RepositoryPackage plugin =
+          createFakePlugin('a_plugin', packagesDir);
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 
 | **Support**    | SDK 21+ | iOS 10+* | [See `camera_web `][1] |
@@ -165,7 +167,7 @@ A very useful plugin.
     });
 
     test('fails if the OS support table is missing a supported OS', () async {
-      final Directory pluginDir = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'a_plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -175,7 +177,7 @@ A very useful plugin.
         },
       );
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 
 |                | Android | iOS      |
@@ -202,7 +204,7 @@ A very useful plugin.
     });
 
     test('fails if the OS support table lists an extra OS', () async {
-      final Directory pluginDir = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'a_plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -211,7 +213,7 @@ A very useful plugin.
         },
       );
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 
 |                | Android | iOS      | Web                    |
@@ -239,7 +241,7 @@ A very useful plugin.
 
     test('fails if the OS support table has unexpected OS formatting',
         () async {
-      final Directory pluginDir = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'a_plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
@@ -250,7 +252,7 @@ A very useful plugin.
         },
       );
 
-      pluginDir.childFile('README.md').writeAsStringSync('''
+      plugin.readmeFile.writeAsStringSync('''
 A very useful plugin.
 
 |                | android | ios      | MacOS | web                    |
@@ -278,9 +280,10 @@ A very useful plugin.
 
   group('code blocks', () {
     test('fails on missing info string', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      packageDir.childFile('README.md').writeAsStringSync('''
+      package.readmeFile.writeAsStringSync('''
 Example:
 
 ```
@@ -307,9 +310,10 @@ void main() {
     });
 
     test('allows unknown info strings', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      packageDir.childFile('README.md').writeAsStringSync('''
+      package.readmeFile.writeAsStringSync('''
 Example:
 
 ```someunknowninfotag
@@ -331,9 +335,10 @@ A B C
     });
 
     test('allows space around info strings', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      packageDir.childFile('README.md').writeAsStringSync('''
+      package.readmeFile.writeAsStringSync('''
 Example:
 
 ```  dart
@@ -355,9 +360,10 @@ A B C
     });
 
     test('passes when excerpt requirement is met', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      packageDir.childFile('README.md').writeAsStringSync('''
+      package.readmeFile.writeAsStringSync('''
 Example:
 
 <?code-excerpt "main.dart (SomeSection)"?>
@@ -379,9 +385,10 @@ A B C
     });
 
     test('fails on missing excerpt tag when requested', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir);
+      final RepositoryPackage package =
+          createFakePackage('a_package', packagesDir);
 
-      packageDir.childFile('README.md').writeAsStringSync('''
+      package.readmeFile.writeAsStringSync('''
 Example:
 
 ```dart

--- a/script/tool/test/test_command_test.dart
+++ b/script/tool/test/test_command_test.dart
@@ -40,9 +40,9 @@ void main() {
     });
 
     test('runs flutter test on each plugin', () async {
-      final Directory plugin1Dir = createFakePlugin('plugin1', packagesDir,
+      final RepositoryPackage plugin1 = createFakePlugin('plugin1', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+      final RepositoryPackage plugin2 = createFakePlugin('plugin2', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(runner, <String>['test']);
@@ -51,15 +51,15 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(getFlutterCommand(mockPlatform),
-              const <String>['test', '--color'], plugin1Dir.path),
+              const <String>['test', '--color'], plugin1.path),
           ProcessCall(getFlutterCommand(mockPlatform),
-              const <String>['test', '--color'], plugin2Dir.path),
+              const <String>['test', '--color'], plugin2.path),
         ]),
       );
     });
 
     test('runs flutter test on Flutter package example tests', () async {
-      final Directory pluginDir = createFakePlugin('a_plugin', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('a_plugin', packagesDir,
           extraFiles: <String>[
             'test/empty_test.dart',
             'example/test/an_example_test.dart'
@@ -71,11 +71,9 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(getFlutterCommand(mockPlatform),
-              const <String>['test', '--color'], pluginDir.path),
-          ProcessCall(
-              getFlutterCommand(mockPlatform),
-              const <String>['test', '--color'],
-              pluginDir.childDirectory('example').path),
+              const <String>['test', '--color'], plugin.path),
+          ProcessCall(getFlutterCommand(mockPlatform),
+              const <String>['test', '--color'], getExampleDir(plugin).path),
         ]),
       );
     });
@@ -110,7 +108,7 @@ void main() {
 
     test('skips testing plugins without test directory', () async {
       createFakePlugin('plugin1', packagesDir);
-      final Directory plugin2Dir = createFakePlugin('plugin2', packagesDir,
+      final RepositoryPackage plugin2 = createFakePlugin('plugin2', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(runner, <String>['test']);
@@ -119,15 +117,15 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(getFlutterCommand(mockPlatform),
-              const <String>['test', '--color'], plugin2Dir.path),
+              const <String>['test', '--color'], plugin2.path),
         ]),
       );
     });
 
     test('runs dart run test on non-Flutter packages', () async {
-      final Directory pluginDir = createFakePlugin('a', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('a', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
-      final Directory packageDir = createFakePackage('b', packagesDir,
+      final RepositoryPackage package = createFakePackage('b', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(
@@ -139,34 +137,34 @@ void main() {
           ProcessCall(
               getFlutterCommand(mockPlatform),
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              pluginDir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
+              plugin.path),
+          ProcessCall('dart', const <String>['pub', 'get'], package.path),
           ProcessCall(
               'dart',
               const <String>['run', '--enable-experiment=exp1', 'test'],
-              packageDir.path),
+              package.path),
         ]),
       );
     });
 
     test('runs dart run test on non-Flutter package examples', () async {
-      final Directory packageDir = createFakePackage('a_package', packagesDir,
-          extraFiles: <String>[
-            'test/empty_test.dart',
-            'example/test/an_example_test.dart'
-          ]);
+      final RepositoryPackage package = createFakePackage(
+          'a_package', packagesDir, extraFiles: <String>[
+        'test/empty_test.dart',
+        'example/test/an_example_test.dart'
+      ]);
 
       await runCapturingPrint(runner, <String>['test']);
 
       expect(
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
-          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
-          ProcessCall('dart', const <String>['run', 'test'], packageDir.path),
+          ProcessCall('dart', const <String>['pub', 'get'], package.path),
+          ProcessCall('dart', const <String>['run', 'test'], package.path),
           ProcessCall('dart', const <String>['pub', 'get'],
-              packageDir.childDirectory('example').path),
+              getExampleDir(package).path),
           ProcessCall('dart', const <String>['run', 'test'],
-              packageDir.childDirectory('example').path),
+              getExampleDir(package).path),
         ]),
       );
     });
@@ -220,7 +218,7 @@ void main() {
     });
 
     test('runs on Chrome for web plugins', () async {
-      final Directory pluginDir = createFakePlugin(
+      final RepositoryPackage plugin = createFakePlugin(
         'plugin',
         packagesDir,
         extraFiles: <String>['test/empty_test.dart'],
@@ -237,15 +235,15 @@ void main() {
           ProcessCall(
               getFlutterCommand(mockPlatform),
               const <String>['test', '--color', '--platform=chrome'],
-              pluginDir.path),
+              plugin.path),
         ]),
       );
     });
 
     test('enable-experiment flag', () async {
-      final Directory pluginDir = createFakePlugin('a', packagesDir,
+      final RepositoryPackage plugin = createFakePlugin('a', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
-      final Directory packageDir = createFakePackage('b', packagesDir,
+      final RepositoryPackage package = createFakePackage('b', packagesDir,
           extraFiles: <String>['test/empty_test.dart']);
 
       await runCapturingPrint(
@@ -257,12 +255,12 @@ void main() {
           ProcessCall(
               getFlutterCommand(mockPlatform),
               const <String>['test', '--color', '--enable-experiment=exp1'],
-              pluginDir.path),
-          ProcessCall('dart', const <String>['pub', 'get'], packageDir.path),
+              plugin.path),
+          ProcessCall('dart', const <String>['pub', 'get'], package.path),
           ProcessCall(
               'dart',
               const <String>['run', '--enable-experiment=exp1', 'test'],
-              packageDir.path),
+              package.path),
         ]),
       );
     });

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -8,7 +8,6 @@ import 'package:args/command_runner.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_plugin_tools/src/common/core.dart';
-import 'package:flutter_plugin_tools/src/common/repository_package.dart';
 import 'package:flutter_plugin_tools/src/update_excerpts_command.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -42,9 +41,9 @@ void main() {
   });
 
   test('runs pub get before running scripts', () async {
-    final Directory package = createFakePlugin('a_package', packagesDir,
+    final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
         extraFiles: <String>['example/build.excerpt.yaml']);
-    final Directory example = package.childDirectory('example');
+    final Directory example = getExampleDir(package);
 
     await runCapturingPrint(runner, <String>['update-excerpts']);
 
@@ -69,9 +68,9 @@ void main() {
   });
 
   test('runs when config is present', () async {
-    final Directory package = createFakePlugin('a_package', packagesDir,
+    final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
         extraFiles: <String>['example/build.excerpt.yaml']);
-    final Directory example = package.childDirectory('example');
+    final Directory example = getExampleDir(package);
 
     final List<String> output =
         await runCapturingPrint(runner, <String>['update-excerpts']);
@@ -128,7 +127,7 @@ void main() {
   });
 
   test('restores pubspec even if running the script fails', () async {
-    final Directory package = createFakePlugin('a_package', packagesDir,
+    final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
         extraFiles: <String>['example/build.excerpt.yaml']);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
@@ -152,11 +151,8 @@ void main() {
               '    Unable to get script dependencies')
         ]));
 
-    final String examplePubspecContent = RepositoryPackage(package)
-        .getExamples()
-        .first
-        .pubspecFile
-        .readAsStringSync();
+    final String examplePubspecContent =
+        package.getExamples().first.pubspecFile.readAsStringSync();
     expect(examplePubspecContent, isNot(contains('code_excerpter')));
     expect(examplePubspecContent, isNot(contains('code_excerpt_updater')));
   });

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -414,14 +414,14 @@ This is necessary because of X, Y, and Z
     test('Allow empty lines in front of the first version in CHANGELOG',
         () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: version);
       const String changelog = '''
 
 ## $version
 * Some changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=main']);
       expect(
@@ -433,13 +433,13 @@ This is necessary because of X, Y, and Z
     });
 
     test('Throws if versions in changelog and pubspec do not match', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: '1.0.1');
       const String changelog = '''
 ## 1.0.2
 * Some changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       Error? commandError;
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=main', '--against-pub'],
@@ -458,14 +458,14 @@ This is necessary because of X, Y, and Z
 
     test('Success if CHANGELOG and pubspec versions match', () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
 ## $version
 * Some changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=main']);
       expect(
@@ -479,7 +479,7 @@ This is necessary because of X, Y, and Z
     test(
         'Fail if pubspec version only matches an older version listed in CHANGELOG',
         () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
       const String changelog = '''
@@ -488,7 +488,7 @@ This is necessary because of X, Y, and Z
 ## 1.0.0
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       bool hasError = false;
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=main', '--against-pub'],
@@ -509,7 +509,7 @@ This is necessary because of X, Y, and Z
     test('Allow NEXT as a placeholder for gathering CHANGELOG entries',
         () async {
       const String version = '1.0.0';
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
@@ -518,7 +518,7 @@ This is necessary because of X, Y, and Z
 ## $version
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
         MockProcess(stdout: 'version: 1.0.0'),
       ];
@@ -536,7 +536,7 @@ This is necessary because of X, Y, and Z
 
     test('Fail if NEXT appears after a version', () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
@@ -547,7 +547,7 @@ This is necessary because of X, Y, and Z
 ## 1.0.0
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       bool hasError = false;
       final List<String> output = await runCapturingPrint(
           runner, <String>['version-check', '--base-sha=main', '--against-pub'],
@@ -569,7 +569,7 @@ This is necessary because of X, Y, and Z
     test('Fail if NEXT is left in the CHANGELOG when adding a version bump',
         () async {
       const String version = '1.0.1';
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: version);
 
       const String changelog = '''
@@ -580,7 +580,7 @@ This is necessary because of X, Y, and Z
 ## 1.0.0
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
 
       bool hasError = false;
       final List<String> output = await runCapturingPrint(
@@ -603,7 +603,7 @@ This is necessary because of X, Y, and Z
     });
 
     test('Fail if the version changes without replacing NEXT', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: '1.0.1');
 
       const String changelog = '''
@@ -612,7 +612,7 @@ This is necessary because of X, Y, and Z
 ## 1.0.0
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
 
       bool hasError = false;
       final List<String> output = await runCapturingPrint(
@@ -635,7 +635,7 @@ This is necessary because of X, Y, and Z
     test(
         'fails gracefully if the version headers are not found due to using the wrong style',
         () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
       const String changelog = '''
@@ -644,7 +644,7 @@ This is necessary because of X, Y, and Z
 # 1.0.0
 * Some other changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
         MockProcess(stdout: 'version: 1.0.0'),
       ];
@@ -670,14 +670,14 @@ This is necessary because of X, Y, and Z
     });
 
     test('fails gracefully if the version is unparseable', () async {
-      final Directory pluginDirectory =
+      final RepositoryPackage plugin =
           createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
       const String changelog = '''
 ## Alpha
 * Some changes.
 ''';
-      createFakeCHANGELOG(pluginDirectory, changelog);
+      createFakeCHANGELOG(plugin, changelog);
       processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
         MockProcess(stdout: 'version: 1.0.0'),
       ];
@@ -715,14 +715,14 @@ This is necessary because of X, Y, and Z
       }
 
       test('passes for unchanged packages', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -744,14 +744,14 @@ This is necessary because of X, Y, and Z
       test(
           'fails if a version change is missing from a change that does not '
           'pass the exemption check', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -779,14 +779,14 @@ packages/plugin/lib/plugin.dart
       });
 
       test('passes version change requirement when version changes', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.1');
 
         const String changelog = '''
 ## 1.0.1
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -810,14 +810,14 @@ packages/plugin/pubspec.yaml
       });
 
       test('version change check ignores files outside the package', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -840,14 +840,14 @@ tool/plugin/lib/plugin.dart
       });
 
       test('allows missing version change for exempt changes', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -873,14 +873,14 @@ packages/plugin/CHANGELOG.md
       });
 
       test('allows missing version change with justification', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -914,14 +914,14 @@ No version change: Code change is only to implementation comments.
       });
 
       test('fails if a CHANGELOG change is missing', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -949,14 +949,14 @@ packages/plugin/example/lib/foo.dart
       });
 
       test('passes CHANGELOG check when the CHANGELOG is changed', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -980,14 +980,14 @@ packages/plugin/CHANGELOG.md
 
       test('fails CHANGELOG check if only another package CHANGELOG chages',
           () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];
@@ -1014,14 +1014,14 @@ packages/another_plugin/CHANGELOG.md
       });
 
       test('allows missing CHANGELOG change with justification', () async {
-        final Directory pluginDirectory =
+        final RepositoryPackage plugin =
             createFakePlugin('plugin', packagesDir, version: '1.0.0');
 
         const String changelog = '''
 ## 1.0.0
 * Some changes.
 ''';
-        createFakeCHANGELOG(pluginDirectory, changelog);
+        createFakeCHANGELOG(plugin, changelog);
         processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
           MockProcess(stdout: 'version: 1.0.0'),
         ];

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -82,13 +82,12 @@ void main() {
       });
 
       test('runs for iOS plugin', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          platformIOS: const PlatformDetails(PlatformSupport.inline)
-        });
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
+            platformSupport: <String, PlatformDetails>{
+              platformIOS: const PlatformDetails(PlatformSupport.inline)
+            });
 
-        final Directory pluginExampleDirectory =
-            pluginDirectory.childDirectory('example');
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'xcode-analyze',
@@ -184,14 +183,12 @@ void main() {
       });
 
       test('runs for macOS plugin', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin', packagesDir,
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
               platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
-        final Directory pluginExampleDirectory =
-            pluginDirectory1.childDirectory('example');
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'xcode-analyze',
@@ -251,15 +248,13 @@ void main() {
 
     group('combined', () {
       test('runs both iOS and macOS when supported', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin', packagesDir,
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
               platformIOS: const PlatformDetails(PlatformSupport.inline),
               platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
-        final Directory pluginExampleDirectory =
-            pluginDirectory1.childDirectory('example');
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'xcode-analyze',
@@ -311,14 +306,12 @@ void main() {
       });
 
       test('runs only macOS for a macOS plugin', () async {
-        final Directory pluginDirectory1 = createFakePlugin(
-            'plugin', packagesDir,
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
               platformMacOS: const PlatformDetails(PlatformSupport.inline),
             });
 
-        final Directory pluginExampleDirectory =
-            pluginDirectory1.childDirectory('example');
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'xcode-analyze',
@@ -353,13 +346,12 @@ void main() {
       });
 
       test('runs only iOS for a iOS plugin', () async {
-        final Directory pluginDirectory = createFakePlugin(
-            'plugin', packagesDir, platformSupport: <String, PlatformDetails>{
-          platformIOS: const PlatformDetails(PlatformSupport.inline)
-        });
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
+            platformSupport: <String, PlatformDetails>{
+              platformIOS: const PlatformDetails(PlatformSupport.inline)
+            });
 
-        final Directory pluginExampleDirectory =
-            pluginDirectory.childDirectory('example');
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
 
         final List<String> output = await runCapturingPrint(runner, <String>[
           'xcode-analyze',


### PR DESCRIPTION
Converts the test utils for creating fake packages and associated files
to use the newer `RepositoryPackage` instead of `Directory`, to improve
the typing of common objects.

As part of this, converts various test-local support utilities to take
`RepositoryPackage`s to keep the consistent type, and adds several more
package path utility methods for common subpaths to reduce duplication
of `directory.child{File,Directory}('some-hard-coded-value')`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
