### PR TITLE
[google_sign_in_platform_interface] Add availability to mock models

### DIFF
--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.1.3
 
+* Enables mocking models by changing overridden operator == parameter type from `dynamic` to `Object`.
 * Removes unnecessary imports.
 
 ## 2.1.2

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/src/types.dart
@@ -79,7 +79,7 @@ class GoogleSignInUserData {
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }
@@ -122,7 +122,7 @@ class GoogleSignInTokenData {
   @override
   // TODO(stuartmorgan): Make this class immutable in the next breaking change.
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) {
       return true;
     }

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
@@ -29,6 +29,44 @@ void main() {
       GoogleSignInPlatform.instance = ImplementsWithIsMock();
     });
   });
+
+  group('GoogleSignInTokenData', () {
+    test('can be compared by == operator', () {
+      final GoogleSignInTokenData firstInstance = GoogleSignInTokenData(
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        serverAuthCode: 'serverAuthCode',
+      );
+      final GoogleSignInTokenData secondInstance = GoogleSignInTokenData(
+        accessToken: 'accessToken',
+        idToken: 'idToken',
+        serverAuthCode: 'serverAuthCode',
+      );
+      expect(firstInstance == secondInstance, isTrue);
+    });
+  });
+
+  group('GoogleSignInUserData', () {
+    test('can be compared by == operator', () {
+      final GoogleSignInUserData firstInstance = GoogleSignInUserData(
+        email: 'email',
+        id: 'id',
+        displayName: 'displayName',
+        photoUrl: 'photoUrl',
+        idToken: 'idToken',
+        serverAuthCode: 'serverAuthCode',
+      );
+      final GoogleSignInUserData secondInstance = GoogleSignInUserData(
+        email: 'email',
+        id: 'id',
+        displayName: 'displayName',
+        photoUrl: 'photoUrl',
+        idToken: 'idToken',
+        serverAuthCode: 'serverAuthCode',
+      );
+      expect(firstInstance == secondInstance, isTrue);
+    });
+  });
 }
 
 class ImplementsWithIsMock extends Mock implements GoogleSignInPlatform {


### PR DESCRIPTION
Split PR From https://github.com/flutter/plugins/pull/5642 because of https://github.com/flutter/plugins/pull/5642#discussion_r868219111 (To keep federated safety)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
