### PR TITLE
[local_auth] fix `use_key_in_widget_constructors` lint

### DIFF
--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+* Removes ignoring `public_member_api_docs` lint.
+* Fixes `use_key_in_widget_constructors` lint.
+
 ## 2.0.1
 
 * Restores the ability to import `error_codes.dart`.

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.2
 
-* Removes ignoring `public_member_api_docs` lint.
+* Removes ignoring `public_member_api_docs` lint in the example.
 * Fixes `use_key_in_widget_constructors` lint.
 
 ## 2.0.1

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.0.2
 
-* Removes ignoring `public_member_api_docs` lint in the example.
-* Fixes `use_key_in_widget_constructors` lint.
+* Fixes `use_key_in_widget_constructors` lint in the example.
+* Removes ignoring `public_member_api_docs` lint.
 
 ## 2.0.1
 

--- a/packages/local_auth/local_auth/example/lib/main.dart
+++ b/packages/local_auth/local_auth/example/lib/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: public_member_api_docs
-
 import 'dart:async';
 
 import 'package:flutter/material.dart';
@@ -14,7 +12,9 @@ void main() {
   runApp(const MyApp());
 }
 
+/// MyApp is the Main Application.
 class MyApp extends StatefulWidget {
+  /// Default Constructor
   const MyApp({Key? key}) : super(key: key);
 
   @override

--- a/packages/local_auth/local_auth/example/lib/readme_excerpts.dart
+++ b/packages/local_auth/local_auth/example/lib/readme_excerpts.dart
@@ -24,6 +24,7 @@ import 'package:local_auth_ios/local_auth_ios.dart';
 void main() {
   runApp(const MyApp());
 }
+
 /// MyApp is the Main Application.
 class MyApp extends StatefulWidget {
   /// Default Constructor

--- a/packages/local_auth/local_auth/example/lib/readme_excerpts.dart
+++ b/packages/local_auth/local_auth/example/lib/readme_excerpts.dart
@@ -5,8 +5,6 @@
 // This file exists solely to host compiled excerpts for README.md, and is not
 // intended for use as an actual example application.
 
-// ignore_for_file: public_member_api_docs
-
 import 'package:flutter/material.dart';
 // #docregion ErrorHandling
 import 'package:flutter/services.dart';
@@ -24,10 +22,13 @@ import 'package:local_auth_ios/local_auth_ios.dart';
 // #enddocregion CustomMessages
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
-
+/// MyApp is the Main Application.
 class MyApp extends StatefulWidget {
+  /// Default Constructor
+  const MyApp({Key? key}) : super(key: key);
+
   @override
   State<MyApp> createState() => _MyAppState();
 }

--- a/packages/local_auth/local_auth/lib/src/local_auth.dart
+++ b/packages/local_auth/local_auth/lib/src/local_auth.dart
@@ -2,12 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// This is a temporary ignore to allow us to land a new set of linter rules in a
-// series of manageable patches instead of one gigantic PR. It disables some of
-// the new lints that are already failing on this plugin, for this plugin. It
-// should be deleted and the failing lints addressed as soon as possible.
-// ignore_for_file: public_member_api_docs
-
 import 'dart:async';
 
 import 'package:flutter/services.dart';

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Android and iOS devices to allow local
   authentication via fingerprint, touch ID, face ID, passcode, pin, or pattern.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 2.0.1
+version: 2.0.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
* Fixes `use_key_in_widget_constructors` lint.
* Removes ignoring `public_member_api_docs` lint.

Fixes https://github.com/flutter/flutter/issues/103389

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
