### PR TITLE
Revert "Enable lints `library_private_types_in_public_api`, `sort_child_properties_last` and `use_key_in_widget_constructors`"

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -134,7 +134,6 @@ linter:
     - leading_newlines_in_multiline_strings
     - library_names
     - library_prefixes
-    - library_private_types_in_public_api
     # - lines_longer_than_80_chars # not required by flutter style
     - list_remove_unrelated_type
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
@@ -198,7 +197,7 @@ linter:
     - recursive_getters
     # - sized_box_for_whitespace # not yet tested
     - slash_for_doc_comments
-    - sort_child_properties_last
+    # - sort_child_properties_last # not yet tested
     - sort_constructors_first
     - sort_unnamed_constructors_first
     - test_types_in_equals
@@ -230,7 +229,7 @@ linter:
     - use_full_hex_values_for_flutter_colors
     # - use_function_type_syntax_for_parameters # not yet tested
     - use_is_even_rather_than_modulo
-    - use_key_in_widget_constructors
+    # - use_key_in_widget_constructors # not yet tested
     - use_late_for_private_fields_and_variables
     - use_raw_strings
     - use_rethrow_when_possible

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.9.4+22
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.9.4+21
 

--- a/packages/camera/camera/README.md
+++ b/packages/camera/camera/README.md
@@ -89,22 +89,18 @@ Here is a small example flutter app displaying a full screen camera preview.
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 
-late List<CameraDescription> _cameras;
+late List<CameraDescription> cameras;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  _cameras = await availableCameras();
-  runApp(const CameraApp());
+  cameras = await availableCameras();
+  runApp(CameraApp());
 }
 
-/// CameraApp is the Main Application.
 class CameraApp extends StatefulWidget {
-  /// Default Constructor
-  const CameraApp({Key? key}) : super(key: key);
-
   @override
-  State<CameraApp> createState() => _CameraAppState();
+  _CameraAppState createState() => _CameraAppState();
 }
 
 class _CameraAppState extends State<CameraApp> {
@@ -113,7 +109,7 @@ class _CameraAppState extends State<CameraApp> {
   @override
   void initState() {
     super.initState();
-    controller = CameraController(_cameras[0], ResolutionPreset.max);
+    controller = CameraController(cameras[0], ResolutionPreset.max);
     controller.initialize().then((_) {
       if (!mounted) {
         return;

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 import 'dart:async';
 import 'dart:io';
 
@@ -11,13 +13,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:video_player/video_player.dart';
 
-/// Camera example home widget.
 class CameraExampleHome extends StatefulWidget {
-  /// Default Constructor
-  const CameraExampleHome({Key? key}) : super(key: key);
-
   @override
-  State<CameraExampleHome> createState() {
+  _CameraExampleHomeState createState() {
     return _CameraExampleHomeState();
   }
 }
@@ -36,7 +34,7 @@ IconData getCameraLensIcon(CameraLensDirection direction) {
   }
 }
 
-void _logError(String code, String? message) {
+void logError(String code, String? message) {
   if (message != null) {
     print('Error: $code\nError Message: $message');
   } else {
@@ -136,6 +134,12 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
         children: <Widget>[
           Expanded(
             child: Container(
+              child: Padding(
+                padding: const EdgeInsets.all(1.0),
+                child: Center(
+                  child: _cameraPreviewWidget(),
+                ),
+              ),
               decoration: BoxDecoration(
                 color: Colors.black,
                 border: Border.all(
@@ -144,12 +148,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                           ? Colors.redAccent
                           : Colors.grey,
                   width: 3.0,
-                ),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.all(1.0),
-                child: Center(
-                  child: _cameraPreviewWidget(),
                 ),
               ),
             ),
@@ -235,8 +233,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               Container()
             else
               SizedBox(
-                width: 64.0,
-                height: 64.0,
                 child: (localVideoController == null)
                     ? (
                         // The captured image on the web contains a network-accessible URL
@@ -247,8 +243,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                             ? Image.network(imageFile!.path)
                             : Image.file(File(imageFile!.path)))
                     : Container(
-                        decoration: BoxDecoration(
-                            border: Border.all(color: Colors.pink)),
                         child: Center(
                           child: AspectRatio(
                               aspectRatio:
@@ -257,7 +251,11 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                                       : 1.0,
                               child: VideoPlayer(localVideoController)),
                         ),
+                        decoration: BoxDecoration(
+                            border: Border.all(color: Colors.pink)),
                       ),
+                width: 64.0,
+                height: 64.0,
               ),
           ],
         ),
@@ -396,6 +394,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
+                    child: const Text('AUTO'),
                     style: styleAuto,
                     onPressed: controller != null
                         ? () =>
@@ -407,22 +406,21 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                         showInSnackBar('Resetting exposure point');
                       }
                     },
-                    child: const Text('AUTO'),
                   ),
                   TextButton(
+                    child: const Text('LOCKED'),
                     style: styleLocked,
                     onPressed: controller != null
                         ? () =>
                             onSetExposureModeButtonPressed(ExposureMode.locked)
                         : null,
-                    child: const Text('LOCKED'),
                   ),
                   TextButton(
+                    child: const Text('RESET OFFSET'),
                     style: styleLocked,
                     onPressed: controller != null
                         ? () => controller!.setExposureOffset(0.0)
                         : null,
-                    child: const Text('RESET OFFSET'),
                   ),
                 ],
               ),
@@ -481,6 +479,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                 mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
+                    child: const Text('AUTO'),
                     style: styleAuto,
                     onPressed: controller != null
                         ? () => onSetFocusModeButtonPressed(FocusMode.auto)
@@ -491,14 +490,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
                       }
                       showInSnackBar('Resetting focus point');
                     },
-                    child: const Text('AUTO'),
                   ),
                   TextButton(
+                    child: const Text('LOCKED'),
                     style: styleLocked,
                     onPressed: controller != null
                         ? () => onSetFocusModeButtonPressed(FocusMode.locked)
                         : null,
-                    child: const Text('LOCKED'),
                   ),
                 ],
               ),
@@ -584,13 +582,13 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       onNewCameraSelected(description);
     };
 
-    if (_cameras.isEmpty) {
+    if (cameras.isEmpty) {
       _ambiguate(SchedulerBinding.instance)?.addPostFrameCallback((_) async {
         showInSnackBar('No camera found.');
       });
       return const Text('None');
     } else {
-      for (final CameraDescription cameraDescription in _cameras) {
+      for (final CameraDescription cameraDescription in cameras) {
         toggles.add(
           SizedBox(
             width: 90.0,
@@ -1016,35 +1014,31 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
   }
 
   void _showCameraException(CameraException e) {
-    _logError(e.code, e.description);
+    logError(e.code, e.description);
     showInSnackBar('Error: ${e.code}\n${e.description}');
   }
 }
 
-/// CameraApp is the Main Application.
 class CameraApp extends StatelessWidget {
-  /// Default Constructor
-  const CameraApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       home: CameraExampleHome(),
     );
   }
 }
 
-List<CameraDescription> _cameras = <CameraDescription>[];
+List<CameraDescription> cameras = <CameraDescription>[];
 
 Future<void> main() async {
   // Fetch the available cameras before initializing the app.
   try {
     WidgetsFlutterBinding.ensureInitialized();
-    _cameras = await availableCameras();
+    cameras = await availableCameras();
   } on CameraException catch (e) {
-    _logError(e.code, e.description);
+    logError(e.code, e.description);
   }
-  runApp(const CameraApp());
+  runApp(CameraApp());
 }
 
 /// This allows a value of type T or T? to be treated as a value of type T?.

--- a/packages/camera/camera/example/lib/readme_full_example.dart
+++ b/packages/camera/camera/example/lib/readme_full_example.dart
@@ -2,26 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 // #docregion FullAppExample
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 
-late List<CameraDescription> _cameras;
+late List<CameraDescription> cameras;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  _cameras = await availableCameras();
-  runApp(const CameraApp());
+  cameras = await availableCameras();
+  runApp(CameraApp());
 }
 
-/// CameraApp is the Main Application.
 class CameraApp extends StatefulWidget {
-  /// Default Constructor
-  const CameraApp({Key? key}) : super(key: key);
-
   @override
-  State<CameraApp> createState() => _CameraAppState();
+  _CameraAppState createState() => _CameraAppState();
 }
 
 class _CameraAppState extends State<CameraApp> {
@@ -30,7 +28,7 @@ class _CameraAppState extends State<CameraApp> {
   @override
   void initState() {
     super.initState();
-    controller = CameraController(_cameras[0], ResolutionPreset.max);
+    controller = CameraController(cameras[0], ResolutionPreset.max);
     controller.initialize().then((_) {
       if (!mounted) {
         return;

--- a/packages/camera/camera/example/test/main_test.dart
+++ b/packages/camera/camera/example/test/main_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   testWidgets('Test snackbar', (WidgetTester tester) async {
     WidgetsFlutterBinding.ensureInitialized();
-    await tester.pumpWidget(const CameraApp());
+    await tester.pumpWidget(CameraApp());
     await tester.pumpAndSettle();
     expect(find.byType(SnackBar), findsOneWidget);
   });

--- a/packages/camera/camera/lib/src/camera_preview.dart
+++ b/packages/camera/camera/lib/src/camera_preview.dart
@@ -10,8 +10,7 @@ import 'package:flutter/services.dart';
 /// A widget showing a live camera preview.
 class CameraPreview extends StatelessWidget {
   /// Creates a preview widget for the given camera controller.
-  const CameraPreview(this.controller, {Key? key, this.child})
-      : super(key: key);
+  const CameraPreview(this.controller, {this.child});
 
   /// The controller for the camera that the preview is shown for.
   final CameraController controller;

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.4+22
+version: 0.9.4+21
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.2.1+5
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.2.1+4
 
 * Migrates from `ui.hash*` to `Object.hash*`.

--- a/packages/camera/camera_web/example/lib/main.dart
+++ b/packages/camera/camera_web/example/lib/main.dart
@@ -4,13 +4,10 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(MyApp());
 
 /// App for testing
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const Directionality(

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.1+5
+version: 0.2.1+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.1.0+1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.1.0
 

--- a/packages/camera/camera_windows/example/lib/main.dart
+++ b/packages/camera/camera_windows/example/lib/main.dart
@@ -9,14 +9,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// Example app for Camera Windows plugin.
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   State<MyApp> createState() => _MyAppState();
 }

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -1,8 +1,8 @@
 name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
+version: 0.1.0
 repository: https://github.com/flutter/plugins/tree/master/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.1.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,13 +1,8 @@
-## 0.2.0+2
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.2.0+1
 
 * Adds OS version support information to README.
 * Updates `androidx.test.ext:junit` and `androidx.test.ext:truth` for
-  compatibility with updated Flutter template.
+  compatibilty with updated Flutter template.
 
 ## 0.2.0
 

--- a/packages/espresso/example/lib/main.dart
+++ b/packages/espresso/example/lib/main.dart
@@ -4,13 +4,10 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(MyApp());
 
 /// Example app for Espresso plugin.
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
@@ -48,7 +45,7 @@ class _MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<_MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<_MyHomePage> {

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -3,7 +3,7 @@ description: Java classes for testing Flutter apps using Espresso.
   Allows driving Flutter widgets from a native Espresso test.
 repository: https://github.com/flutter/plugins/tree/main/packages/espresso
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+espresso%22
-version: 0.2.0+2
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,9 +1,7 @@
-## 0.8.4+2
+## NEXT
 
 * Removes unnecessary imports.
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.8.4+1
 

--- a/packages/file_selector/file_selector/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector/example/lib/get_directory_page.dart
@@ -7,9 +7,6 @@ import 'package:flutter/material.dart';
 
 /// Screen that shows an example of getDirectoryPath
 class GetDirectoryPage extends StatelessWidget {
-  /// Default Constructor
-  const GetDirectoryPage({Key? key}) : super(key: key);
-
   Future<void> _getDirectoryPath(BuildContext context) async {
     const String confirmButtonText = 'Choose';
     final String? directoryPath = await getDirectoryPath(
@@ -53,7 +50,7 @@ class GetDirectoryPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog
 class TextDisplay extends StatelessWidget {
   /// Default Constructor
-  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+  const TextDisplay(this.directoryPath);
 
   /// Directory path
   final String directoryPath;

--- a/packages/file_selector/file_selector/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector/example/lib/home_page.dart
@@ -6,9 +6,6 @@ import 'package:flutter/material.dart';
 
 /// Home Page of the application
 class HomePage extends StatelessWidget {
-  /// Default Constructor
-  const HomePage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(

--- a/packages/file_selector/file_selector/example/lib/main.dart
+++ b/packages/file_selector/file_selector/example/lib/main.dart
@@ -11,14 +11,11 @@ import 'package:example/save_text_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// MyApp is the Main Application
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -27,14 +24,13 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const HomePage(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        '/open/image': (BuildContext context) => const OpenImagePage(),
-        '/open/images': (BuildContext context) =>
-            const OpenMultipleImagesPage(),
-        '/open/text': (BuildContext context) => const OpenTextPage(),
+        '/open/image': (BuildContext context) => OpenImagePage(),
+        '/open/images': (BuildContext context) => OpenMultipleImagesPage(),
+        '/open/text': (BuildContext context) => OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
-        '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/directory': (BuildContext context) => GetDirectoryPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -10,9 +10,6 @@ import 'package:flutter/material.dart';
 
 /// Screen that shows an example of openFiles
 class OpenImagePage extends StatelessWidget {
-  /// Default Constructor
-  const OpenImagePage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
@@ -62,8 +59,7 @@ class OpenImagePage extends StatelessWidget {
 /// Widget that displays a text file in a dialog
 class ImageDisplay extends StatelessWidget {
   /// Default Constructor
-  const ImageDisplay(this.fileName, this.filePath, {Key? key})
-      : super(key: key);
+  const ImageDisplay(this.fileName, this.filePath);
 
   /// Image's name
   final String fileName;

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -10,9 +10,6 @@ import 'package:flutter/material.dart';
 
 /// Screen that shows an example of openFiles
 class OpenMultipleImagesPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenMultipleImagesPage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
@@ -64,7 +61,7 @@ class OpenMultipleImagesPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog
 class MultipleImagesDisplay extends StatelessWidget {
   /// Default Constructor
-  const MultipleImagesDisplay(this.files, {Key? key}) : super(key: key);
+  const MultipleImagesDisplay(this.files);
 
   /// The files containing the images
   final List<XFile> files;

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -7,9 +7,6 @@ import 'package:flutter/material.dart';
 
 /// Screen that shows an example of openFile
 class OpenTextPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenTextPage({Key? key}) : super(key: key);
-
   Future<void> _openTextFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
@@ -58,8 +55,7 @@ class OpenTextPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog
 class TextDisplay extends StatelessWidget {
   /// Default Constructor
-  const TextDisplay(this.fileName, this.fileContent, {Key? key})
-      : super(key: key);
+  const TextDisplay(this.fileName, this.fileContent);
 
   /// File's name
   final String fileName;

--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -8,9 +8,6 @@ import 'package:flutter/material.dart';
 
 /// Page for showing an example of saving with file_selector
 class SaveTextPage extends StatelessWidget {
-  /// Default Constructor
-  SaveTextPage({Key? key}) : super(key: key);
-
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _contentController = TextEditingController();
 

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.4+2
+version: 0.8.4+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.8.2+1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.8.2
 

--- a/packages/file_selector/file_selector_macos/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_directory_page.dart
@@ -8,9 +8,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a directory using `getDirectoryPath`,
 /// then displays the selected directory in a dialog.
 class GetDirectoryPage extends StatelessWidget {
-  /// Default Constructor
-  const GetDirectoryPage({Key? key}) : super(key: key);
-
   Future<void> _getDirectoryPath(BuildContext context) async {
     const String confirmButtonText = 'Choose';
     final String? directoryPath =
@@ -55,7 +52,7 @@ class GetDirectoryPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
   /// Creates a `TextDisplay`.
-  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+  const TextDisplay(this.directoryPath);
 
   /// The path selected in the dialog.
   final String directoryPath;

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -6,9 +6,6 @@ import 'package:flutter/material.dart';
 
 /// Home Page of the application.
 class HomePage extends StatelessWidget {
-  /// Default Constructor
-  const HomePage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(

--- a/packages/file_selector/file_selector_macos/example/lib/main.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/main.dart
@@ -11,14 +11,11 @@ import 'package:example/save_text_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// MyApp is the Main Application.
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -27,14 +24,13 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const HomePage(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        '/open/image': (BuildContext context) => const OpenImagePage(),
-        '/open/images': (BuildContext context) =>
-            const OpenMultipleImagesPage(),
-        '/open/text': (BuildContext context) => const OpenTextPage(),
+        '/open/image': (BuildContext context) => OpenImagePage(),
+        '/open/images': (BuildContext context) => OpenMultipleImagesPage(),
+        '/open/text': (BuildContext context) => OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
-        '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/directory': (BuildContext context) => GetDirectoryPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
@@ -11,9 +11,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select an image file using
 /// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenImagePage extends StatelessWidget {
-  /// Default Constructor
-  const OpenImagePage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
@@ -62,8 +59,7 @@ class OpenImagePage extends StatelessWidget {
 /// Widget that displays an image in a dialog.
 class ImageDisplay extends StatelessWidget {
   /// Default Constructor.
-  const ImageDisplay(this.fileName, this.filePath, {Key? key})
-      : super(key: key);
+  const ImageDisplay(this.fileName, this.filePath);
 
   /// The name of the selected file.
   final String fileName;

--- a/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
@@ -11,9 +11,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select multiple image files using
 /// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenMultipleImagesPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenMultipleImagesPage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
@@ -66,7 +63,7 @@ class OpenMultipleImagesPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class MultipleImagesDisplay extends StatelessWidget {
   /// Default Constructor.
-  const MultipleImagesDisplay(this.files, {Key? key}) : super(key: key);
+  const MultipleImagesDisplay(this.files);
 
   /// The files containing the images.
   final List<XFile> files;

--- a/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
@@ -8,9 +8,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a text file using `openFile`, then
 /// displays its contents in a dialog.
 class OpenTextPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenTextPage({Key? key}) : super(key: key);
-
   Future<void> _openTextFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
@@ -59,8 +56,7 @@ class OpenTextPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
   /// Default Constructor.
-  const TextDisplay(this.fileName, this.fileContent, {Key? key})
-      : super(key: key);
+  const TextDisplay(this.fileName, this.fileContent);
 
   /// The name of the selected file.
   final String fileName;

--- a/packages/file_selector/file_selector_macos/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/save_text_page.dart
@@ -9,9 +9,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a save location using `getSavePath`,
 /// then writes text to a file at that location.
 class SaveTextPage extends StatelessWidget {
-  /// Default Constructor
-  SaveTextPage({Key? key}) : super(key: key);
-
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _contentController = TextEditingController();
 
@@ -70,8 +67,8 @@ class SaveTextPage extends StatelessWidget {
                 primary: Colors.blue,
                 onPrimary: Colors.white,
               ),
-              onPressed: _saveFile,
               child: const Text('Press to save a text file'),
+              onPressed: _saveFile,
             ),
           ],
         ),

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.2+1
+version: 0.8.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.0.5
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.4
 

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.5
+version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.8.1+4
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.8.1+3
 
 * Minor code cleanup for new analysis rules.

--- a/packages/file_selector/file_selector_web/example/lib/main.dart
+++ b/packages/file_selector/file_selector_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_web
 description: Web platform implementation of file_selector
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.1+4
+version: 0.8.1+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_windows/CHANGELOG.md
+++ b/packages/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.8.2+1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.8.2
 

--- a/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
@@ -8,9 +8,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a directory using `getDirectoryPath`,
 ///  then displays the selected directory in a dialog.
 class GetDirectoryPage extends StatelessWidget {
-  /// Default Constructor
-  const GetDirectoryPage({Key? key}) : super(key: key);
-
   Future<void> _getDirectoryPath(BuildContext context) async {
     const String confirmButtonText = 'Choose';
     final String? directoryPath =
@@ -55,7 +52,7 @@ class GetDirectoryPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
   /// Creates a `TextDisplay`.
-  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+  const TextDisplay(this.directoryPath);
 
   /// The path selected in the dialog.
   final String directoryPath;

--- a/packages/file_selector/file_selector_windows/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/home_page.dart
@@ -6,9 +6,6 @@ import 'package:flutter/material.dart';
 
 /// Home Page of the application.
 class HomePage extends StatelessWidget {
-  /// Default Constructor
-  const HomePage({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(

--- a/packages/file_selector/file_selector_windows/example/lib/main.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/main.dart
@@ -11,14 +11,11 @@ import 'package:example/save_text_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// MyApp is the Main Application.
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -27,14 +24,13 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: const HomePage(),
+      home: HomePage(),
       routes: <String, WidgetBuilder>{
-        '/open/image': (BuildContext context) => const OpenImagePage(),
-        '/open/images': (BuildContext context) =>
-            const OpenMultipleImagesPage(),
-        '/open/text': (BuildContext context) => const OpenTextPage(),
+        '/open/image': (BuildContext context) => OpenImagePage(),
+        '/open/images': (BuildContext context) => OpenMultipleImagesPage(),
+        '/open/text': (BuildContext context) => OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
-        '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/directory': (BuildContext context) => GetDirectoryPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
@@ -11,9 +11,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select an image file using
 /// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenImagePage extends StatelessWidget {
-  /// Default Constructor
-  const OpenImagePage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
@@ -62,8 +59,7 @@ class OpenImagePage extends StatelessWidget {
 /// Widget that displays an image in a dialog.
 class ImageDisplay extends StatelessWidget {
   /// Default Constructor.
-  const ImageDisplay(this.fileName, this.filePath, {Key? key})
-      : super(key: key);
+  const ImageDisplay(this.fileName, this.filePath);
 
   /// The name of the selected file.
   final String fileName;

--- a/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
@@ -11,9 +11,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select multiple image files using
 /// `openFiles`, then displays the selected images in a gallery dialog.
 class OpenMultipleImagesPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenMultipleImagesPage({Key? key}) : super(key: key);
-
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
@@ -66,7 +63,7 @@ class OpenMultipleImagesPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class MultipleImagesDisplay extends StatelessWidget {
   /// Default Constructor.
-  const MultipleImagesDisplay(this.files, {Key? key}) : super(key: key);
+  const MultipleImagesDisplay(this.files);
 
   /// The files containing the images.
   final List<XFile> files;

--- a/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
@@ -8,9 +8,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a text file using `openFile`, then
 /// displays its contents in a dialog.
 class OpenTextPage extends StatelessWidget {
-  /// Default Constructor
-  const OpenTextPage({Key? key}) : super(key: key);
-
   Future<void> _openTextFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
@@ -59,8 +56,7 @@ class OpenTextPage extends StatelessWidget {
 /// Widget that displays a text file in a dialog.
 class TextDisplay extends StatelessWidget {
   /// Default Constructor.
-  const TextDisplay(this.fileName, this.fileContent, {Key? key})
-      : super(key: key);
+  const TextDisplay(this.fileName, this.fileContent);
 
   /// The name of the selected file.
   final String fileName;

--- a/packages/file_selector/file_selector_windows/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/save_text_page.dart
@@ -9,9 +9,6 @@ import 'package:flutter/material.dart';
 /// Screen that allows the user to select a save location using `getSavePath`,
 /// then writes text to a file at that location.
 class SaveTextPage extends StatelessWidget {
-  /// Default Constructor
-  SaveTextPage({Key? key}) : super(key: key);
-
   final TextEditingController _nameController = TextEditingController();
   final TextEditingController _contentController = TextEditingController();
 
@@ -70,8 +67,8 @@ class SaveTextPage extends StatelessWidget {
                 primary: Colors.blue,
                 onPrimary: Colors.white,
               ),
-              onPressed: _saveFile,
               child: const Text('Press to save a text file'),
+              onPressed: _saveFile,
             ),
           ],
         ),

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_windows
 description: Windows implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/file_selector/file_selector_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.2+1
+version: 0.8.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.0.6
+## NEXT
 
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.5
 

--- a/packages/flutter_plugin_android_lifecycle/example/integration_test/flutter_plugin_android_lifecycle_test.dart
+++ b/packages/flutter_plugin_android_lifecycle/example/integration_test/flutter_plugin_android_lifecycle_test.dart
@@ -10,6 +10,6 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('loads', (WidgetTester tester) async {
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
   });
 }

--- a/packages/flutter_plugin_android_lifecycle/example/lib/main.dart
+++ b/packages/flutter_plugin_android_lifecycle/example/lib/main.dart
@@ -2,15 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(MyApp());
 
-/// MyApp is the Main Application.
 class MyApp extends StatelessWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_plugin_android_lifecycle
 description: Flutter plugin for accessing an Android Lifecycle within other plugins.
 repository: https://github.com/flutter/plugins/tree/main/packages/flutter_plugin_android_lifecycle
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+flutter_plugin_android_lifecycle%22
-version: 2.0.6
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.1.5
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.1.4
 
@@ -225,7 +223,7 @@ GoogleMapController is now uniformly driven by implementing `DefaultLifecycleObs
 
 ## 0.5.26+1
 
-* Removes an erroneously added method from the GoogleMapController.h header file.
+* Removes a errorneously added method from the GoogleMapController.h header file.
 
 ## 0.5.26
 

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/animate_camera.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class AnimateCameraPage extends GoogleMapExampleAppPage {
-  const AnimateCameraPage({Key? key})
-      : super(const Icon(Icons.map), 'Camera control, animated', key: key);
+  const AnimateCameraPage()
+      : super(const Icon(Icons.map), 'Camera control, animated');
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class AnimateCameraPage extends GoogleMapExampleAppPage {
 }
 
 class AnimateCamera extends StatefulWidget {
-  const AnimateCamera({Key? key}) : super(key: key);
+  const AnimateCamera();
   @override
   State createState() => AnimateCameraState();
 }

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/lite_mode.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/lite_mode.dart
@@ -12,8 +12,7 @@ const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
 class LiteModePage extends GoogleMapExampleAppPage {
-  const LiteModePage({Key? key})
-      : super(const Icon(Icons.map), 'Lite mode', key: key);
+  const LiteModePage() : super(const Icon(Icons.map), 'Lite mode');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: public_member_api_docs
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -41,11 +43,7 @@ final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
   const TileOverlayPage(),
 ];
 
-/// MapsDemo is the Main Application.
 class MapsDemo extends StatelessWidget {
-  /// Default Constructor
-  const MapsDemo({Key? key}) : super(key: key);
-
   void _pushPage(BuildContext context, GoogleMapExampleAppPage page) {
     Navigator.of(context).push(MaterialPageRoute<void>(
         builder: (_) => Scaffold(
@@ -74,5 +72,5 @@ void main() {
   if (defaultTargetPlatform == TargetPlatform.android) {
     AndroidGoogleMapsFlutter.useAndroidViewSurface = true;
   }
-  runApp(const MaterialApp(home: MapsDemo()));
+  runApp(MaterialApp(home: MapsDemo()));
 }

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -12,8 +12,7 @@ const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
 class MapClickPage extends GoogleMapExampleAppPage {
-  const MapClickPage({Key? key})
-      : super(const Icon(Icons.mouse), 'Map click', key: key);
+  const MapClickPage() : super(const Icon(Icons.mouse), 'Map click');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_coordinates.dart
@@ -12,8 +12,7 @@ const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
 class MapCoordinatesPage extends GoogleMapExampleAppPage {
-  const MapCoordinatesPage({Key? key})
-      : super(const Icon(Icons.map), 'Map coordinates', key: key);
+  const MapCoordinatesPage() : super(const Icon(Icons.map), 'Map coordinates');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
@@ -16,8 +16,7 @@ final LatLngBounds sydneyBounds = LatLngBounds(
 );
 
 class MapUiPage extends GoogleMapExampleAppPage {
-  const MapUiPage({Key? key})
-      : super(const Icon(Icons.map), 'User interface', key: key);
+  const MapUiPage() : super(const Icon(Icons.map), 'User interface');
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +25,7 @@ class MapUiPage extends GoogleMapExampleAppPage {
 }
 
 class MapUiBody extends StatefulWidget {
-  const MapUiBody({Key? key}) : super(key: key);
+  const MapUiBody();
 
   @override
   State<StatefulWidget> createState() => MapUiBodyState();

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/marker_icons.dart
@@ -11,8 +11,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class MarkerIconsPage extends GoogleMapExampleAppPage {
-  const MarkerIconsPage({Key? key})
-      : super(const Icon(Icons.image), 'Marker icons', key: key);
+  const MarkerIconsPage() : super(const Icon(Icons.image), 'Marker icons');
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +20,7 @@ class MarkerIconsPage extends GoogleMapExampleAppPage {
 }
 
 class MarkerIconsBody extends StatefulWidget {
-  const MarkerIconsBody({Key? key}) : super(key: key);
+  const MarkerIconsBody();
 
   @override
   State<StatefulWidget> createState() => MarkerIconsBodyState();

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/move_camera.dart
@@ -10,8 +10,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class MoveCameraPage extends GoogleMapExampleAppPage {
-  const MoveCameraPage({Key? key})
-      : super(const Icon(Icons.map), 'Camera control', key: key);
+  const MoveCameraPage() : super(const Icon(Icons.map), 'Camera control');
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +19,7 @@ class MoveCameraPage extends GoogleMapExampleAppPage {
 }
 
 class MoveCamera extends StatefulWidget {
-  const MoveCamera({Key? key}) : super(key: key);
+  const MoveCamera();
   @override
   State createState() => MoveCameraState();
 }

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -9,8 +9,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PaddingPage extends GoogleMapExampleAppPage {
-  const PaddingPage({Key? key})
-      : super(const Icon(Icons.map), 'Add padding to the map', key: key);
+  const PaddingPage() : super(const Icon(Icons.map), 'Add padding to the map');
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +18,7 @@ class PaddingPage extends GoogleMapExampleAppPage {
 }
 
 class MarkerIconsBody extends StatefulWidget {
-  const MarkerIconsBody({Key? key}) : super(key: key);
+  const MarkerIconsBody();
 
   @override
   State<StatefulWidget> createState() => MarkerIconsBodyState();

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/page.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/page.dart
@@ -7,8 +7,7 @@
 import 'package:flutter/material.dart';
 
 abstract class GoogleMapExampleAppPage extends StatelessWidget {
-  const GoogleMapExampleAppPage(this.leading, this.title, {Key? key})
-      : super(key: key);
+  const GoogleMapExampleAppPage(this.leading, this.title);
 
   final Widget leading;
   final String title;

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_circle.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlaceCirclePage extends GoogleMapExampleAppPage {
-  const PlaceCirclePage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place circle', key: key);
+  const PlaceCirclePage()
+      : super(const Icon(Icons.linear_scale), 'Place circle');
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class PlaceCirclePage extends GoogleMapExampleAppPage {
 }
 
 class PlaceCircleBody extends StatefulWidget {
-  const PlaceCircleBody({Key? key}) : super(key: key);
+  const PlaceCircleBody();
 
   @override
   State<StatefulWidget> createState() => PlaceCircleBodyState();
@@ -170,42 +170,42 @@ class PlaceCircleBodyState extends State<PlaceCircleBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed: _add,
                           child: const Text('add'),
+                          onPressed: _add,
                         ),
                         TextButton(
+                          child: const Text('remove'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _remove(selectedId),
-                          child: const Text('remove'),
                         ),
                         TextButton(
+                          child: const Text('toggle visible'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _toggleVisible(selectedId),
-                          child: const Text('toggle visible'),
                         ),
                       ],
                     ),
                     Column(
                       children: <Widget>[
                         TextButton(
+                          child: const Text('change stroke width'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeStrokeWidth(selectedId),
-                          child: const Text('change stroke width'),
                         ),
                         TextButton(
+                          child: const Text('change stroke color'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeStrokeColor(selectedId),
-                          child: const Text('change stroke color'),
                         ),
                         TextButton(
+                          child: const Text('change fill color'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeFillColor(selectedId),
-                          child: const Text('change fill color'),
                         ),
                       ],
                     )

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -15,8 +15,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlaceMarkerPage extends GoogleMapExampleAppPage {
-  const PlaceMarkerPage({Key? key})
-      : super(const Icon(Icons.place), 'Place marker', key: key);
+  const PlaceMarkerPage() : super(const Icon(Icons.place), 'Place marker');
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +24,7 @@ class PlaceMarkerPage extends GoogleMapExampleAppPage {
 }
 
 class PlaceMarkerBody extends StatefulWidget {
-  const PlaceMarkerBody({Key? key}) : super(key: key);
+  const PlaceMarkerBody();
 
   @override
   State<StatefulWidget> createState() => PlaceMarkerBodyState();
@@ -309,13 +308,13 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: <Widget>[
               TextButton(
-                onPressed: _add,
                 child: const Text('Add'),
+                onPressed: _add,
               ),
               TextButton(
+                child: const Text('Remove'),
                 onPressed:
                     selectedId == null ? null : () => _remove(selectedId),
-                child: const Text('Remove'),
               ),
             ],
           ),
@@ -323,61 +322,62 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
             alignment: WrapAlignment.spaceEvenly,
             children: <Widget>[
               TextButton(
+                child: const Text('change info'),
                 onPressed:
                     selectedId == null ? null : () => _changeInfo(selectedId),
-                child: const Text('change info'),
               ),
               TextButton(
+                child: const Text('change info anchor'),
                 onPressed: selectedId == null
                     ? null
                     : () => _changeInfoAnchor(selectedId),
-                child: const Text('change info anchor'),
               ),
               TextButton(
+                child: const Text('change alpha'),
                 onPressed:
                     selectedId == null ? null : () => _changeAlpha(selectedId),
-                child: const Text('change alpha'),
               ),
               TextButton(
+                child: const Text('change anchor'),
                 onPressed:
                     selectedId == null ? null : () => _changeAnchor(selectedId),
-                child: const Text('change anchor'),
               ),
               TextButton(
+                child: const Text('toggle draggable'),
                 onPressed: selectedId == null
                     ? null
                     : () => _toggleDraggable(selectedId),
-                child: const Text('toggle draggable'),
               ),
               TextButton(
+                child: const Text('toggle flat'),
                 onPressed:
                     selectedId == null ? null : () => _toggleFlat(selectedId),
-                child: const Text('toggle flat'),
               ),
               TextButton(
+                child: const Text('change position'),
                 onPressed: selectedId == null
                     ? null
                     : () => _changePosition(selectedId),
-                child: const Text('change position'),
               ),
               TextButton(
+                child: const Text('change rotation'),
                 onPressed: selectedId == null
                     ? null
                     : () => _changeRotation(selectedId),
-                child: const Text('change rotation'),
               ),
               TextButton(
+                child: const Text('toggle visible'),
                 onPressed: selectedId == null
                     ? null
                     : () => _toggleVisible(selectedId),
-                child: const Text('toggle visible'),
               ),
               TextButton(
+                child: const Text('change zIndex'),
                 onPressed:
                     selectedId == null ? null : () => _changeZIndex(selectedId),
-                child: const Text('change zIndex'),
               ),
               TextButton(
+                child: const Text('set marker icon'),
                 onPressed: selectedId == null
                     ? null
                     : () {
@@ -387,7 +387,6 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
                           },
                         );
                       },
-                child: const Text('set marker icon'),
               ),
             ],
           ),

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polygon.dart
@@ -10,8 +10,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlacePolygonPage extends GoogleMapExampleAppPage {
-  const PlacePolygonPage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place polygon', key: key);
+  const PlacePolygonPage()
+      : super(const Icon(Icons.linear_scale), 'Place polygon');
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +20,7 @@ class PlacePolygonPage extends GoogleMapExampleAppPage {
 }
 
 class PlacePolygonBody extends StatefulWidget {
-  const PlacePolygonBody({Key? key}) : super(key: key);
+  const PlacePolygonBody();
 
   @override
   State<StatefulWidget> createState() => PlacePolygonBodyState();
@@ -196,64 +196,64 @@ class PlacePolygonBodyState extends State<PlacePolygonBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed: _add,
                           child: const Text('add'),
+                          onPressed: _add,
                         ),
                         TextButton(
+                          child: const Text('remove'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _remove(selectedId),
-                          child: const Text('remove'),
                         ),
                         TextButton(
+                          child: const Text('toggle visible'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _toggleVisible(selectedId),
-                          child: const Text('toggle visible'),
                         ),
                         TextButton(
+                          child: const Text('toggle geodesic'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _toggleGeodesic(selectedId),
-                          child: const Text('toggle geodesic'),
                         ),
                       ],
                     ),
                     Column(
                       children: <Widget>[
                         TextButton(
+                          child: const Text('add holes'),
                           onPressed: (selectedId == null)
                               ? null
                               : ((polygons[selectedId]!.holes.isNotEmpty)
                                   ? null
                                   : () => _addHoles(selectedId)),
-                          child: const Text('add holes'),
                         ),
                         TextButton(
+                          child: const Text('remove holes'),
                           onPressed: (selectedId == null)
                               ? null
                               : ((polygons[selectedId]!.holes.isEmpty)
                                   ? null
                                   : () => _removeHoles(selectedId)),
-                          child: const Text('remove holes'),
                         ),
                         TextButton(
+                          child: const Text('change stroke width'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeWidth(selectedId),
-                          child: const Text('change stroke width'),
                         ),
                         TextButton(
+                          child: const Text('change stroke color'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeStrokeColor(selectedId),
-                          child: const Text('change stroke color'),
                         ),
                         TextButton(
+                          child: const Text('change fill color'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeFillColor(selectedId),
-                          child: const Text('change fill color'),
                         ),
                       ],
                     )

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_polyline.dart
@@ -11,8 +11,8 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class PlacePolylinePage extends GoogleMapExampleAppPage {
-  const PlacePolylinePage({Key? key})
-      : super(const Icon(Icons.linear_scale), 'Place polyline', key: key);
+  const PlacePolylinePage()
+      : super(const Icon(Icons.linear_scale), 'Place polyline');
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +21,7 @@ class PlacePolylinePage extends GoogleMapExampleAppPage {
 }
 
 class PlacePolylineBody extends StatefulWidget {
-  const PlacePolylineBody({Key? key}) : super(key: key);
+  const PlacePolylineBody();
 
   @override
   State<StatefulWidget> createState() => PlacePolylineBodyState();
@@ -234,66 +234,66 @@ class PlacePolylineBodyState extends State<PlacePolylineBody> {
                     Column(
                       children: <Widget>[
                         TextButton(
-                          onPressed: _add,
                           child: const Text('add'),
+                          onPressed: _add,
                         ),
                         TextButton(
+                          child: const Text('remove'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _remove(selectedId),
-                          child: const Text('remove'),
                         ),
                         TextButton(
+                          child: const Text('toggle visible'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _toggleVisible(selectedId),
-                          child: const Text('toggle visible'),
                         ),
                         TextButton(
+                          child: const Text('toggle geodesic'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _toggleGeodesic(selectedId),
-                          child: const Text('toggle geodesic'),
                         ),
                       ],
                     ),
                     Column(
                       children: <Widget>[
                         TextButton(
+                          child: const Text('change width'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeWidth(selectedId),
-                          child: const Text('change width'),
                         ),
                         TextButton(
+                          child: const Text('change color'),
                           onPressed: (selectedId == null)
                               ? null
                               : () => _changeColor(selectedId),
-                          child: const Text('change color'),
                         ),
                         TextButton(
+                          child: const Text('change start cap [Android only]'),
                           onPressed: isIOS || (selectedId == null)
                               ? null
                               : () => _changeStartCap(selectedId),
-                          child: const Text('change start cap [Android only]'),
                         ),
                         TextButton(
+                          child: const Text('change end cap [Android only]'),
                           onPressed: isIOS || (selectedId == null)
                               ? null
                               : () => _changeEndCap(selectedId),
-                          child: const Text('change end cap [Android only]'),
                         ),
                         TextButton(
+                          child: const Text('change joint type [Android only]'),
                           onPressed: isIOS || (selectedId == null)
                               ? null
                               : () => _changeJointType(selectedId),
-                          child: const Text('change joint type [Android only]'),
                         ),
                         TextButton(
+                          child: const Text('change pattern [Android only]'),
                           onPressed: isIOS || (selectedId == null)
                               ? null
                               : () => _changePattern(selectedId),
-                          child: const Text('change pattern [Android only]'),
                         ),
                       ],
                     )

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/scrolling_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/scrolling_map.dart
@@ -14,8 +14,7 @@ import 'page.dart';
 const LatLng _center = LatLng(32.080664, 34.9563837);
 
 class ScrollingMapPage extends GoogleMapExampleAppPage {
-  const ScrollingMapPage({Key? key})
-      : super(const Icon(Icons.map), 'Scrolling map', key: key);
+  const ScrollingMapPage() : super(const Icon(Icons.map), 'Scrolling map');
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +23,7 @@ class ScrollingMapPage extends GoogleMapExampleAppPage {
 }
 
 class ScrollingMapBody extends StatelessWidget {
-  const ScrollingMapBody({Key? key}) : super(key: key);
+  const ScrollingMapBody();
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/snapshot.dart
@@ -15,9 +15,8 @@ const CameraPosition _kInitialPosition =
     CameraPosition(target: LatLng(-33.852, 151.211), zoom: 11.0);
 
 class SnapshotPage extends GoogleMapExampleAppPage {
-  const SnapshotPage({Key? key})
-      : super(const Icon(Icons.camera_alt), 'Take a snapshot of the map',
-            key: key);
+  const SnapshotPage()
+      : super(const Icon(Icons.camera_alt), 'Take a snapshot of the map');
 
   @override
   Widget build(BuildContext context) {

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
@@ -13,8 +13,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'page.dart';
 
 class TileOverlayPage extends GoogleMapExampleAppPage {
-  const TileOverlayPage({Key? key})
-      : super(const Icon(Icons.map), 'Tile overlay', key: key);
+  const TileOverlayPage() : super(const Icon(Icons.map), 'Tile overlay');
 
   @override
   Widget build(BuildContext context) {
@@ -23,7 +22,7 @@ class TileOverlayPage extends GoogleMapExampleAppPage {
 }
 
 class TileOverlayBody extends StatefulWidget {
-  const TileOverlayBody({Key? key}) : super(key: key);
+  const TileOverlayBody();
 
   @override
   State<StatefulWidget> createState() => TileOverlayBodyState();
@@ -91,16 +90,16 @@ class TileOverlayBodyState extends State<TileOverlayBody> {
           ),
         ),
         TextButton(
-          onPressed: _addTileOverlay,
           child: const Text('Add tile overlay'),
+          onPressed: _addTileOverlay,
         ),
         TextButton(
-          onPressed: _removeTileOverlay,
           child: const Text('Remove tile overlay'),
+          onPressed: _removeTileOverlay,
         ),
         TextButton(
-          onPressed: _clearTileCache,
           child: const Text('Clear tile cache'),
+          onPressed: _clearTileCache,
         ),
       ],
     );

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/controller.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: library_private_types_in_public_api
-
 part of google_maps_flutter;
 
 /// Controller for a single GoogleMap instance running on the host platform.

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.1.5
+version: 2.1.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.3.2+2
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.3.2+1
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/lib/main.dart
@@ -11,7 +11,7 @@ void main() {
 /// App for testing
 class MyApp extends StatefulWidget {
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.3.2+2
+version: 0.3.2+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 5.3.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 5.3.0
 
 * Moves Android and iOS implementations to federated packages.

--- a/packages/google_sign_in/google_sign_in/example/lib/main.dart
+++ b/packages/google_sign_in/google_sign_in/example/lib/main.dart
@@ -22,7 +22,7 @@ GoogleSignIn _googleSignIn = GoogleSignIn(
 
 void main() {
   runApp(
-    const MaterialApp(
+    MaterialApp(
       title: 'Google Sign In',
       home: SignInDemo(),
     ),
@@ -30,8 +30,6 @@ void main() {
 }
 
 class SignInDemo extends StatefulWidget {
-  const SignInDemo({Key? key}) : super(key: key);
-
   @override
   State createState() => SignInDemoState();
 }
@@ -127,8 +125,8 @@ class SignInDemoState extends State<SignInDemo> {
           const Text('Signed in successfully.'),
           Text(_contactText),
           ElevatedButton(
-            onPressed: _handleSignOut,
             child: const Text('SIGN OUT'),
+            onPressed: _handleSignOut,
           ),
           ElevatedButton(
             child: const Text('REFRESH'),
@@ -142,8 +140,8 @@ class SignInDemoState extends State<SignInDemo> {
         children: <Widget>[
           const Text('You are not currently signed in.'),
           ElevatedButton(
-            onPressed: _handleSignIn,
             child: const Text('SIGN IN'),
+            onPressed: _handleSignIn,
           ),
         ],
       );

--- a/packages/google_sign_in/google_sign_in/lib/widgets.dart
+++ b/packages/google_sign_in/google_sign_in/lib/widgets.dart
@@ -22,13 +22,11 @@ class GoogleUserCircleAvatar extends StatelessWidget {
   /// in place of a profile photo, or a default profile photo if the user's
   /// identity does not specify a `displayName`.
   const GoogleUserCircleAvatar({
-    Key? key,
     required this.identity,
     this.placeholderPhotoUrl,
     this.foregroundColor,
     this.backgroundColor,
-  })  : assert(identity != null),
-        super(key: key);
+  }) : assert(identity != null);
 
   /// A regular expression that matches against the "size directive" path
   /// segment of Google profile image URLs.

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.3.1
+version: 5.3.0
 
 
 environment:

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 5.2.7
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 5.2.6
 
 * Switches to an internal method channel, rather than the default.

--- a/packages/google_sign_in/google_sign_in_android/example/lib/main.dart
+++ b/packages/google_sign_in/google_sign_in_android/example/lib/main.dart
@@ -14,7 +14,7 @@ import 'package:http/http.dart' as http;
 
 void main() {
   runApp(
-    const MaterialApp(
+    MaterialApp(
       title: 'Google Sign In',
       home: SignInDemo(),
     ),
@@ -22,8 +22,6 @@ void main() {
 }
 
 class SignInDemo extends StatefulWidget {
-  const SignInDemo({Key? key}) : super(key: key);
-
   @override
   State createState() => SignInDemoState();
 }
@@ -144,8 +142,8 @@ class SignInDemoState extends State<SignInDemo> {
           const Text('Signed in successfully.'),
           Text(_contactText),
           ElevatedButton(
-            onPressed: _handleSignOut,
             child: const Text('SIGN OUT'),
+            onPressed: _handleSignOut,
           ),
           ElevatedButton(
             child: const Text('REFRESH'),
@@ -159,8 +157,8 @@ class SignInDemoState extends State<SignInDemo> {
         children: <Widget>[
           const Text('You are not currently signed in.'),
           ElevatedButton(
-            onPressed: _handleSignIn,
             child: const Text('SIGN IN'),
+            onPressed: _handleSignIn,
           ),
         ],
       );

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.2.7
+version: 5.2.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 5.2.7
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 5.2.6
 
 * Switches to an internal method channel, rather than the default.

--- a/packages/google_sign_in/google_sign_in_ios/example/lib/main.dart
+++ b/packages/google_sign_in/google_sign_in_ios/example/lib/main.dart
@@ -14,7 +14,7 @@ import 'package:http/http.dart' as http;
 
 void main() {
   runApp(
-    const MaterialApp(
+    MaterialApp(
       title: 'Google Sign In',
       home: SignInDemo(),
     ),
@@ -22,8 +22,6 @@ void main() {
 }
 
 class SignInDemo extends StatefulWidget {
-  const SignInDemo({Key? key}) : super(key: key);
-
   @override
   State createState() => SignInDemoState();
 }
@@ -144,8 +142,8 @@ class SignInDemoState extends State<SignInDemo> {
           const Text('Signed in successfully.'),
           Text(_contactText),
           ElevatedButton(
-            onPressed: _handleSignOut,
             child: const Text('SIGN OUT'),
+            onPressed: _handleSignOut,
           ),
           ElevatedButton(
             child: const Text('REFRESH'),
@@ -159,8 +157,8 @@ class SignInDemoState extends State<SignInDemo> {
         children: <Widget>[
           const Text('You are not currently signed in.'),
           ElevatedButton(
-            onPressed: _handleSignIn,
             child: const Text('SIGN IN'),
+            onPressed: _handleSignIn,
           ),
         ],
       );

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_ios
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.2.7
+version: 5.2.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.10.1+1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.10.1
 
 * Updates minimum Flutter version to 2.8.

--- a/packages/google_sign_in/google_sign_in_web/example/lib/main.dart
+++ b/packages/google_sign_in/google_sign_in_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Sign-In, a secure authentication system
   for signing in with a Google account on Android, iOS and Web.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 0.10.1+1
+version: 0.10.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.8.5+1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.8.5
 
 * Moves Android and iOS implementations to federated packages.

--- a/packages/image_picker/image_picker/example/lib/main.dart
+++ b/packages/image_picker/image_picker/example/lib/main.dart
@@ -13,12 +13,10 @@ import 'package:image_picker/image_picker.dart';
 import 'package:video_player/video_player.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
@@ -34,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -179,22 +177,21 @@ class _MyHomePageState extends State<MyHomePage> {
     }
     if (_imageFileList != null) {
       return Semantics(
-        label: 'image_picker_example_picked_images',
-        child: ListView.builder(
-          key: UniqueKey(),
-          itemBuilder: (BuildContext context, int index) {
-            // Why network for web?
-            // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
-            return Semantics(
-              label: 'image_picker_example_picked_image',
-              child: kIsWeb
-                  ? Image.network(_imageFileList![index].path)
-                  : Image.file(File(_imageFileList![index].path)),
-            );
-          },
-          itemCount: _imageFileList!.length,
-        ),
-      );
+          child: ListView.builder(
+            key: UniqueKey(),
+            itemBuilder: (BuildContext context, int index) {
+              // Why network for web?
+              // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
+              return Semantics(
+                label: 'image_picker_example_picked_image',
+                child: kIsWeb
+                    ? Image.network(_imageFileList![index].path)
+                    : Image.file(File(_imageFileList![index].path)),
+              );
+            },
+            itemCount: _imageFileList!.length,
+          ),
+          label: 'image_picker_example_picked_images');
     } else if (_pickImageError != null) {
       return Text(
         'Pick image error: $_pickImageError',
@@ -420,7 +417,7 @@ typedef OnPickImageCallback = void Function(
     double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
-  const AspectRatioVideo(this.controller, {Key? key}) : super(key: key);
+  const AspectRatioVideo(this.controller);
 
   final VideoPlayerController? controller;
 

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for selecting images from the Android and iOS image
   library, and taking new pictures with the camera.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.5+1
+version: 0.8.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.8.4+12
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.8.4+11
 
 * Splits from `image_picker` as a federated implementation.

--- a/packages/image_picker/image_picker_android/example/lib/main.dart
+++ b/packages/image_picker/image_picker_android/example/lib/main.dart
@@ -13,12 +13,10 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
 import 'package:video_player/video_player.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
@@ -34,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -179,22 +177,21 @@ class _MyHomePageState extends State<MyHomePage> {
     }
     if (_imageFileList != null) {
       return Semantics(
-        label: 'image_picker_example_picked_images',
-        child: ListView.builder(
-          key: UniqueKey(),
-          itemBuilder: (BuildContext context, int index) {
-            // Why network for web?
-            // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
-            return Semantics(
-              label: 'image_picker_example_picked_image',
-              child: kIsWeb
-                  ? Image.network(_imageFileList![index].path)
-                  : Image.file(File(_imageFileList![index].path)),
-            );
-          },
-          itemCount: _imageFileList!.length,
-        ),
-      );
+          child: ListView.builder(
+            key: UniqueKey(),
+            itemBuilder: (BuildContext context, int index) {
+              // Why network for web?
+              // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
+              return Semantics(
+                label: 'image_picker_example_picked_image',
+                child: kIsWeb
+                    ? Image.network(_imageFileList![index].path)
+                    : Image.file(File(_imageFileList![index].path)),
+              );
+            },
+            itemCount: _imageFileList!.length,
+          ),
+          label: 'image_picker_example_picked_images');
     } else if (_pickImageError != null) {
       return Text(
         'Pick image error: $_pickImageError',
@@ -420,7 +417,7 @@ typedef OnPickImageCallback = void Function(
     double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
-  const AspectRatioVideo(this.controller, {Key? key}) : super(key: key);
+  const AspectRatioVideo(this.controller);
 
   final VideoPlayerController? controller;
 

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.4+12
+version: 0.8.4+11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.1.7
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.1.6
 
 * Internal code cleanup for stricter analysis options.

--- a/packages/image_picker/image_picker_for_web/example/lib/main.dart
+++ b/packages/image_picker/image_picker_for_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_for_web
 description: Web platform implementation of image_picker
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_for_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 2.1.7
+version: 2.1.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.8.5+1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.8.5
 

--- a/packages/image_picker/image_picker_ios/example/lib/main.dart
+++ b/packages/image_picker/image_picker_ios/example/lib/main.dart
@@ -13,12 +13,10 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
 import 'package:video_player/video_player.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
@@ -34,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -179,22 +177,21 @@ class _MyHomePageState extends State<MyHomePage> {
     }
     if (_imageFileList != null) {
       return Semantics(
-        label: 'image_picker_example_picked_images',
-        child: ListView.builder(
-          key: UniqueKey(),
-          itemBuilder: (BuildContext context, int index) {
-            // Why network for web?
-            // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
-            return Semantics(
-              label: 'image_picker_example_picked_image',
-              child: kIsWeb
-                  ? Image.network(_imageFileList![index].path)
-                  : Image.file(File(_imageFileList![index].path)),
-            );
-          },
-          itemCount: _imageFileList!.length,
-        ),
-      );
+          child: ListView.builder(
+            key: UniqueKey(),
+            itemBuilder: (BuildContext context, int index) {
+              // Why network for web?
+              // See https://pub.dev/packages/image_picker#getting-ready-for-the-web-platform
+              return Semantics(
+                label: 'image_picker_example_picked_image',
+                child: kIsWeb
+                    ? Image.network(_imageFileList![index].path)
+                    : Image.file(File(_imageFileList![index].path)),
+              );
+            },
+            itemCount: _imageFileList!.length,
+          ),
+          label: 'image_picker_example_picked_images');
     } else if (_pickImageError != null) {
       return Text(
         'Pick image error: $_pickImageError',
@@ -420,7 +417,7 @@ typedef OnPickImageCallback = void Function(
     double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
-  const AspectRatioVideo(this.controller, {Key? key}) : super(key: key);
+  const AspectRatioVideo(this.controller);
 
   final VideoPlayerController? controller;
 

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the video_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.5+1
+version: 0.8.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/image_picker/image_picker_windows/CHANGELOG.md
+++ b/packages/image_picker/image_picker_windows/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.1.0+1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.1.0
 

--- a/packages/image_picker/image_picker_windows/example/lib/main.dart
+++ b/packages/image_picker/image_picker_windows/example/lib/main.dart
@@ -12,12 +12,10 @@ import 'package:image_picker_platform_interface/image_picker_platform_interface.
 import 'package:video_player/video_player.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
@@ -33,7 +31,7 @@ class MyHomePage extends StatefulWidget {
   final String? title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -178,18 +176,17 @@ class _MyHomePageState extends State<MyHomePage> {
     }
     if (_imageFileList != null) {
       return Semantics(
-        label: 'image_picker_example_picked_images',
-        child: ListView.builder(
-          key: UniqueKey(),
-          itemBuilder: (BuildContext context, int index) {
-            return Semantics(
-              label: 'image_picker_example_picked_image',
-              child: Image.file(File(_imageFileList![index].path)),
-            );
-          },
-          itemCount: _imageFileList!.length,
-        ),
-      );
+          child: ListView.builder(
+            key: UniqueKey(),
+            itemBuilder: (BuildContext context, int index) {
+              return Semantics(
+                label: 'image_picker_example_picked_image',
+                child: Image.file(File(_imageFileList![index].path)),
+              );
+            },
+            itemCount: _imageFileList!.length,
+          ),
+          label: 'image_picker_example_picked_images');
     } else if (_pickImageError != null) {
       return Text(
         'Pick image error: $_pickImageError',
@@ -366,7 +363,7 @@ typedef OnPickImageCallback = void Function(
     double? maxWidth, double? maxHeight, int? quality);
 
 class AspectRatioVideo extends StatefulWidget {
-  const AspectRatioVideo(this.controller, {Key? key}) : super(key: key);
+  const AspectRatioVideo(this.controller);
 
   final VideoPlayerController? controller;
 

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_windows
 description: Windows platform implementation of image_picker
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.1.0+1
+version: 0.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,9 +1,7 @@
-## 3.0.3
+## NEXT
 
 * Removes unnecessary imports.
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 3.0.2
 

--- a/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
@@ -33,7 +33,7 @@ const List<String> _kProductIds = <String>[
 
 class _MyApp extends StatefulWidget {
   @override
-  State<_MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<_MyApp> {
@@ -247,61 +247,60 @@ class _MyAppState extends State<_MyApp> {
       (ProductDetails productDetails) {
         final PurchaseDetails? previousPurchase = purchases[productDetails.id];
         return ListTile(
-          title: Text(
-            productDetails.title,
-          ),
-          subtitle: Text(
-            productDetails.description,
-          ),
-          trailing: previousPurchase != null
-              ? IconButton(
-                  onPressed: () => confirmPriceChange(context),
-                  icon: const Icon(Icons.upgrade))
-              : TextButton(
-                  style: TextButton.styleFrom(
-                    backgroundColor: Colors.green[800],
-                    primary: Colors.white,
-                  ),
-                  onPressed: () {
-                    late PurchaseParam purchaseParam;
+            title: Text(
+              productDetails.title,
+            ),
+            subtitle: Text(
+              productDetails.description,
+            ),
+            trailing: previousPurchase != null
+                ? IconButton(
+                    onPressed: () => confirmPriceChange(context),
+                    icon: const Icon(Icons.upgrade))
+                : TextButton(
+                    child: Text(productDetails.price),
+                    style: TextButton.styleFrom(
+                      backgroundColor: Colors.green[800],
+                      primary: Colors.white,
+                    ),
+                    onPressed: () {
+                      late PurchaseParam purchaseParam;
 
-                    if (Platform.isAndroid) {
-                      // NOTE: If you are making a subscription purchase/upgrade/downgrade, we recommend you to
-                      // verify the latest status of you your subscription by using server side receipt validation
-                      // and update the UI accordingly. The subscription purchase status shown
-                      // inside the app may not be accurate.
-                      final GooglePlayPurchaseDetails? oldSubscription =
-                          _getOldSubscription(productDetails, purchases);
+                      if (Platform.isAndroid) {
+                        // NOTE: If you are making a subscription purchase/upgrade/downgrade, we recommend you to
+                        // verify the latest status of you your subscription by using server side receipt validation
+                        // and update the UI accordingly. The subscription purchase status shown
+                        // inside the app may not be accurate.
+                        final GooglePlayPurchaseDetails? oldSubscription =
+                            _getOldSubscription(productDetails, purchases);
 
-                      purchaseParam = GooglePlayPurchaseParam(
+                        purchaseParam = GooglePlayPurchaseParam(
+                            productDetails: productDetails,
+                            applicationUserName: null,
+                            changeSubscriptionParam: (oldSubscription != null)
+                                ? ChangeSubscriptionParam(
+                                    oldPurchaseDetails: oldSubscription,
+                                    prorationMode: ProrationMode
+                                        .immediateWithTimeProration,
+                                  )
+                                : null);
+                      } else {
+                        purchaseParam = PurchaseParam(
                           productDetails: productDetails,
                           applicationUserName: null,
-                          changeSubscriptionParam: (oldSubscription != null)
-                              ? ChangeSubscriptionParam(
-                                  oldPurchaseDetails: oldSubscription,
-                                  prorationMode:
-                                      ProrationMode.immediateWithTimeProration,
-                                )
-                              : null);
-                    } else {
-                      purchaseParam = PurchaseParam(
-                        productDetails: productDetails,
-                        applicationUserName: null,
-                      );
-                    }
+                        );
+                      }
 
-                    if (productDetails.id == _kConsumableId) {
-                      _inAppPurchase.buyConsumable(
-                          purchaseParam: purchaseParam,
-                          autoConsume: _kAutoConsume || Platform.isIOS);
-                    } else {
-                      _inAppPurchase.buyNonConsumable(
-                          purchaseParam: purchaseParam);
-                    }
-                  },
-                  child: Text(productDetails.price),
-                ),
-        );
+                      if (productDetails.id == _kConsumableId) {
+                        _inAppPurchase.buyConsumable(
+                            purchaseParam: purchaseParam,
+                            autoConsume: _kAutoConsume || Platform.isIOS);
+                      } else {
+                        _inAppPurchase.buyNonConsumable(
+                            purchaseParam: purchaseParam);
+                      }
+                    },
+                  ));
       },
     ));
 
@@ -341,9 +340,9 @@ class _MyAppState extends State<_MyApp> {
       const Divider(),
       GridView.count(
         crossAxisCount: 5,
+        children: tokens,
         shrinkWrap: true,
         padding: const EdgeInsets.all(16.0),
-        children: tokens,
       )
     ]));
   }
@@ -360,12 +359,12 @@ class _MyAppState extends State<_MyApp> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
           TextButton(
+            child: const Text('Restore purchases'),
             style: TextButton.styleFrom(
               backgroundColor: Theme.of(context).primaryColor,
               primary: Colors.white,
             ),
             onPressed: () => _inAppPurchase.restorePurchases(),
-            child: const Text('Restore purchases'),
           ),
         ],
       ),

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.0.3
+version: 3.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.2.2+4
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.2.2+3
 

--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -37,7 +37,7 @@ const List<String> _kProductIds = <String>[
 
 class _MyApp extends StatefulWidget {
   @override
-  State<_MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<_MyApp> {
@@ -264,6 +264,7 @@ class _MyAppState extends State<_MyApp> {
                     },
                     icon: const Icon(Icons.upgrade))
                 : TextButton(
+                    child: Text(productDetails.price),
                     style: TextButton.styleFrom(
                       backgroundColor: Colors.green[800],
                       primary: Colors.white,
@@ -296,7 +297,6 @@ class _MyAppState extends State<_MyApp> {
                             purchaseParam: purchaseParam);
                       }
                     },
-                    child: Text(productDetails.price),
                   ));
       },
     ));
@@ -337,9 +337,9 @@ class _MyAppState extends State<_MyApp> {
       const Divider(),
       GridView.count(
         crossAxisCount: 5,
+        children: tokens,
         shrinkWrap: true,
         padding: const EdgeInsets.all(16.0),
-        children: tokens,
       )
     ]));
   }

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.2+4
+version: 0.2.2+3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.3.0+6
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.3.0+5
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -37,7 +37,7 @@ const List<String> _kProductIds = <String>[
 
 class _MyApp extends StatefulWidget {
   @override
-  State<_MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<_MyApp> {
@@ -259,6 +259,7 @@ class _MyAppState extends State<_MyApp> {
                     },
                     icon: const Icon(Icons.upgrade))
                 : TextButton(
+                    child: Text(productDetails.price),
                     style: TextButton.styleFrom(
                       backgroundColor: Colors.green[800],
                       primary: Colors.white,
@@ -277,7 +278,6 @@ class _MyAppState extends State<_MyApp> {
                             purchaseParam: purchaseParam);
                       }
                     },
-                    child: Text(productDetails.price),
                   ));
       },
     ));
@@ -318,9 +318,9 @@ class _MyAppState extends State<_MyApp> {
       const Divider(),
       GridView.count(
         crossAxisCount: 5,
+        children: tokens,
         shrinkWrap: true,
         padding: const EdgeInsets.all(16.0),
-        children: tokens,
       )
     ]));
   }
@@ -337,12 +337,12 @@ class _MyAppState extends State<_MyApp> {
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
           TextButton(
+            child: const Text('Restore purchases'),
             style: TextButton.styleFrom(
               backgroundColor: Theme.of(context).primaryColor,
               primary: Colors.white,
             ),
             onPressed: () => _iapStoreKitPlatform.restorePurchases(),
-            child: const Text('Restore purchases'),
           ),
         ],
       ),

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.0+6
+version: 0.3.0+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 0.2.0+6
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.2.0+5
 

--- a/packages/ios_platform_images/example/lib/main.dart
+++ b/packages/ios_platform_images/example/lib/main.dart
@@ -5,15 +5,12 @@
 import 'package:flutter/material.dart';
 import 'package:ios_platform_images/ios_platform_images.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(MyApp());
 
 /// Main widget for the example app.
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/ios_platform_images/example/test/widget_test.dart
+++ b/packages/ios_platform_images/example/test/widget_test.dart
@@ -12,7 +12,7 @@ import 'package:ios_platform_images_example/main.dart';
 void main() {
   testWidgets('Verify loads image', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(MyApp());
 
     expect(
       find.byWidgetPredicate(

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
 repository: https://github.com/flutter/plugins/tree/main/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.0+6
+version: 0.2.0+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -4,8 +4,6 @@
 * Updates README to match API changes in 2.0, and to improve clarity in
   general.
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.0
 

--- a/packages/local_auth/local_auth/example/lib/main.dart
+++ b/packages/local_auth/local_auth/example/lib/main.dart
@@ -11,14 +11,12 @@ import 'package:flutter/services.dart';
 import 'package:local_auth/local_auth.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -171,14 +169,14 @@ class _MyAppState extends State<MyApp> {
                 const Divider(height: 100),
                 Text('Can check biometrics: $_canCheckBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _checkBiometrics,
                   child: const Text('Check biometrics'),
+                  onPressed: _checkBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Available biometrics: $_availableBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _getAvailableBiometrics,
                   child: const Text('Get available biometrics'),
+                  onPressed: _getAvailableBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Current State: $_authorized\n'),
@@ -197,7 +195,6 @@ class _MyAppState extends State<MyApp> {
                   Column(
                     children: <Widget>[
                       ElevatedButton(
-                        onPressed: _authenticate,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[
@@ -205,9 +202,9 @@ class _MyAppState extends State<MyApp> {
                             Icon(Icons.perm_device_information),
                           ],
                         ),
+                        onPressed: _authenticate,
                       ),
                       ElevatedButton(
-                        onPressed: _authenticateWithBiometrics,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[
@@ -217,6 +214,7 @@ class _MyAppState extends State<MyApp> {
                             const Icon(Icons.fingerprint),
                           ],
                         ),
+                        onPressed: _authenticateWithBiometrics,
                       ),
                     ],
                   ),

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 1.0.3
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 1.0.2
 

--- a/packages/local_auth/local_auth_android/example/lib/main.dart
+++ b/packages/local_auth/local_auth_android/example/lib/main.dart
@@ -12,14 +12,12 @@ import 'package:local_auth_android/local_auth_android.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -176,14 +174,14 @@ class _MyAppState extends State<MyApp> {
                 Text(
                     'Device supports biometrics: $_deviceSupportsBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _checkBiometrics,
                   child: const Text('Check biometrics'),
+                  onPressed: _checkBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Enrolled biometrics: $_enrolledBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _getEnrolledBiometrics,
                   child: const Text('Get enrolled biometrics'),
+                  onPressed: _getEnrolledBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Current State: $_authorized\n'),
@@ -202,7 +200,6 @@ class _MyAppState extends State<MyApp> {
                   Column(
                     children: <Widget>[
                       ElevatedButton(
-                        onPressed: _authenticate,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[
@@ -210,9 +207,9 @@ class _MyAppState extends State<MyApp> {
                             Icon(Icons.perm_device_information),
                           ],
                         ),
+                        onPressed: _authenticate,
                       ),
                       ElevatedButton(
-                        onPressed: _authenticateWithBiometrics,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[
@@ -222,6 +219,7 @@ class _MyAppState extends State<MyApp> {
                             const Icon(Icons.fingerprint),
                           ],
                         ),
+                        onPressed: _authenticateWithBiometrics,
                       ),
                     ],
                   ),

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.3
+version: 1.0.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 1.0.5
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 1.0.4
 

--- a/packages/local_auth/local_auth_ios/example/lib/main.dart
+++ b/packages/local_auth/local_auth_ios/example/lib/main.dart
@@ -12,14 +12,12 @@ import 'package:local_auth_ios/local_auth_ios.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {
@@ -175,14 +173,14 @@ class _MyAppState extends State<MyApp> {
                 const Divider(height: 100),
                 Text('Device supports biometrics: $_canCheckBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _checkBiometrics,
                   child: const Text('Check biometrics'),
+                  onPressed: _checkBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Enrolled biometrics: $_enrolledBiometrics\n'),
                 ElevatedButton(
-                  onPressed: _getEnrolledBiometrics,
                   child: const Text('Get enrolled biometrics'),
+                  onPressed: _getEnrolledBiometrics,
                 ),
                 const Divider(height: 100),
                 Text('Current State: $_authorized\n'),
@@ -201,7 +199,6 @@ class _MyAppState extends State<MyApp> {
                   Column(
                     children: <Widget>[
                       ElevatedButton(
-                        onPressed: _authenticate,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[
@@ -209,9 +206,9 @@ class _MyAppState extends State<MyApp> {
                             Icon(Icons.perm_device_information),
                           ],
                         ),
+                        onPressed: _authenticate,
                       ),
                       ElevatedButton(
-                        onPressed: _authenticateWithBiometrics,
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: <Widget>[
@@ -221,6 +218,7 @@ class _MyAppState extends State<MyApp> {
                             const Icon(Icons.fingerprint),
                           ],
                         ),
+                        onPressed: _authenticateWithBiometrics,
                       ),
                     ],
                   ),

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_ios
 description: iOS implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/local_auth/local_auth_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.5
+version: 1.0.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,9 +1,7 @@
-## 2.0.10
+## NEXT
 
 * Removes unnecessary imports.
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.9
 

--- a/packages/path_provider/path_provider/example/lib/main.dart
+++ b/packages/path_provider/path_provider/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -33,7 +31,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -140,10 +138,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: _requestTempDirectory,
                     child: const Text(
                       'Get Temporary Directory',
                     ),
+                    onPressed: _requestTempDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(
@@ -157,10 +155,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: _requestAppDocumentsDirectory,
                     child: const Text(
                       'Get Application Documents Directory',
                     ),
+                    onPressed: _requestAppDocumentsDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(
@@ -174,10 +172,10 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: _requestAppSupportDirectory,
                     child: const Text(
                       'Get Application Support Directory',
                     ),
+                    onPressed: _requestAppSupportDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(
@@ -191,13 +189,13 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed:
-                        Platform.isAndroid ? null : _requestAppLibraryDirectory,
                     child: Text(
                       Platform.isAndroid
                           ? 'Application Library Directory unavailable'
                           : 'Get Application Library Directory',
                     ),
+                    onPressed:
+                        Platform.isAndroid ? null : _requestAppLibraryDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(
@@ -211,14 +209,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: !Platform.isAndroid
-                        ? null
-                        : _requestExternalStorageDirectory,
                     child: Text(
                       !Platform.isAndroid
                           ? 'External storage is unavailable'
                           : 'Get External Storage Directory',
                     ),
+                    onPressed: !Platform.isAndroid
+                        ? null
+                        : _requestExternalStorageDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(
@@ -232,6 +230,11 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
+                    child: Text(
+                      !Platform.isAndroid
+                          ? 'External directories are unavailable'
+                          : 'Get External Storage Directories',
+                    ),
                     onPressed: !Platform.isAndroid
                         ? null
                         : () {
@@ -239,11 +242,6 @@ class _MyHomePageState extends State<MyHomePage> {
                               StorageDirectory.music,
                             );
                           },
-                    child: Text(
-                      !Platform.isAndroid
-                          ? 'External directories are unavailable'
-                          : 'Get External Storage Directories',
-                    ),
                   ),
                 ),
                 FutureBuilder<List<Directory>?>(
@@ -257,14 +255,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: !Platform.isAndroid
-                        ? null
-                        : _requestExternalCacheDirectories,
                     child: Text(
                       !Platform.isAndroid
                           ? 'External directories are unavailable'
                           : 'Get External Cache Directories',
                     ),
+                    onPressed: !Platform.isAndroid
+                        ? null
+                        : _requestExternalCacheDirectories,
                   ),
                 ),
                 FutureBuilder<List<Directory>?>(
@@ -278,14 +276,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 Padding(
                   padding: const EdgeInsets.all(16.0),
                   child: ElevatedButton(
-                    onPressed: Platform.isAndroid || Platform.isIOS
-                        ? null
-                        : _requestDownloadsDirectory,
                     child: Text(
                       Platform.isAndroid || Platform.isIOS
                           ? 'Downloads directory is unavailable'
                           : 'Get Downloads Directory',
                     ),
+                    onPressed: Platform.isAndroid || Platform.isIOS
+                        ? null
+                        : _requestDownloadsDirectory,
                   ),
                 ),
                 FutureBuilder<Directory?>(

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider
 description: Flutter plugin for getting commonly used locations on host platform file systems, such as the temp and app data directories.
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.10
+version: 2.0.9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.14
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.13
 
 * Fixes typing build warning.

--- a/packages/path_provider/path_provider_android/example/lib/main.dart
+++ b/packages/path_provider/path_provider_android/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -31,7 +29,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -123,8 +121,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestTempDirectory,
                 child: const Text('Get Temporary Directory'),
+                onPressed: _requestTempDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -132,8 +130,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestAppDocumentsDirectory,
                 child: const Text('Get Application Documents Directory'),
+                onPressed: _requestAppDocumentsDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -141,8 +139,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestAppSupportDirectory,
                 child: const Text('Get Application Support Directory'),
+                onPressed: _requestAppSupportDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -150,8 +148,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestExternalStorageDirectory,
                 child: const Text('Get External Storage Directory'),
+                onPressed: _requestExternalStorageDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -176,8 +174,8 @@ class _MyHomePageState extends State<MyHomePage> {
               Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: ElevatedButton(
-                  onPressed: _requestExternalCacheDirectories,
                   child: const Text('Get External Cache Directories'),
+                  onPressed: _requestExternalCacheDirectories,
                 ),
               ),
             ]),

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_android
 description: Android implementation of the path_provider plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.14
+version: 2.0.13
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_ios/CHANGELOG.md
+++ b/packages/path_provider/path_provider_ios/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.9
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.8
 
 * Switches to a package-internal implementation of the platform interface.

--- a/packages/path_provider/path_provider_ios/example/lib/main.dart
+++ b/packages/path_provider/path_provider_ios/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -31,7 +29,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -92,8 +90,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestTempDirectory,
                 child: const Text('Get Temporary Directory'),
+                onPressed: _requestTempDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -101,8 +99,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestAppDocumentsDirectory,
                 child: const Text('Get Application Documents Directory'),
+                onPressed: _requestAppDocumentsDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -110,8 +108,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestAppSupportDirectory,
                 child: const Text('Get Application Support Directory'),
+                onPressed: _requestAppSupportDirectory,
               ),
             ),
             FutureBuilder<String?>(
@@ -119,8 +117,8 @@ class _MyHomePageState extends State<MyHomePage> {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: _requestAppLibraryDirectory,
                 child: const Text('Get Application Library Directory'),
+                onPressed: _requestAppLibraryDirectory,
               ),
             ),
             FutureBuilder<String?>(

--- a/packages/path_provider/path_provider_ios/pubspec.yaml
+++ b/packages/path_provider/path_provider_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_ios
 description: iOS implementation of the path_provider plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.9
+version: 2.0.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.1.6
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.1.5
 
 * Removes dependency on `meta`.

--- a/packages/path_provider/path_provider_linux/example/lib/main.dart
+++ b/packages/path_provider/path_provider_linux/example/lib/main.dart
@@ -7,16 +7,13 @@ import 'package:flutter/services.dart';
 import 'package:path_provider_linux/path_provider_linux.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// Sample app
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_linux
 description: Linux implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.6
+version: 2.1.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_macos/CHANGELOG.md
+++ b/packages/path_provider/path_provider_macos/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.6
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.5
 
 * Removes dependency on `meta`.

--- a/packages/path_provider/path_provider_macos/example/lib/main.dart
+++ b/packages/path_provider/path_provider_macos/example/lib/main.dart
@@ -8,15 +8,13 @@ import 'package:flutter/material.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// Sample app
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/path_provider/path_provider_macos/pubspec.yaml
+++ b/packages/path_provider/path_provider_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_macos
 description: macOS implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.6
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.6
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.5
 
 * Removes dependency on `meta`.

--- a/packages/path_provider/path_provider_windows/example/lib/main.dart
+++ b/packages/path_provider/path_provider_windows/example/lib/main.dart
@@ -8,15 +8,13 @@ import 'package:flutter/material.dart';
 import 'package:path_provider_windows/path_provider_windows.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// Sample app
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.0.6
+version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,10 +1,8 @@
-## 0.6.0+11
+## NEXT
 
 * Removes unnecessary imports.
 * Updates minimum Flutter version to 2.8.
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.6.0+10
 

--- a/packages/quick_actions/quick_actions/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:quick_actions/quick_actions.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -30,7 +28,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for creating shortcuts on home screen, also known as
   Quick Actions on iOS and App Shortcuts on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/quick_actions/quick_actions
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+quick_actions%22
-version: 0.6.0+11
+version: 0.6.0+10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 0.6.0+10
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 0.6.0+9
 
 * Switches to a package-internal implementation of the platform interface.

--- a/packages/quick_actions/quick_actions_android/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions_android/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:quick_actions_android/quick_actions_android.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -30,7 +28,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_android
 description: An implementation for the Android platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/quick_actions/quick_actions_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.6.0+10
+version: 0.6.0+9
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/packages/quick_actions/quick_actions_ios/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_ios/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.6.0+10
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.6.0+9
 

--- a/packages/quick_actions/quick_actions_ios/example/lib/main.dart
+++ b/packages/quick_actions/quick_actions_ios/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:quick_actions_ios/quick_actions_ios.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -30,7 +28,7 @@ class MyHomePage extends StatefulWidget {
   const MyHomePage({Key? key}) : super(key: key);
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/quick_actions/quick_actions_ios/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: quick_actions_ios
 description: An implementation for the iOS platform of the Flutter `quick_actions` plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/quick_actions/quick_actions_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.6.0+10
+version: 0.6.0+9
 
 environment:
   sdk: ">=2.15.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.0.14
+## NEXT
 
 * Adds OS version support information to README.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.13
 

--- a/packages/shared_preferences/shared_preferences/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.14
+version: 2.0.13
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.12
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.11
 
 * Switches to an in-package method channel implementation.

--- a/packages/shared_preferences/shared_preferences_android/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_android/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_android
 description: Android implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.12
+version: 2.0.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_ios/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.1.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.1.0
 
 * Upgrades to using Pigeon.

--- a/packages/shared_preferences/shared_preferences_ios/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_ios/example/lib/main.dart
@@ -8,12 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_ios
 description: iOS implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.1
+version: 2.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.1.1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.1.0
 

--- a/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_linux/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences_linux/shared_preferences_linux.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.1
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_macos/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.0.4
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.3
 

--- a/packages/shared_preferences/shared_preferences_macos/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_macos/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_macos
 description: macOS implementation of the shared_preferences plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.4
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.4
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.3
 
 * Fixes newly enabled analyzer options.

--- a/packages/shared_preferences/shared_preferences_web/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_web
 description: Web platform implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.4
+version: 2.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.1.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.1.0
 
 * Deprecated `SharedPreferencesWindows.instance` in favor of `SharedPreferencesStorePlatform.instance`.

--- a/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
+++ b/packages/shared_preferences/shared_preferences_windows/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences_windows/shared_preferences_windows.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.1
+version: 2.1.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 6.1.1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 6.1.0
 

--- a/packages/url_launcher/url_launcher/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher/example/lib/main.dart
@@ -11,12 +11,10 @@ import 'package:url_launcher/link.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -34,7 +32,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher/lib/src/link.dart
@@ -86,7 +86,7 @@ class Link extends StatelessWidget implements LinkInfo {
 /// event channel messages to instruct the framework to push the route name.
 class DefaultLinkDelegate extends StatelessWidget {
   /// Creates a delegate for the given [link].
-  const DefaultLinkDelegate(this.link, {Key? key}) : super(key: key);
+  const DefaultLinkDelegate(this.link);
 
   /// Given a [link], creates an instance of [DefaultLinkDelegate].
   ///

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.1.1
+version: 6.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 6.0.17
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 6.0.16
 
 * Adds fallback querying for `canLaunch` with web URLs, to avoid false negatives

--- a/packages/url_launcher/url_launcher_android/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_android/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -33,7 +31,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.17
+version: 6.0.16
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 6.0.16
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 6.0.15
 
 * Switches to an in-package method channel implementation.

--- a/packages/url_launcher/url_launcher_ios/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_ios/example/lib/main.dart
@@ -10,12 +10,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -33,7 +31,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_ios
 description: iOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.16
+version: 6.0.15
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 3.0.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 3.0.0
 
 * Changes the major version since, due to a typo in `default_package` in

--- a/packages/url_launcher/url_launcher_linux/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_linux/example/lib/main.dart
@@ -9,12 +9,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -32,7 +30,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_linux
 description: Linux implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.0.1
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 3.0.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 3.0.0
 
 * Changes the major version since, due to a typo in `default_package` in

--- a/packages/url_launcher/url_launcher_macos/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_macos/example/lib/main.dart
@@ -9,12 +9,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -32,7 +30,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_macos
 description: macOS implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.0.1
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 2.0.10
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 2.0.9
 
 - Fixes invalid routes when opening a `Link` in a new tab

--- a/packages/url_launcher/url_launcher_web/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -31,7 +31,7 @@ HtmlViewFactory get linkViewFactory => LinkViewController._viewFactory;
 /// It uses a platform view to render an anchor element in the DOM.
 class WebLinkDelegate extends StatefulWidget {
   /// Creates a delegate for the given [link].
-  const WebLinkDelegate(this.link, {Key? key}) : super(key: key);
+  const WebLinkDelegate(this.link);
 
   /// Information about the link built by the app.
   final LinkInfo link;

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.10
+version: 2.0.9
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 3.0.1
-
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
-
 ## 3.0.0
 
 * Changes the major version since, due to a typo in `default_package` in

--- a/packages/url_launcher/url_launcher_windows/example/lib/main.dart
+++ b/packages/url_launcher/url_launcher_windows/example/lib/main.dart
@@ -9,12 +9,10 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -32,7 +30,7 @@ class MyHomePage extends StatefulWidget {
   final String title;
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  _MyHomePageState createState() => _MyHomePageState();
 }
 
 class _MyHomePageState extends State<MyHomePage> {

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_windows
 description: Windows implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 3.0.1
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.4.1
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.4.0
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -708,14 +708,14 @@ class _VideoAppLifeCycleObserver extends Object with WidgetsBindingObserver {
 /// Widget that displays the video controlled by [controller].
 class VideoPlayer extends StatefulWidget {
   /// Uses the given [controller] for all video rendered in this widget.
-  const VideoPlayer(this.controller, {Key? key}) : super(key: key);
+  const VideoPlayer(this.controller);
 
   /// The [VideoPlayerController] responsible for the video being rendered in
   /// this widget.
   final VideoPlayerController controller;
 
   @override
-  State<VideoPlayer> createState() => _VideoPlayerState();
+  _VideoPlayerState createState() => _VideoPlayerState();
 }
 
 class _VideoPlayerState extends State<VideoPlayer> {
@@ -883,11 +883,10 @@ class VideoProgressIndicator extends StatefulWidget {
   /// to `top: 5.0`.
   const VideoProgressIndicator(
     this.controller, {
-    Key? key,
     this.colors = const VideoProgressColors(),
     required this.allowScrubbing,
     this.padding = const EdgeInsets.only(top: 5.0),
-  }) : super(key: key);
+  });
 
   /// The [VideoPlayerController] that actually associates a video with this
   /// widget.
@@ -911,7 +910,7 @@ class VideoProgressIndicator extends StatefulWidget {
   final EdgeInsets padding;
 
   @override
-  State<VideoProgressIndicator> createState() => _VideoProgressIndicatorState();
+  _VideoProgressIndicatorState createState() => _VideoProgressIndicatorState();
 }
 
 class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
@@ -985,8 +984,8 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
     );
     if (widget.allowScrubbing) {
       return _VideoScrubber(
-        controller: controller,
         child: paddedProgressIndicator,
+        controller: controller,
       );
     } else {
       return paddedProgressIndicator;

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.1
+version: 2.4.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.3.3
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.3.2
 

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -351,14 +351,14 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 /// Widget that displays the video controlled by [controller].
 class VideoPlayer extends StatefulWidget {
   /// Uses the given [controller] for all video rendered in this widget.
-  const VideoPlayer(this.controller, {Key? key}) : super(key: key);
+  const VideoPlayer(this.controller);
 
   /// The [MiniController] responsible for the video being rendered in
   /// this widget.
   final MiniController controller;
 
   @override
-  State<VideoPlayer> createState() => _VideoPlayerState();
+  _VideoPlayerState createState() => _VideoPlayerState();
 }
 
 class _VideoPlayerState extends State<VideoPlayer> {
@@ -450,14 +450,14 @@ class _VideoScrubberState extends State<_VideoScrubber> {
 class VideoProgressIndicator extends StatefulWidget {
   /// Construct an instance that displays the play/buffering status of the video
   /// controlled by [controller].
-  const VideoProgressIndicator(this.controller, {Key? key}) : super(key: key);
+  const VideoProgressIndicator(this.controller);
 
   /// The [MiniController] that actually associates a video with this
   /// widget.
   final MiniController controller;
 
   @override
-  State<VideoProgressIndicator> createState() => _VideoProgressIndicatorState();
+  _VideoProgressIndicatorState createState() => _VideoProgressIndicatorState();
 }
 
 class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
@@ -527,11 +527,11 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
       );
     }
     return _VideoScrubber(
-      controller: controller,
       child: Padding(
         padding: const EdgeInsets.only(top: 5.0),
         child: progressIndicator,
       ),
+      controller: controller,
     );
   }
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.3
+version: 2.3.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.3.4
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.3.3
 

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -351,14 +351,14 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
 /// Widget that displays the video controlled by [controller].
 class VideoPlayer extends StatefulWidget {
   /// Uses the given [controller] for all video rendered in this widget.
-  const VideoPlayer(this.controller, {Key? key}) : super(key: key);
+  const VideoPlayer(this.controller);
 
   /// The [MiniController] responsible for the video being rendered in
   /// this widget.
   final MiniController controller;
 
   @override
-  State<VideoPlayer> createState() => _VideoPlayerState();
+  _VideoPlayerState createState() => _VideoPlayerState();
 }
 
 class _VideoPlayerState extends State<VideoPlayer> {
@@ -450,14 +450,14 @@ class _VideoScrubberState extends State<_VideoScrubber> {
 class VideoProgressIndicator extends StatefulWidget {
   /// Construct an instance that displays the play/buffering status of the video
   /// controlled by [controller].
-  const VideoProgressIndicator(this.controller, {Key? key}) : super(key: key);
+  const VideoProgressIndicator(this.controller);
 
   /// The [MiniController] that actually associates a video with this
   /// widget.
   final MiniController controller;
 
   @override
-  State<VideoProgressIndicator> createState() => _VideoProgressIndicatorState();
+  _VideoProgressIndicatorState createState() => _VideoProgressIndicatorState();
 }
 
 class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
@@ -527,11 +527,11 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
       );
     }
     return _VideoScrubber(
-      controller: controller,
       child: Padding(
         padding: const EdgeInsets.only(top: 5.0),
         child: progressIndicator,
       ),
+      controller: controller,
     );
   }
 }

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/master/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.4
+version: 2.3.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.0.9
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.0.8
 

--- a/packages/video_player/video_player_web/example/lib/main.dart
+++ b/packages/video_player/video_player_web/example/lib/main.dart
@@ -5,16 +5,13 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(MyApp());
 }
 
 /// App for testing
 class MyApp extends StatefulWidget {
-  /// Default Constructor
-  const MyApp({Key? key}) : super(key: key);
-
   @override
-  State<MyApp> createState() => _MyAppState();
+  _MyAppState createState() => _MyAppState();
 }
 
 class _MyAppState extends State<MyApp> {

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.9
+version: 2.0.8
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 3.0.3
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 3.0.2
 
@@ -13,7 +11,7 @@
 
 * Removes a duplicate Android-specific integration test.
 * Fixes an integration test race condition.
-* Fixes comments (accidentally mixed // with ///).
+* Fixes comments (accidentially mixed // with ///).
 
 ## 3.0.0
 

--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -1306,8 +1306,7 @@ Future<String> _runJavascriptReturningResult(
 
 class ResizableWebView extends StatefulWidget {
   const ResizableWebView(
-      {Key? key, required this.onResize, required this.onPageFinished})
-      : super(key: key);
+      {required this.onResize, required this.onPageFinished});
 
   final JavascriptMessageHandler onResize;
   final VoidCallback onPageFinished;

--- a/packages/webview_flutter/webview_flutter/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter/example/lib/main.dart
@@ -71,12 +71,12 @@ const String kTransparentBackgroundPage = '''
 ''';
 
 class WebViewExample extends StatefulWidget {
-  const WebViewExample({Key? key, this.cookieManager}) : super(key: key);
+  const WebViewExample({this.cookieManager});
 
   final CookieManager? cookieManager;
 
   @override
-  State<WebViewExample> createState() => _WebViewExampleState();
+  _WebViewExampleState createState() => _WebViewExampleState();
 }
 
 class _WebViewExampleState extends State<WebViewExample> {
@@ -190,9 +190,8 @@ enum MenuOptions {
 }
 
 class SampleMenu extends StatelessWidget {
-  SampleMenu(this.controller, CookieManager? cookieManager, {Key? key})
-      : cookieManager = cookieManager ?? CookieManager(),
-        super(key: key);
+  SampleMenu(this.controller, CookieManager? cookieManager)
+      : cookieManager = cookieManager ?? CookieManager();
 
   final Future<WebViewController> controller;
   late final CookieManager cookieManager;
@@ -251,8 +250,8 @@ class SampleMenu extends StatelessWidget {
           itemBuilder: (BuildContext context) => <PopupMenuItem<MenuOptions>>[
             PopupMenuItem<MenuOptions>(
               value: MenuOptions.showUserAgent,
-              enabled: controller.hasData,
               child: const Text('Show user agent'),
+              enabled: controller.hasData,
             ),
             const PopupMenuItem<MenuOptions>(
               value: MenuOptions.listCookies,
@@ -444,9 +443,8 @@ class SampleMenu extends StatelessWidget {
 }
 
 class NavigationControls extends StatelessWidget {
-  const NavigationControls(this._webViewControllerFuture, {Key? key})
-      : assert(_webViewControllerFuture != null),
-        super(key: key);
+  const NavigationControls(this._webViewControllerFuture)
+      : assert(_webViewControllerFuture != null);
 
   final Future<WebViewController> _webViewControllerFuture;
 

--- a/packages/webview_flutter/webview_flutter/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter
 description: A Flutter plugin that provides a WebView widget on Android and iOS.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.0.3
+version: 3.0.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.8.7
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.8.6
 

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -1446,10 +1446,9 @@ Future<String> _runJavaScriptReturningResult(
 
 class ResizableWebView extends StatefulWidget {
   const ResizableWebView({
-    Key? key,
     required this.onResize,
     required this.onPageFinished,
-  }) : super(key: key);
+  });
 
   final JavascriptMessageHandler onResize;
   final VoidCallback onPageFinished;

--- a/packages/webview_flutter/webview_flutter_android/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/lib/main.dart
@@ -247,8 +247,8 @@ class _SampleMenu extends StatelessWidget {
           itemBuilder: (BuildContext context) => <PopupMenuItem<_MenuOptions>>[
             PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.showUserAgent,
-              enabled: controller.hasData,
               child: const Text('Show user agent'),
+              enabled: controller.hasData,
             ),
             const PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.listCookies,

--- a/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/lib/web_view.dart
@@ -250,7 +250,7 @@ class WebView extends StatefulWidget {
   final Color? backgroundColor;
 
   @override
-  State<WebView> createState() => _WebViewState();
+  _WebViewState createState() => _WebViewState();
 }
 
 class _WebViewState extends State<WebView> {

--- a/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/webview_android_widget.dart
@@ -15,7 +15,6 @@ import 'src/android_webview.dart' as android_webview;
 class WebViewAndroidWidget extends StatefulWidget {
   /// Constructs a [WebViewAndroidWidget].
   const WebViewAndroidWidget({
-    Key? key,
     required this.creationParams,
     required this.useHybridComposition,
     required this.callbacksHandler,
@@ -25,7 +24,7 @@ class WebViewAndroidWidget extends StatefulWidget {
     @visibleForTesting
         this.flutterAssetManager = const android_webview.FlutterAssetManager(),
     @visibleForTesting this.webStorage,
-  }) : super(key: key);
+  });
 
   /// Initial parameters used to setup the WebView.
   final CreationParams creationParams;

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.8.7
+version: 2.8.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,9 +1,7 @@
-## 0.1.0+2
+## NEXT
 
 * Removes unnecessary imports.
 * Fixes unit tests to run on latest `master` version of Flutter.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 0.1.0+1
 

--- a/packages/webview_flutter/webview_flutter_web/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_web/example/lib/web_view.dart
@@ -46,7 +46,7 @@ class WebView extends StatefulWidget {
   final String? initialUrl;
 
   @override
-  State<WebView> createState() => _WebViewState();
+  _WebViewState createState() => _WebViewState();
 }
 
 class _WebViewState extends State<WebView> {

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_web
 description: A Flutter plugin that provides a WebView widget on web.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 0.1.0+2
+version: 0.1.0+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,8 +1,6 @@
-## 2.7.4
+## NEXT
 
 * Removes unnecessary imports.
-* Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors
-  lint warnings.
 
 ## 2.7.3
 

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -1181,8 +1181,7 @@ Future<String> _getUserAgent(WebViewController controller) async {
 
 class ResizableWebView extends StatefulWidget {
   const ResizableWebView(
-      {Key? key, required this.onResize, required this.onPageFinished})
-      : super(key: key);
+      {required this.onResize, required this.onPageFinished});
 
   final JavascriptMessageHandler onResize;
   final VoidCallback onPageFinished;

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/lib/main.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/lib/main.dart
@@ -232,8 +232,8 @@ class _SampleMenu extends StatelessWidget {
           itemBuilder: (BuildContext context) => <PopupMenuItem<_MenuOptions>>[
             PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.showUserAgent,
-              enabled: controller.hasData,
               child: const Text('Show user agent'),
+              enabled: controller.hasData,
             ),
             const PopupMenuItem<_MenuOptions>(
               value: _MenuOptions.listCookies,

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/lib/web_view.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/lib/web_view.dart
@@ -240,7 +240,7 @@ class WebView extends StatefulWidget {
   final Color? backgroundColor;
 
   @override
-  State<WebView> createState() => _WebViewState();
+  _WebViewState createState() => _WebViewState();
 }
 
 class _WebViewState extends State<WebView> {

--- a/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/lib/src/web_kit_webview_widget.dart
@@ -18,14 +18,13 @@ import 'web_kit/web_kit.dart';
 class WebKitWebViewWidget extends StatefulWidget {
   /// Constructs a [WebKitWebViewWidget].
   const WebKitWebViewWidget({
-    Key? key,
     required this.creationParams,
     required this.callbacksHandler,
     required this.javascriptChannelRegistry,
     required this.onBuildWidget,
     this.configuration,
     @visibleForTesting this.webViewProxy = const WebViewWidgetProxy(),
-  }) : super(key: key);
+  });
 
   /// The initial parameters used to setup the WebView.
   final CreationParams creationParams;

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.7.4
+version: 2.7.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -322,7 +322,7 @@ and `firebase-test-lab`.
 
 ## v.0.0.36+2
 
-- Default to showing podspec lint warnings.
+- Default to showing podspec lint warnings
 
 ## v.0.0.36+1
 

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+- Fixes changelog validation when reverting to a `NEXT` state.
+
 ## 0.8.5
 
 - Updates `test` to inculde the Dart unit tests of examples, if any.

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -39,8 +39,11 @@ enum _CurrentVersionState {
   /// The version is unchanged.
   unchanged,
 
-  /// The version has changed, and the transition is valid.
-  validChange,
+  /// The version has increased, and the transition is valid.
+  validIncrease,
+
+  /// The version has decrease, and the transition is a valid revert.
+  validRevert,
 
   /// The version has changed, and the transition is invalid.
   invalidChange,
@@ -218,7 +221,8 @@ class VersionCheckCommand extends PackageLoopingCommand {
       case _CurrentVersionState.unchanged:
         versionChanged = false;
         break;
-      case _CurrentVersionState.validChange:
+      case _CurrentVersionState.validIncrease:
+      case _CurrentVersionState.validRevert:
         versionChanged = true;
         break;
       case _CurrentVersionState.invalidChange:
@@ -232,7 +236,7 @@ class VersionCheckCommand extends PackageLoopingCommand {
     }
 
     if (!(await _validateChangelogVersion(package,
-        pubspec: pubspec, pubspecVersionChanged: versionChanged))) {
+        pubspec: pubspec, pubspecVersionState: versionState))) {
       errors.add('CHANGELOG.md failed validation.');
     }
 
@@ -322,7 +326,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
           '${getBoolArg(_againstPubFlag) ? 'on pub server' : 'at git base'}.');
       logWarning(
           '${indentation}If this plugin is not new, something has gone wrong.');
-      return _CurrentVersionState.validChange; // Assume new, thus valid.
+      return _CurrentVersionState.validIncrease; // Assume new, thus valid.
     }
 
     if (previousVersion == currentVersion) {
@@ -340,7 +344,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       if (possibleVersionsFromNewVersion.containsKey(previousVersion)) {
         logWarning('${indentation}New version is lower than previous version. '
             'This is assumed to be a revert.');
-        return _CurrentVersionState.validChange;
+        return _CurrentVersionState.validRevert;
       }
     }
 
@@ -367,7 +371,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
       return _CurrentVersionState.invalidChange;
     }
 
-    return _CurrentVersionState.validChange;
+    return _CurrentVersionState.validIncrease;
   }
 
   /// Checks whether or not [package]'s CHANGELOG's versioning is correct,
@@ -378,7 +382,7 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
   Future<bool> _validateChangelogVersion(
     RepositoryPackage package, {
     required Pubspec pubspec,
-    required bool pubspecVersionChanged,
+    required _CurrentVersionState pubspecVersionState,
   }) async {
     // This method isn't called unless `version` is non-null.
     final Version fromPubspec = pubspec.version!;
@@ -405,8 +409,9 @@ ${indentation}HTTP response: ${pubVersionFinderResponse.httpResponse.body}
     // changes that don't warrant publishing on their own.
     final bool hasNextSection = versionString == 'NEXT';
     if (hasNextSection) {
-      // NEXT should not be present in a commit that changes the version.
-      if (pubspecVersionChanged) {
+      // NEXT should not be present in a commit that increases the version.
+      if (pubspecVersionState == _CurrentVersionState.validIncrease ||
+          pubspecVersionState == _CurrentVersionState.invalidChange) {
         printError(badNextErrorMessage);
         return false;
       }

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -319,14 +319,14 @@ String _pluginPlatformSection(
   return entry;
 }
 
-typedef ErrorHandler = void Function(Error error);
+typedef _ErrorHandler = void Function(Error error);
 
 /// Run the command [runner] with the given [args] and return
 /// what was printed.
 /// A custom [errorHandler] can be used to handle the runner error as desired without throwing.
 Future<List<String>> runCapturingPrint(
     CommandRunner<void> runner, List<String> args,
-    {ErrorHandler? errorHandler}) async {
+    {_ErrorHandler? errorHandler}) async {
   final List<String> prints = <String>[];
   final ZoneSpecification spec = ZoneSpecification(
     print: (_, __, ___, String message) {


### PR DESCRIPTION
Reverts flutter/plugins#5428

It interacted with another PR that landed at about the same time and broke the tree. Reverting to re-land with the fix, rather than fixing forward, because otherwise we'll have to manually release every one of these plugins.

This includes a fix for a latent bug in the `version-check` repo tooling command that caused it to fail when reverting a package that previously had a NEXT section, so that tests will pass.

No version change: The original PR was meant to have a version change, but it was lost in auto-merge.

Fixes https://github.com/flutter/plugins/pull/5691 and the red tree.