### PR TITLE
[tools] Fix `publish` flag calculation

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - Fixes changelog validation when reverting to a `NEXT` state.
+- Fixes multiplication of `--force` flag when publishing multiple packages.
 
 ## 0.8.5
 

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -192,7 +192,9 @@ abstract class PluginCommand extends Command<void> {
 
   /// Convenience accessor for List<String> arguments.
   List<String> getStringListArg(String key) {
-    return (argResults![key] as List<String>?) ?? <String>[];
+    // Clone the list so that if a caller modifies the result it won't change
+    // the actual arguments list for future queries.
+    return List<String>.from(argResults![key] as List<String>? ?? <String>[]);
   }
 
   /// If true, commands should log timing information that might be useful in

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -121,6 +121,8 @@ class PublishPluginCommand extends PackageLoopingCommand {
   List<String> _existingGitTags = <String>[];
   // The remote to push tags to.
   late _RemoteInfo _remote;
+  // Flags to pass to `pub publish`.
+  late List<String> _publishFlags;
 
   @override
   String get successSummaryMessage => 'published';
@@ -148,6 +150,11 @@ class PublishPluginCommand extends PackageLoopingCommand {
         await repository.runCommand(<String>['tag', '--sort=-committerdate']);
     _existingGitTags = (existingTagsResult.stdout as String).split('\n')
       ..removeWhere((String element) => element.isEmpty);
+
+    _publishFlags = <String>[
+      ...getStringListArg(_pubFlagsOption),
+      if (getBoolArg(_skipConfirmationFlag)) '--force',
+    ];
 
     if (getBoolArg(_dryRunFlag)) {
       print('=============== DRY RUN ===============');
@@ -333,22 +340,18 @@ Safe to ignore if the package is deleted in this commit.
 
   Future<bool> _publish(RepositoryPackage package) async {
     print('Publishing...');
-    final List<String> publishFlags = getStringListArg(_pubFlagsOption);
-    print('Running `pub publish ${publishFlags.join(' ')}` in '
+    print('Running `pub publish ${_publishFlags.join(' ')}` in '
         '${package.directory.absolute.path}...\n');
     if (getBoolArg(_dryRunFlag)) {
       return true;
     }
 
-    if (getBoolArg(_skipConfirmationFlag)) {
-      publishFlags.add('--force');
-    }
-    if (publishFlags.contains('--force')) {
+    if (_publishFlags.contains('--force')) {
       _ensureValidPubCredential();
     }
 
     final io.Process publish = await processRunner.start(
-        flutterCommand, <String>['pub', 'publish'] + publishFlags,
+        flutterCommand, <String>['pub', 'publish', ..._publishFlags],
         workingDirectory: package.directory);
     publish.stdout.transform(utf8.decoder).listen((String data) => print(data));
     publish.stderr.transform(utf8.decoder).listen((String data) => print(data));

--- a/script/tool/test/publish_plugin_command_test.dart
+++ b/script/tool/test/publish_plugin_command_test.dart
@@ -224,6 +224,35 @@ void main() {
               plugin.path)));
     });
 
+    test('--force is only added once, regardless of plugin count', () async {
+      _createMockCredentialFile();
+      final RepositoryPackage plugin1 =
+          createFakePlugin('plugin_a', packagesDir, examples: <String>[]);
+      final RepositoryPackage plugin2 =
+          createFakePlugin('plugin_b', packagesDir, examples: <String>[]);
+
+      await runCapturingPrint(commandRunner, <String>[
+        'publish-plugin',
+        '--packages=plugin_a,plugin_b',
+        '--skip-confirmation',
+        '--pub-publish-flags',
+        '--server=bar'
+      ]);
+
+      expect(
+          processRunner.recordedCalls,
+          containsAllInOrder(<ProcessCall>[
+            ProcessCall(
+                flutterCommand,
+                const <String>['pub', 'publish', '--server=bar', '--force'],
+                plugin1.path),
+            ProcessCall(
+                flutterCommand,
+                const <String>['pub', 'publish', '--server=bar', '--force'],
+                plugin2.path),
+          ]));
+    });
+
     test('throws if pub publish fails', () async {
       createFakePlugin('foo', packagesDir, examples: <String>[]);
 


### PR DESCRIPTION
Makes `getStringListArg` safer, by preventing accidental modification of
the arg parser results themselves. Also changes the way `publish` works
to determine the flags to pass once, rather than once per package, since
they don't change on each run.

Either fixes the accumulation of `--force` flags when publishing
multiple packages. The former is a general safety fix for the internal
utility API, and the latter is a minor cleanup that is no longer
necessary, but avoids pointless duplicate work.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
