### PR TITLE
Added ability to purchase multiple quantity of one product

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -68,10 +68,10 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
   Future<bool> isAvailable() => SKPaymentQueueWrapper.canMakePayments();
 
   @override
-  Future<bool> buyNonConsumable({required PurchaseParam purchaseParam}) async {
+  Future<bool> buyNonConsumable({required PurchaseParam purchaseParam, int quantity = 1}) async {
     await _skPaymentQueueWrapper.addPayment(SKPaymentWrapper(
         productIdentifier: purchaseParam.productDetails.id,
-        quantity: 1,
+        quantity: quantity,
         applicationUsername: purchaseParam.applicationUserName,
         simulatesAskToBuyInSandbox: purchaseParam is AppStorePurchaseParam &&
             purchaseParam.simulatesAskToBuyInSandbox,
@@ -82,9 +82,9 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
 
   @override
   Future<bool> buyConsumable(
-      {required PurchaseParam purchaseParam, bool autoConsume = true}) {
+      {required PurchaseParam purchaseParam, bool autoConsume = true, int quantity = 1}) {
     assert(autoConsume == true, 'On iOS, we should always auto consume');
-    return buyNonConsumable(purchaseParam: purchaseParam);
+    return buyNonConsumable(purchaseParam: purchaseParam, quantity = 1);
   }
 
   @override


### PR DESCRIPTION
I faced the following issue using the in_app_purchase_storekit plugin: I was not able to purchase multiple quantity of one product. 

To fix this I added quantity param to buyNonConsumable and buyConsumable methods and passed the value to _skPaymentQueueWrapper.addPayment() call inside the buyNonConsumable method.


