### PR TITLE
[ios_platform_images] Ignore ImageProvider.load deprecation.

### DIFF
--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0+7
+
+* Ignore deprecation of `load` method in [ImageProvider] so it can be
+  deprecated at the framework level, without breaking CI.
+
 ## 0.2.0+6
 
 * Removes unnecessary imports.

--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 0.2.0+7
 
-* Ignore deprecation of `load` method in [ImageProvider] so it can be
-  deprecated at the framework level, without breaking CI.
+* Ignores the warning for the upcoming deprecation of `ImageProvider.load`.
 
 ## 0.2.0+6
 

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -63,7 +63,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
   }
 
   /// See [ImageProvider.load].
-  // TODO(jmagman) Implement the new API once it lands, https://github.com/flutter/flutter/issues/103556
+  // TODO(jmagman): Implement the new API once it lands, https://github.com/flutter/flutter/issues/103556
   @override
   // ignore:deprecated_member_use
   ImageStreamCompleter load(_FutureMemoryImage key, DecoderCallback decode) {

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -64,6 +64,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
 
   /// See [ImageProvider.load].
   @override
+  // ignore:deprecated_member_use
   ImageStreamCompleter load(_FutureMemoryImage key, DecoderCallback decode) {
     return _FutureImageStreamCompleter(
       codec: _loadAsync(key, decode),

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -63,6 +63,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
   }
 
   /// See [ImageProvider.load].
+  // TODO(jmagman) Implement the new API once it lands, https://github.com/flutter/flutter/issues/103556
   @override
   // ignore:deprecated_member_use
   ImageStreamCompleter load(_FutureMemoryImage key, DecoderCallback decode) {

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
 repository: https://github.com/flutter/plugins/tree/main/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.0+6
+version: 0.2.0+7
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
We need to ignore this deprecation notice, that is incoming here:

* https://github.com/flutter/flutter/pull/103496

This PR ensures that the one above can be landed without breaking the `Linux flutter_plugins` check.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [~] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
