### PR TITLE
[ios_platform_images] Ignore ImageProvider.load deprecation

### DIFF
--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+8
+
+* Ignores the warning for the upcoming deprecation of `ImageProvider.load` in the correct line.
+
 ## 0.2.0+7
 
 * Ignores the warning for the upcoming deprecation of `ImageProvider.load`.

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -62,10 +62,10 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
     return SynchronousFuture<_FutureMemoryImage>(this);
   }
 
+  // ignore:deprecated_member_use
   /// See [ImageProvider.load].
   // TODO(jmagman): Implement the new API once it lands, https://github.com/flutter/flutter/issues/103556
   @override
-  // ignore:deprecated_member_use
   ImageStreamCompleter load(_FutureMemoryImage key, DecoderCallback decode) {
     return _FutureImageStreamCompleter(
       codec: _loadAsync(key, decode),

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
 repository: https://github.com/flutter/plugins/tree/main/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.0+7
+version: 0.2.0+8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
We need to ignore this deprecation notice, that is incoming here:

* https://github.com/flutter/flutter/pull/103496

[This PR](https://github.com/flutter/plugins/pull/5701) attempted to ensure that the one above could be landed without breaking the `Linux flutter_plugins` check, however it didn't because the problem was actually happening in a *documentation* line.

This PR moves the `// ignore` statement to the correct place that is triggering the problem. To verify this'd fix the issue, I used the `flutter` version from @jonahwilliams' branch.

### Testing:

```
dit@dit:~/github/plugins/packages/ios_platform_images$ flutter --version
Flutter 3.1.0-0.0.pre.691 • channel use_immutable_buffer • git@github.com:jonahwilliams/flutter.git
Framework • revision 7aa17dfc78 (89 minutes ago) • 2022-05-12 14:12:51 -0700
Engine • revision db84036d27
Tools • Dart 2.18.0 (build 2.18.0-106.0.dev) • DevTools 2.13.1

dit@dit:~/github/plugins/packages/ios_platform_images$ flutter analyze
Analyzing ios_platform_images...                                        
No issues found! (ran in 1.9s)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [~] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
