### PR TITLE
[ci/tools] Add iOS/macOS analysis to catch deprecated code

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -334,6 +334,11 @@ task:
         - ./script/tool_runner.sh build-examples --ios
       xcode_analyze_script:
         - ./script/tool_runner.sh xcode-analyze --ios
+      xcode_analyze_deprecation_script:
+        # Ensure we don't accidentally introduce deprecated code.
+        # TODO(stuartmorgan): Update this to a newer version of iOS to get
+        # ahead of upcoming deprecations.
+        - ./script/tool_runner.sh xcode-analyze --ios --ios-min-version=11.0
       native_test_script:
         - ./script/tool_runner.sh native-test --ios --ios-destination "platform=iOS Simulator,name=iPhone 11,OS=latest"
       drive_script:
@@ -362,6 +367,9 @@ task:
         - ./script/tool_runner.sh build-examples --macos
       xcode_analyze_script:
         - ./script/tool_runner.sh xcode-analyze --macos
+      xcode_analyze_deprecation_script:
+        # Ensure we don't accidentally introduce deprecated code.
+        - ./script/tool_runner.sh xcode-analyze --macos --macos-min-version=12.3
       native_test_script:
         - ./script/tool_runner.sh native-test --macos
       drive_script:

--- a/packages/google_sign_in/google_sign_in_ios/example/ios/Podfile
+++ b/packages/google_sign_in/google_sign_in_ios/example/ios/Podfile
@@ -25,6 +25,9 @@ end
 
 require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
 
+# Suppress warnings from transitive dependencies that cause analysis to fail.
+pod 'AppAuth', :inhibit_warnings => true
+
 flutter_ios_podfile_setup
 
 target 'Runner' do

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Fixes changelog validation when reverting to a `NEXT` state.
 - Fixes multiplication of `--force` flag when publishing multiple packages.
+- Adds minimum deployment target flags to `xcode-analyze` to allow
+  enforcing deprecation warning handling in advance of actually dropping
+  support for an OS version.
 
 ## 0.8.5
 

--- a/script/tool/test/xcode_analyze_command_test.dart
+++ b/script/tool/test/xcode_analyze_command_test.dart
@@ -123,6 +123,47 @@ void main() {
             ]));
       });
 
+      test('passes min iOS deployment version when requested', () async {
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
+            platformSupport: <String, PlatformDetails>{
+              platformIOS: const PlatformDetails(PlatformSupport.inline)
+            });
+
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+        final List<String> output = await runCapturingPrint(runner,
+            <String>['xcode-analyze', '--ios', '--ios-min-version=14.0']);
+
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for plugin'),
+              contains('plugin/example (iOS) passed analysis.')
+            ]));
+
+        expect(
+            processRunner.recordedCalls,
+            orderedEquals(<ProcessCall>[
+              ProcessCall(
+                  'xcrun',
+                  const <String>[
+                    'xcodebuild',
+                    'analyze',
+                    '-workspace',
+                    'ios/Runner.xcworkspace',
+                    '-scheme',
+                    'Runner',
+                    '-configuration',
+                    'Debug',
+                    '-destination',
+                    'generic/platform=iOS Simulator',
+                    'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
+                    'IOS_DEPLOYMENT_TARGET=14.0',
+                  ],
+                  pluginExampleDirectory.path),
+            ]));
+      });
+
       test('fails if xcrun fails', () async {
         createFakePlugin('plugin', packagesDir,
             platformSupport: <String, PlatformDetails>{
@@ -213,6 +254,41 @@ void main() {
                     '-configuration',
                     'Debug',
                     'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
+                  ],
+                  pluginExampleDirectory.path),
+            ]));
+      });
+
+      test('passes min macOS deployment version when requested', () async {
+        final RepositoryPackage plugin = createFakePlugin('plugin', packagesDir,
+            platformSupport: <String, PlatformDetails>{
+              platformMacOS: const PlatformDetails(PlatformSupport.inline),
+            });
+
+        final Directory pluginExampleDirectory = getExampleDir(plugin);
+
+        final List<String> output = await runCapturingPrint(runner,
+            <String>['xcode-analyze', '--macos', '--macos-min-version=12.0']);
+
+        expect(output,
+            contains(contains('plugin/example (macOS) passed analysis.')));
+
+        expect(
+            processRunner.recordedCalls,
+            orderedEquals(<ProcessCall>[
+              ProcessCall(
+                  'xcrun',
+                  const <String>[
+                    'xcodebuild',
+                    'analyze',
+                    '-workspace',
+                    'macos/Runner.xcworkspace',
+                    '-scheme',
+                    'Runner',
+                    '-configuration',
+                    'Debug',
+                    'GCC_TREAT_WARNINGS_AS_ERRORS=YES',
+                    'MACOSX_DEPLOYMENT_VERSION=12.0',
                   ],
                   pluginExampleDirectory.path),
             ]));


### PR DESCRIPTION
Adds flags to `xcode-analyze` that allow running it with an overridden minimum deployment version, and adds iOS and macOS CI runs with those flags, to catch deprecation warnings that don't actually apply yet. By keeping this ahead of the actual minimum we can:
- Ensure that we aren't accidentally creating additional technical debt in new PRs by writing already-deprecated code without corresponding new codepaths.
- Control when we address new deprecations, rather than having to deal with it as part of the process of dropping old iOS version support.

The added tests will only add 1-2 minutes to each of the iOS platform test shards, so is a relatively low cost.

No CHANGELOG change: The change to `google_sign_in_ios`'s example only changes anything in a test configuration that didn't previously exist.

Fixes https://github.com/flutter/flutter/issues/102835

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
