### PR TITLE
Fix issue where map updates don't take effect in Flutter v3.0.0

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.1.6
 
+* Fixes issue in Flutter v3.0.0 where markers aren't updated.
 * Fixes iOS native unit tests on M1 devices.
 * Minor fixes for new analysis options.
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.6
 
-* Fixes issue in Flutter v3.0.0 where markers aren't updated on Android.
+* Fixes issue in Flutter v3.0.0 where some updates to the map don't take effect on Android.
 * Fixes iOS native unit tests on M1 devices.
 * Minor fixes for new analysis options.
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.1.6
 
-* Fixes issue in Flutter v3.0.0 where markers aren't updated.
+* Fixes issue in Flutter v3.0.0 where markers aren't updated on Android.
 * Fixes iOS native unit tests on M1 devices.
 * Minor fixes for new analysis options.
 

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -133,7 +133,7 @@ final class GoogleMapController
     return trackCameraPosition ? googleMap.getCameraPosition() : null;
   }
 
-  private boolean invalidatePending = false;
+  private boolean loadedCallbackPending = false;
 
   /**
    * Invalidates the map view after the map has finished rendering.
@@ -152,19 +152,19 @@ final class GoogleMapController
    * (16.66ms at 60hz) have passed since the drawing operation was issued.
    */
   private void invalidateMapIfNeeded() {
-    if (googleMap == null || invalidatePending) {
+    if (googleMap == null || loadedCallbackPending) {
       return;
     }
-    invalidatePending = true;
+    loadedCallbackPending = true;
     googleMap.setOnMapLoadedCallback(
         new GoogleMap.OnMapLoadedCallback() {
           @Override
           public void onMapLoaded() {
+            loadedCallbackPending = false;
             postFrameCallback(
                 () -> {
                   postFrameCallback(
                       () -> {
-                        invalidatePending = false;
                         if (mapView != null) {
                           mapView.invalidate();
                         }

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -153,14 +153,14 @@ final class GoogleMapController
   }
 
   private static void postFrameCallback(Runnable f) {
-    Choreographer.getInstance().postFrameCallback(
-      new Choreographer.FrameCallback() {
-        @Override
-        public void doFrame(long frameTimeNanos) {
-          f.run();
-        }
-      }
-    );
+    Choreographer.getInstance()
+        .postFrameCallback(
+            new Choreographer.FrameCallback() {
+              @Override
+              public void doFrame(long frameTimeNanos) {
+                f.run();
+              }
+            });
   }
 
   @Override
@@ -272,16 +272,19 @@ final class GoogleMapController
           // To workaround this limitation, wait two frames.
           // This ensures that at least the frame budget (16.66ms at 60hz) have passed since the
           // drawing operation was issued.
-          googleMap.setOnMapLoadedCallback(new GoogleMap.OnMapLoadedCallback() {
-            @Override
-            public void onMapLoaded() {
-              postFrameCallback(() -> {
-                postFrameCallback(() -> {
-                  mapView.invalidate();
-                });
+          googleMap.setOnMapLoadedCallback(
+              new GoogleMap.OnMapLoadedCallback() {
+                @Override
+                public void onMapLoaded() {
+                  postFrameCallback(
+                      () -> {
+                        postFrameCallback(
+                            () -> {
+                              mapView.invalidate();
+                            });
+                      });
+                }
               });
-            }
-          });
 
           result.success(null);
           break;

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -303,6 +303,7 @@ final class GoogleMapController
         }
       case "markers#update":
         {
+          invalidateMapIfNeeded();
           List<Object> markersToAdd = call.argument("markersToAdd");
           markersController.addMarkers(markersToAdd);
           List<Object> markersToChange = call.argument("markersToChange");
@@ -310,7 +311,6 @@ final class GoogleMapController
           List<Object> markerIdsToRemove = call.argument("markerIdsToRemove");
           markersController.removeMarkers(markerIdsToRemove);
           result.success(null);
-          invalidateMapIfNeeded();
           break;
         }
       case "markers#showInfoWindow":
@@ -333,6 +333,7 @@ final class GoogleMapController
         }
       case "polygons#update":
         {
+          invalidateMapIfNeeded();
           List<Object> polygonsToAdd = call.argument("polygonsToAdd");
           polygonsController.addPolygons(polygonsToAdd);
           List<Object> polygonsToChange = call.argument("polygonsToChange");
@@ -340,11 +341,11 @@ final class GoogleMapController
           List<Object> polygonIdsToRemove = call.argument("polygonIdsToRemove");
           polygonsController.removePolygons(polygonIdsToRemove);
           result.success(null);
-          invalidateMapIfNeeded();
           break;
         }
       case "polylines#update":
         {
+          invalidateMapIfNeeded();
           List<Object> polylinesToAdd = call.argument("polylinesToAdd");
           polylinesController.addPolylines(polylinesToAdd);
           List<Object> polylinesToChange = call.argument("polylinesToChange");
@@ -352,11 +353,11 @@ final class GoogleMapController
           List<Object> polylineIdsToRemove = call.argument("polylineIdsToRemove");
           polylinesController.removePolylines(polylineIdsToRemove);
           result.success(null);
-          invalidateMapIfNeeded();
           break;
         }
       case "circles#update":
         {
+          invalidateMapIfNeeded();
           List<Object> circlesToAdd = call.argument("circlesToAdd");
           circlesController.addCircles(circlesToAdd);
           List<Object> circlesToChange = call.argument("circlesToChange");
@@ -364,7 +365,6 @@ final class GoogleMapController
           List<Object> circleIdsToRemove = call.argument("circleIdsToRemove");
           circlesController.removeCircles(circleIdsToRemove);
           result.success(null);
-          invalidateMapIfNeeded();
           break;
         }
       case "map#isCompassEnabled":
@@ -437,6 +437,7 @@ final class GoogleMapController
         }
       case "map#setStyle":
         {
+          invalidateMapIfNeeded();
           boolean mapStyleSet;
           if (call.arguments instanceof String) {
             String mapStyle = (String) call.arguments;
@@ -455,11 +456,11 @@ final class GoogleMapController
                 "Unable to set the map style. Please check console logs for errors.");
           }
           result.success(mapStyleResult);
-          invalidateMapIfNeeded();
           break;
         }
       case "tileOverlays#update":
         {
+          invalidateMapIfNeeded();
           List<Map<String, ?>> tileOverlaysToAdd = call.argument("tileOverlaysToAdd");
           tileOverlaysController.addTileOverlays(tileOverlaysToAdd);
           List<Map<String, ?>> tileOverlaysToChange = call.argument("tileOverlaysToChange");
@@ -467,14 +468,13 @@ final class GoogleMapController
           List<String> tileOverlaysToRemove = call.argument("tileOverlayIdsToRemove");
           tileOverlaysController.removeTileOverlays(tileOverlaysToRemove);
           result.success(null);
-          invalidateMapIfNeeded();
           break;
         }
       case "tileOverlays#clearTileCache":
         {
+          invalidateMapIfNeeded();
           String tileOverlayId = call.argument("tileOverlayId");
           tileOverlaysController.clearTileCache(tileOverlayId);
-          invalidateMapIfNeeded();
           result.success(null);
           break;
         }

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -133,6 +133,8 @@ final class GoogleMapController
     return trackCameraPosition ? googleMap.getCameraPosition() : null;
   }
 
+  private boolean invalidatePending = false;
+
   /**
    * Invalidates the map view after the map has finished rendering.
    *
@@ -172,7 +174,16 @@ final class GoogleMapController
         });
   }
 
-  private boolean invalidatePending = false;
+  private static void postFrameCallback(Runnable f) {
+    Choreographer.getInstance()
+        .postFrameCallback(
+            new Choreographer.FrameCallback() {
+              @Override
+              public void doFrame(long frameTimeNanos) {
+                f.run();
+              }
+            });
+  }
 
   @Override
   public void onMapReady(GoogleMap googleMap) {
@@ -197,17 +208,6 @@ final class GoogleMapController
     updateInitialPolylines();
     updateInitialCircles();
     updateInitialTileOverlays();
-  }
-
-  private static void postFrameCallback(Runnable f) {
-    Choreographer.getInstance()
-        .postFrameCallback(
-            new Choreographer.FrameCallback() {
-              @Override
-              public void doFrame(long frameTimeNanos) {
-                f.run();
-              }
-            });
   }
 
   @Override

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -4,10 +4,11 @@
 
 package io.flutter.plugins.googlemaps;
 
-import static org.mockito.Mockito.verify;
-import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import android.content.Context;
 import android.os.Build;
@@ -16,6 +17,9 @@ import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
 import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,10 +29,6 @@ import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-import java.util.HashMap;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.MethodCall;
-import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
@@ -71,13 +71,17 @@ public class GoogleMapControllerTest {
   public void InvalidateMapAfterMarkersUpdate() throws InterruptedException {
     googleMapController.onMapReady(mockGoogleMap);
     MethodChannel.Result result = mock(MethodChannel.Result.class);
-    googleMapController.onMethodCall(new MethodCall("markers#update", new HashMap<String, Object>()), result);
+    googleMapController.onMethodCall(
+        new MethodCall("markers#update", new HashMap<String, Object>()), result);
 
-    ArgumentCaptor<GoogleMap.OnMapLoadedCallback> argument = ArgumentCaptor.forClass(GoogleMap.OnMapLoadedCallback.class);
+    ArgumentCaptor<GoogleMap.OnMapLoadedCallback> argument =
+        ArgumentCaptor.forClass(GoogleMap.OnMapLoadedCallback.class);
     verify(mockGoogleMap).setOnMapLoadedCallback(argument.capture());
 
     MapView mapView = mock(MapView.class);
     googleMapController.setView(mapView);
+
+    verify(mapView, never()).invalidate();
     argument.getValue().onMapLoaded();
     verify(mapView).invalidate();
   }

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugins.googlemaps;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.any;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -12,15 +14,21 @@ import android.os.Build;
 import androidx.activity.ComponentActivity;
 import androidx.test.core.app.ApplicationProvider;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapView;
 import io.flutter.plugin.common.BinaryMessenger;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+import java.util.HashMap;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.MethodCall;
+import static org.mockito.Mockito.mock;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.P)
@@ -57,5 +65,20 @@ public class GoogleMapControllerTest {
     assertTrue(googleMapController != null);
     googleMapController.onDestroy(activity);
     assertNull(googleMapController.getView());
+  }
+
+  @Test
+  public void InvalidateMapAfterMarkersUpdate() throws InterruptedException {
+    googleMapController.onMapReady(mockGoogleMap);
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    googleMapController.onMethodCall(new MethodCall​("markers#update", new HashMap<String, Object>()), result);
+
+    ArgumentCaptor<GoogleMap.OnMapLoadedCallback> argument = ArgumentCaptor.forClass(GoogleMap.OnMapLoadedCallback.class);
+    verify(mockGoogleMap).setOnMapLoadedCallback(argument.capture());
+
+    MapView mapView = mock(MapView.class);
+    googleMapController.setView(mapView);
+    argument.getValue().onMapLoaded();
+    verify(mapView).invalidate();
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -85,4 +85,23 @@ public class GoogleMapControllerTest {
     argument.getValue().onMapLoaded();
     verify(mapView).invalidate();
   }
+
+  @Test
+  public void UpdateMarkersAfterControllerIsDestroyed() throws InterruptedException {
+    googleMapController.onMapReady(mockGoogleMap);
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    googleMapController.onMethodCall(
+        new MethodCall("markers#update", new HashMap<String, Object>()), result);
+
+    ArgumentCaptor<GoogleMap.OnMapLoadedCallback> argument =
+        ArgumentCaptor.forClass(GoogleMap.OnMapLoadedCallback.class);
+    verify(mockGoogleMap).setOnMapLoadedCallback(argument.capture());
+
+    MapView mapView = mock(MapView.class);
+    googleMapController.setView(mapView);
+    googleMapController.onDestroy(activity);
+
+    argument.getValue().onMapLoaded();
+    verify(mapView, never()).invalidate();
+  }
 }

--- a/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter/android/src/test/java/io/flutter/plugins/googlemaps/GoogleMapControllerTest.java
@@ -71,7 +71,7 @@ public class GoogleMapControllerTest {
   public void InvalidateMapAfterMarkersUpdate() throws InterruptedException {
     googleMapController.onMapReady(mockGoogleMap);
     MethodChannel.Result result = mock(MethodChannel.Result.class);
-    googleMapController.onMethodCall(new MethodCall​("markers#update", new HashMap<String, Object>()), result);
+    googleMapController.onMethodCall(new MethodCall("markers#update", new HashMap<String, Object>()), result);
 
     ArgumentCaptor<GoogleMap.OnMapLoadedCallback> argument = ArgumentCaptor.forClass(GoogleMap.OnMapLoadedCallback.class);
     verify(mockGoogleMap).setOnMapLoadedCallback(argument.capture());

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.1.5
+version: 2.1.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Android platform views that are displayed as a texture after Flutter v3.0.0.
require that the view hierarchy is notified after all drawing operations have been flushed.
Since the gmscore GL renderer doesn't use standard Android views, and instead uses TextureView,
we notify the view hierarchy by invalidating the view.
Unfortunately, when OnMapLoadedCallback is fired, the texture may not have been updated yet.
To workaround this limitation, wait two frames.
This ensures that at least the frame budget (16.66ms at 60hz) have passed since the
drawing operation was issued.

Ideally, `google_maps_flutter` is rendered a texture, so there's a single mode for platform views, and there's fewer surprises when combined with other platform views like WebView or AdMobView.

I will work on updating the documentation.
Fixes https://github.com/flutter/flutter/issues/103686
