### PR TITLE
[camera] Remove a potential deadlock on Android

### DIFF
--- a/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -672,11 +672,12 @@ class Camera
     if (backgroundHandlerThread != null) {
       backgroundHandlerThread.quitSafely();
       try {
-        backgroundHandlerThread.join();
+        backgroundHandlerThread.join(2500);
       } catch (InterruptedException e) {
         dartMessenger.error(flutterResult, "cameraAccess", e.getMessage(), null);
       }
     }
+
     backgroundHandlerThread = null;
     backgroundHandler = null;
   }
@@ -1090,7 +1091,9 @@ class Camera
 
           @Override
           public void onCancel(Object o) {
-            imageStreamReader.setOnImageAvailableListener(null, backgroundHandler);
+            if (imageStreamReader != null) {
+              imageStreamReader.setOnImageAvailableListener(null, backgroundHandler);
+            }
           }
         });
   }
@@ -1198,7 +1201,6 @@ class Camera
 
   public void dispose() {
     Log.i(TAG, "dispose");
-
     close();
     flutterTexture.release();
     getDeviceOrientationManager().stop();


### PR DESCRIPTION
Here is the scenario fixed by this PR:
- Open the camera in a Flutter app
- Move this app to the background (= no `dispose` method called)
- Open a third-party app requiring the camera

In that case, the native Android code will call `onDisconnected` from `CameraDevice.StateCallback`.
In this call, the `close()` method is launched but never ends because `stopBackgroundThread` is blocked in the `join()` method.

To prevent this, I have simply added a timeout.
2500 milliseconds is totally arbitrary. I can change it.