### PR TITLE
[ci] Initial migration to Cirrus Apple silicon

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -308,7 +308,7 @@ task:
 
 # ARM macOS tasks.
 task:
-  << : *MACOS_TEMPLATE
+  << : *MACOS_ARM_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### iOS+macOS tasks ***

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -57,8 +57,16 @@ macos_template: &MACOS_TEMPLATE
   # Only one macOS task can run in parallel without credits, so use them for
   # PRs on macOS.
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
+
+macos_intel_template: &MACOS_INTEL_TEMPLATE
+  << : *MACOS_TEMPLATE
   osx_instance:
     image: big-sur-xcode-13
+
+macos_arm_template: &MACOS_ARM_TEMPLATE
+  << : *MACOS_TEMPLATE
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:13.4
 
 # Light-workload Linux tasks.
 # These use default machines, with fewer CPUs, to reduce pressure on the
@@ -298,7 +306,7 @@ task:
       drive_script:
         - ./script/tool_runner.sh drive-examples --web --exclude=script/configs/exclude_integration_web.yaml
 
-# macOS tasks.
+# ARM macOS tasks.
 task:
   << : *MACOS_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
@@ -315,6 +323,34 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
+    ### macOS desktop tasks ###
+    - name: macos-platform_tests
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+        PATH: $PATH:/usr/local/bin
+      build_script:
+        - flutter config --enable-macos-desktop
+        - ./script/tool_runner.sh build-examples --macos
+      xcode_analyze_script:
+        - ./script/tool_runner.sh xcode-analyze --macos
+      xcode_analyze_deprecation_script:
+        # Ensure we don't accidentally introduce deprecated code.
+        - ./script/tool_runner.sh xcode-analyze --macos --macos-min-version=12.3
+      native_test_script:
+        - ./script/tool_runner.sh native-test --macos
+      drive_script:
+        - ./script/tool_runner.sh drive-examples --macos --exclude=script/configs/exclude_integration_macos.yaml
+
+# Intel macOS tasks.
+task:
+  << : *MACOS_INTEL_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  matrix:
+    # TODO(stuartmorgan): Swap this and ios-build_all_plugins once simulator
+    # tests are reliable on the ARM infrastructure. See discussion at
+    # https://github.com/flutter/plugins/pull/5693#issuecomment-1126011089
     - name: ios-platform_tests
       env:
         PATH: $PATH:/usr/local/bin
@@ -345,6 +381,8 @@ task:
         # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
         - ./script/tool_runner.sh drive-examples --ios --exclude=script/configs/exclude_integration_ios.yaml
     ### macOS desktop tasks ###
+    # macos-platform_tests builds all the plugins on M1, so this build is run
+    # on Intel to give us build coverage of both host types.
     - name: macos-build_all_plugins
       env:
         BUILD_ALL_ARGS: "macos"
@@ -354,21 +392,3 @@ task:
       setup_script:
         - flutter config --enable-macos-desktop
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
-    - name: macos-platform_tests
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-        PATH: $PATH:/usr/local/bin
-      build_script:
-        - flutter config --enable-macos-desktop
-        - ./script/tool_runner.sh build-examples --macos
-      xcode_analyze_script:
-        - ./script/tool_runner.sh xcode-analyze --macos
-      xcode_analyze_deprecation_script:
-        # Ensure we don't accidentally introduce deprecated code.
-        - ./script/tool_runner.sh xcode-analyze --macos --macos-min-version=12.3
-      native_test_script:
-        - ./script/tool_runner.sh native-test --macos
-      drive_script:
-        - ./script/tool_runner.sh drive-examples --macos --exclude=script/configs/exclude_integration_macos.yaml

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -311,10 +311,6 @@ task:
   << : *MACOS_ARM_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
-    ### iOS+macOS tasks ***
-    - name: darwin-lint_podspecs
-      script:
-        - ./script/tool_runner.sh podspecs
     ### iOS tasks ###
     - name: ios-build_all_plugins
       env:
@@ -348,6 +344,14 @@ task:
   << : *MACOS_INTEL_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
+    ### iOS+macOS tasks ***
+    # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
+    # support. `pod lint` makes a synthetic target that doesn't respect the
+    # pod's arch exclusions, so fails to build.
+    - name: darwin-lint_podspecs
+      script:
+        - ./script/tool_runner.sh podspecs
+    ### iOS tasks ###
     # TODO(stuartmorgan): Swap this and ios-build_all_plugins once simulator
     # tests are reliable on the ARM infrastructure. See discussion at
     # https://github.com/flutter/plugins/pull/5693#issuecomment-1126011089


### PR DESCRIPTION
This adopts the new Apple silicon images for:
- macOS platform tests
- iOS build-all

This gives us build coverage across both architectures for both iOS and
macOS.

Ideally we would use ARM for iOS platform tests instead of build-all,
but driving the iOS tests currently has flaky hangs on ARM. See
https://github.com/flutter/plugins/pull/5693 for details. Completing
that part of the migration is left as a TODO.