### PR TITLE
[ios_platform_images] ignore DecoderCallback deprecation

### DIFF
--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0+9
+
+* Ignores the warning for the upcoming deprecation of `DecoderCallback`.
+
 ## 0.2.0+8
 
 * Ignores the warning for the upcoming deprecation of `ImageProvider.load` in the correct line.

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -66,6 +66,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
   /// See [ImageProvider.load].
   // TODO(jmagman): Implement the new API once it lands, https://github.com/flutter/flutter/issues/103556
   @override
+  // ignore: deprecated_member_use
   ImageStreamCompleter load(_FutureMemoryImage key, DecoderCallback decode) {
     return _FutureImageStreamCompleter(
       codec: _loadAsync(key, decode),
@@ -75,6 +76,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
 
   Future<ui.Codec> _loadAsync(
     _FutureMemoryImage key,
+    // ignore: deprecated_member_use
     DecoderCallback decode,
   ) async {
     assert(key == this);

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
 repository: https://github.com/flutter/plugins/tree/main/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.0+8
+version: 0.2.0+9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This was added to the deprecations of https://github.com/flutter/flutter/pull/103496