### PR TITLE
[video_player]: Support for optional bypassing of audio setup

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 2.4.5
 
-* Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/104231).
+* Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/104231)
+* Adds `bypassAudioSetup` to `VideoPlayerOptions`.
+* Delegates iOS AVAudioSession global configuration to `VideoPlayerController`
 
 ## 2.4.4
 

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -355,9 +355,14 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         break;
     }
 
-    if (videoPlayerOptions?.mixWithOthers != null) {
-      await _videoPlayerPlatform
-          .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
+    if (videoPlayerOptions == null ||
+        (videoPlayerOptions != null &&
+            videoPlayerOptions!.bypassAudioSetup == false)) {
+      await _videoPlayerPlatform.setupAudioSession(AudioSession());
+      if (videoPlayerOptions?.mixWithOthers != null) {
+        await _videoPlayerPlatform
+            .setMixWithOthers(videoPlayerOptions!.mixWithOthers);
+      }
     }
 
     _textureId = (await _videoPlayerPlatform.create(dataSourceDescription)) ??

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.4
+version: 2.4.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -31,3 +31,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+   video_player_platform_interface:
+     path:
+       ../video_player_platform_interface/

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -1012,6 +1012,14 @@ void main() {
       );
     });
 
+    test('setupAudioSession', () async {
+      final VideoPlayerController controller = VideoPlayerController.file(
+          File(''),
+          videoPlayerOptions: VideoPlayerOptions(bypassAudioSetup: false));
+      await controller.initialize();
+      expect(controller.videoPlayerOptions!.bypassAudioSetup, false);
+    });
+
     test('false allowBackgroundPlayback pauses playback', () async {
       final VideoPlayerController controller = VideoPlayerController.file(
         File(''),
@@ -1128,6 +1136,11 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Future<void> setMixWithOthers(bool mixWithOthers) async {
     calls.add('setMixWithOthers');
+  }
+
+  @override
+  Future<void> setupAudioSession(AudioSession config) async {
+    calls.add('setupAduioSession');
   }
 }
 

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.7
+
+* Adds `setupAudioSession` method to `AndroidVideoPlayer`.
+
 ## 2.3.6
 
 * Updates references to the obsolete master branch.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/Messages.java
@@ -557,6 +557,29 @@ public class Messages {
     }
   }
 
+  public static class AudioSessionMessage {
+    /** Constructor is private to enforce null safety; use Builder. */
+    private AudioSessionMessage() {}
+
+    public static class Builder {
+      public @NonNull AudioSessionMessage build() {
+        AudioSessionMessage pigeonReturn = new AudioSessionMessage();
+        return pigeonReturn;
+      }
+    }
+
+    @NonNull
+    Map<String, Object> toMap() {
+      Map<String, Object> toMapResult = new HashMap<>();
+      return toMapResult;
+    }
+
+    static @NonNull AudioSessionMessage fromMap(@NonNull Map<String, Object> map) {
+      AudioSessionMessage pigeonResult = new AudioSessionMessage();
+      return pigeonResult;
+    }
+  }
+
   private static class AndroidVideoPlayerApiCodec extends StandardMessageCodec {
     public static final AndroidVideoPlayerApiCodec INSTANCE = new AndroidVideoPlayerApiCodec();
 
@@ -586,6 +609,9 @@ public class Messages {
         case (byte) 134:
           return VolumeMessage.fromMap((Map<String, Object>) readValue(buffer));
 
+        case (byte) 135:
+          return AudioSessionMessage.fromMap((Map<String, Object>) readValue(buffer));
+
         default:
           return super.readValueOfType(type, buffer);
       }
@@ -614,6 +640,9 @@ public class Messages {
       } else if (value instanceof VolumeMessage) {
         stream.write(134);
         writeValue(stream, ((VolumeMessage) value).toMap());
+      } else if (value instanceof AudioSessionMessage) {
+        stream.write(135);
+        writeValue(stream, ((AudioSessionMessage) value).toMap());
       } else {
         super.writeValue(stream, value);
       }
@@ -645,6 +674,8 @@ public class Messages {
     void pause(@NonNull TextureMessage msg);
 
     void setMixWithOthers(@NonNull MixWithOthersMessage msg);
+
+    void setupAudioSession(@NonNull AudioSessionMessage msg);
 
     /** The codec used by AndroidVideoPlayerApi. */
     static MessageCodec<Object> getCodec() {
@@ -920,6 +951,33 @@ public class Messages {
                     throw new NullPointerException("msgArg unexpectedly null.");
                   }
                   api.setMixWithOthers(msgArg);
+                  wrapped.put("result", null);
+                } catch (Error | RuntimeException exception) {
+                  wrapped.put("error", wrapError(exception));
+                }
+                reply.reply(wrapped);
+              });
+        } else {
+          channel.setMessageHandler(null);
+        }
+      }
+      {
+        BasicMessageChannel<Object> channel =
+            new BasicMessageChannel<>(
+                binaryMessenger,
+                "dev.flutter.pigeon.AndroidVideoPlayerApi.setupAudioSession",
+                getCodec());
+        if (api != null) {
+          channel.setMessageHandler(
+              (message, reply) -> {
+                Map<String, Object> wrapped = new HashMap<>();
+                try {
+                  ArrayList<Object> args = (ArrayList<Object>) message;
+                  AudioSessionMessage msgArg = (AudioSessionMessage) args.get(0);
+                  if (msgArg == null) {
+                    throw new NullPointerException("msgArg unexpectedly null.");
+                  }
+                  api.setupAudioSession(msgArg);
                   wrapped.put("result", null);
                 } catch (Error | RuntimeException exception) {
                   wrapped.put("error", wrapError(exception));

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayerPlugin.java
@@ -12,6 +12,7 @@ import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
+import io.flutter.plugins.videoplayer.Messages.AudioSessionMessage;
 import io.flutter.plugins.videoplayer.Messages.AndroidVideoPlayerApi;
 import io.flutter.plugins.videoplayer.Messages.CreateMessage;
 import io.flutter.plugins.videoplayer.Messages.LoopingMessage;
@@ -210,6 +211,9 @@ public class VideoPlayerPlugin implements FlutterPlugin, AndroidVideoPlayerApi {
   public void setMixWithOthers(MixWithOthersMessage arg) {
     options.mixWithOthers = arg.getMixWithOthers();
   }
+
+  @Override
+  public void setupAudioSession(AudioSessionMessage arg) {}
 
   private interface KeyForAssetFn {
     String get(String asset);

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -164,6 +164,11 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
         .setMixWithOthers(MixWithOthersMessage(mixWithOthers: mixWithOthers));
   }
 
+  @override
+  Future<void> setupAudioSession(AudioSession config) {
+    return _api.setupAudioSession(AudioSessionMessage());
+  }
+
   EventChannel _eventChannelFor(int textureId) {
     return EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }

--- a/packages/video_player/video_player_android/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_android/lib/src/messages.g.dart
@@ -191,6 +191,20 @@ class MixWithOthersMessage {
   }
 }
 
+class AudioSessionMessage {
+  AudioSessionMessage();
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    return pigeonMap;
+  }
+
+  static AudioSessionMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return AudioSessionMessage();
+  }
+}
+
 class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
   const _AndroidVideoPlayerApiCodec();
   @override
@@ -215,6 +229,9 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
       writeValue(buffer, value.encode());
     } else if (value is VolumeMessage) {
       buffer.putUint8(134);
+      writeValue(buffer, value.encode());
+    } else if (value is AudioSessionMessage) {
+      buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -244,6 +261,9 @@ class _AndroidVideoPlayerApiCodec extends StandardMessageCodec {
 
       case 134:
         return VolumeMessage.decode(readValue(buffer)!);
+
+      case 135:
+        return AudioSessionMessage.decode(readValue(buffer)!);
 
       default:
         return super.readValueOfType(type, buffer);
@@ -515,6 +535,30 @@ class AndroidVideoPlayerApi {
   Future<void> setMixWithOthers(MixWithOthersMessage arg_msg) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.AndroidVideoPlayerApi.setMixWithOthers', codec,
+        binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> setupAudioSession(AudioSessionMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.AndroidVideoPlayerApi.setupAudioSession', codec,
         binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;

--- a/packages/video_player/video_player_android/pigeons/messages.dart
+++ b/packages/video_player/video_player_android/pigeons/messages.dart
@@ -56,6 +56,10 @@ class MixWithOthersMessage {
   bool mixWithOthers;
 }
 
+class AudioSessionMessage {
+  AudioSessionMessage();
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class AndroidVideoPlayerApi {
   void initialize();
@@ -69,4 +73,5 @@ abstract class AndroidVideoPlayerApi {
   void seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  void setupAudioSession(AudioSessionMessage msg);
 }

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.6
+version: 2.3.7
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -26,3 +26,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^2.0.1
+
+dependency_overrides:
+  video_player_platform_interface:
+    path:
+      ../video_player_platform_interface/

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -21,6 +21,7 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   VolumeMessage? volumeMessage;
   PlaybackSpeedMessage? playbackSpeedMessage;
   MixWithOthersMessage? mixWithOthersMessage;
+  AudioSessionMessage? audioSessionMessage;
 
   @override
   TextureMessage create(CreateMessage arg) {
@@ -56,6 +57,12 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   void setMixWithOthers(MixWithOthersMessage arg) {
     log.add('setMixWithOthers');
     mixWithOthersMessage = arg;
+  }
+
+  @override
+  void setupAudioSession(AudioSessionMessage arg) {
+    log.add('setupAduioSession');
+    audioSessionMessage = arg;
   }
 
   @override

--- a/packages/video_player/video_player_android/test/test_api.dart
+++ b/packages/video_player/video_player_android/test/test_api.dart
@@ -40,6 +40,9 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
     } else if (value is VolumeMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
+    } else if (value is AudioSessionMessage) {
+      buffer.putUint8(135);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -69,6 +72,9 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       case 134:
         return VolumeMessage.decode(readValue(buffer)!);
 
+      case 135:
+        return AudioSessionMessage.decode(readValue(buffer)!);
+
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -89,6 +95,8 @@ abstract class TestHostVideoPlayerApi {
   void seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  void setupAudioSession(AudioSessionMessage msg);
+
   static void setup(TestHostVideoPlayerApi? api,
       {BinaryMessenger? binaryMessenger}) {
     {
@@ -293,6 +301,26 @@ abstract class TestHostVideoPlayerApi {
           assert(arg_msg != null,
               'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.setMixWithOthers was null, expected non-null MixWithOthersMessage.');
           api.setMixWithOthers(arg_msg!);
+          return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.AndroidVideoPlayerApi.setupAudioSession', codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.setupAudioSession was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final AudioSessionMessage? arg_msg =
+              (args[0] as AudioSessionMessage?);
+          assert(arg_msg != null,
+              'Argument for dev.flutter.pigeon.AndroidVideoPlayerApi.setupAudioSession was null, expected non-null AmbientMixMessage.');
+          api.setupAudioSession(arg_msg!);
           return <Object?, Object?>{};
         });
       }

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.6
+
+* Adds `bypassAudioSetup` to `VideoPlayerOptions`.
+* Adds `setupAudioSession` method to `FLTVideoPlayer`.
+
 ## 2.3.5
 
 * Updates references to the obsolete master branch.

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
@@ -268,4 +268,24 @@
   XCTAssertEqual(t.ty, expectY);
 }
 
+- (void)testSetupAudioSession {
+  FLTVideoPlayerPlugin *videoPlayer = [[FLTVideoPlayerPlugin alloc] init];
+  FLTAudioSessionMessage *msg = [FLTAudioSessionMessage alloc];
+  FLTMixWithOthersMessage *mixWithOthers = [FLTMixWithOthersMessage alloc];
+  AVAudioSession *session = [AVAudioSession sharedInstance];
+  FlutterError *error;
+
+  [videoPlayer initialize:&error];
+
+  [videoPlayer setupAudioSession:msg error:&error];
+
+  XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+
+  mixWithOthers.mixWithOthers = @1;
+  [videoPlayer setMixWithOthers:mixWithOthers error:&error];
+
+  XCTAssertEqual(session.category, AVAudioSessionCategoryPlayback);
+  XCTAssertEqual(session.categoryOptions, AVAudioSessionCategoryOptionMixWithOthers);
+}
+
 @end

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -529,9 +529,6 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
 }
 
 - (void)initialize:(FlutterError *__autoreleasing *)error {
-  // Allow audio playback when the Ring/Silent switch is set to silent
-  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
-
   [self.playersByTextureId
       enumerateKeysAndObjectsUsingBlock:^(NSNumber *textureId, FLTVideoPlayer *player, BOOL *stop) {
         [self.registry unregisterTexture:textureId.unsignedIntegerValue];
@@ -632,6 +629,12 @@ NS_INLINE CGFloat radiansToDegrees(CGFloat radians) {
   } else {
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
   }
+}
+
+- (void)setupAudioSession:(FLTAudioSessionMessage *)input
+                    error:(FlutterError *_Nullable __autoreleasing *)error {
+  // Allow audio playback when the Ring/Silent switch is set to silent
+  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
 }
 
 @end

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.h
@@ -18,6 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 @class FLTPositionMessage;
 @class FLTCreateMessage;
 @class FLTMixWithOthersMessage;
+@class FLTAudioSessionMessage;
+
 
 @interface FLTTextureMessage : NSObject
 /// `init` unavailable to enforce nonnull fields, see the `make` class method.
@@ -80,6 +82,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSNumber *mixWithOthers;
 @end
 
+@interface FLTAudioSessionMessage : NSObject
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)makeAudioSession;
+@end
+
 /// The codec used by FLTAVFoundationVideoPlayerApi.
 NSObject<FlutterMessageCodec> *FLTAVFoundationVideoPlayerApiGetCodec(void);
 
@@ -101,6 +108,10 @@ NSObject<FlutterMessageCodec> *FLTAVFoundationVideoPlayerApiGetCodec(void);
 - (void)pause:(FLTTextureMessage *)msg error:(FlutterError *_Nullable *_Nonnull)error;
 - (void)setMixWithOthers:(FLTMixWithOthersMessage *)msg
                    error:(FlutterError *_Nullable *_Nonnull)error;
+- (void)setupAudioSession:(FLTAudioSessionMessage *)msg
+                   error:(FlutterError *_Nullable *_Nonnull)error;
+
+
 @end
 
 extern void FLTAVFoundationVideoPlayerApiSetup(

--- a/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/messages.g.m
@@ -61,6 +61,10 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 + (FLTMixWithOthersMessage *)fromMap:(NSDictionary *)dict;
 - (NSDictionary *)toMap;
 @end
+@interface FLTAudioSessionMessage ()
++ (FLTAudioSessionMessage *)fromMap:(NSDictionary *)dict;
+- (NSDictionary *)toMap;
+@end
 
 @implementation FLTTextureMessage
 + (instancetype)makeWithTextureId:(NSNumber *)textureId {
@@ -227,6 +231,23 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 }
 @end
 
+@implementation FLTAudioSessionMessage
++ (instancetype)makeAudioSession {
+  FLTAudioSessionMessage *pigeonResult = [[FLTAudioSessionMessage alloc] init];
+  return pigeonResult;
+};
+
++ (FLTAudioSessionMessage *)fromMap:(NSDictionary *)dict {
+  FLTAudioSessionMessage *pigeonResult = [[FLTAudioSessionMessage alloc] init];
+  return pigeonResult;
+}
+
+- (NSDictionary *)toMap {
+  return [[NSDictionary alloc] init];
+}
+
+@end
+
 @interface FLTAVFoundationVideoPlayerApiCodecReader : FlutterStandardReader
 @end
 @implementation FLTAVFoundationVideoPlayerApiCodecReader
@@ -252,6 +273,9 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
 
     case 134:
       return [FLTVolumeMessage fromMap:[self readValue]];
+
+    case 135:
+      return [FLTAudioSessionMessage fromMap:[self readValue]];
 
     default:
       return [super readValueOfType:type];
@@ -283,6 +307,9 @@ static id GetNullableObjectAtIndex(NSArray *array, NSInteger key) {
     [self writeValue:[value toMap]];
   } else if ([value isKindOfClass:[FLTVolumeMessage class]]) {
     [self writeByte:134];
+    [self writeValue:[value toMap]];
+  } else if ([value isKindOfClass:[FLTAudioSessionMessage class]]) {
+    [self writeByte:135];
     [self writeValue:[value toMap]];
   } else {
     [super writeValue:value];
@@ -535,6 +562,28 @@ void FLTAVFoundationVideoPlayerApiSetup(id<FlutterBinaryMessenger> binaryMesseng
         FLTMixWithOthersMessage *arg_msg = GetNullableObjectAtIndex(args, 0);
         FlutterError *error;
         [api setMixWithOthers:arg_msg error:&error];
+        callback(wrapResult(nil, error));
+      }];
+    } else {
+      [channel setMessageHandler:nil];
+    }
+  }
+
+  {
+    FlutterBasicMessageChannel *channel = [[FlutterBasicMessageChannel alloc]
+           initWithName:@"dev.flutter.pigeon.AVFoundationVideoPlayerApi.setupAudioSession"
+        binaryMessenger:binaryMessenger
+                  codec:FLTAVFoundationVideoPlayerApiGetCodec()];
+    if (api) {
+      NSCAssert([api respondsToSelector:@selector(setupAudioSession:error:)],
+                @"FLTAVFoundationVideoPlayerApi api (%@) doesn't respond to "
+                @"@selector(setupAudioSession:error:)",
+                api);
+      [channel setMessageHandler:^(id _Nullable message, FlutterReply callback) {
+        NSArray *args = message;
+        FLTAudioSessionMessage *arg_msg = GetNullableObjectAtIndex(args, 0);
+        FlutterError *error;
+        [api setupAudioSession:arg_msg error:&error];
         callback(wrapResult(nil, error));
       }];
     } else {

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -163,6 +163,11 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
         .setMixWithOthers(MixWithOthersMessage(mixWithOthers: mixWithOthers));
   }
 
+  @override
+  Future<void> setupAudioSession(AudioSession config) {
+    return _api.setupAudioSession(AudioSessionMessage());
+  }
+
   EventChannel _eventChannelFor(int textureId) {
     return EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }

--- a/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/messages.g.dart
@@ -191,6 +191,20 @@ class MixWithOthersMessage {
   }
 }
 
+class AudioSessionMessage {
+  AudioSessionMessage();
+
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    return pigeonMap;
+  }
+
+  static AudioSessionMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    return AudioSessionMessage();
+  }
+}
+
 class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
   const _AVFoundationVideoPlayerApiCodec();
   @override
@@ -215,6 +229,9 @@ class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
       writeValue(buffer, value.encode());
     } else if (value is VolumeMessage) {
       buffer.putUint8(134);
+      writeValue(buffer, value.encode());
+    } else if (value is AudioSessionMessage) {
+      buffer.putUint8(135);
       writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
@@ -245,6 +262,8 @@ class _AVFoundationVideoPlayerApiCodec extends StandardMessageCodec {
       case 134:
         return VolumeMessage.decode(readValue(buffer)!);
 
+      case 135:
+        return AudioSessionMessage.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -515,6 +534,31 @@ class AVFoundationVideoPlayerApi {
   Future<void> setMixWithOthers(MixWithOthersMessage arg_msg) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.AVFoundationVideoPlayerApi.setMixWithOthers', codec,
+        binaryMessenger: _binaryMessenger);
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          (replyMap['error'] as Map<Object?, Object?>?)!;
+      throw PlatformException(
+        code: (error['code'] as String?)!,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      return;
+    }
+  }
+
+  Future<void> setupAudioSession(AudioSessionMessage arg_msg) async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.AVFoundationVideoPlayerApi.setupAudioSession',
+        codec,
         binaryMessenger: _binaryMessenger);
     final Map<Object?, Object?>? replyMap =
         await channel.send(<Object?>[arg_msg]) as Map<Object?, Object?>?;

--- a/packages/video_player/video_player_avfoundation/pigeons/messages.dart
+++ b/packages/video_player/video_player_avfoundation/pigeons/messages.dart
@@ -57,6 +57,10 @@ class MixWithOthersMessage {
   bool mixWithOthers;
 }
 
+class AudioSessionMessage {
+  AudioSessionMessage();
+}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class AVFoundationVideoPlayerApi {
   @ObjCSelector('initialize')
@@ -81,4 +85,6 @@ abstract class AVFoundationVideoPlayerApi {
   void pause(TextureMessage msg);
   @ObjCSelector('setMixWithOthers:')
   void setMixWithOthers(MixWithOthersMessage msg);
+  @ObjCSelector('setupAudioSession:')
+  void setupAudioSession(AudioSessionMessage msg);
 }

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.5
+version: 2.3.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -25,3 +25,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^2.0.1
+
+dependency_overrides:
+   video_player_platform_interface:
+     path:
+       ../video_player_platform_interface/

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -21,6 +21,7 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   VolumeMessage? volumeMessage;
   PlaybackSpeedMessage? playbackSpeedMessage;
   MixWithOthersMessage? mixWithOthersMessage;
+  AudioSessionMessage? audioSessionMessage;
 
   @override
   TextureMessage create(CreateMessage arg) {
@@ -56,6 +57,12 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   void setMixWithOthers(MixWithOthersMessage arg) {
     log.add('setMixWithOthers');
     mixWithOthersMessage = arg;
+  }
+
+  @override
+  void setupAudioSession(AudioSessionMessage arg) {
+    log.add('setupAudioSession');
+    audioSessionMessage = arg;
   }
 
   @override

--- a/packages/video_player/video_player_avfoundation/test/test_api.dart
+++ b/packages/video_player/video_player_avfoundation/test/test_api.dart
@@ -40,6 +40,9 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
     } else if (value is VolumeMessage) {
       buffer.putUint8(134);
       writeValue(buffer, value.encode());
+    } else if (value is AudioSessionMessage) {
+      buffer.putUint8(135);
+      writeValue(buffer, value.encode());
     } else {
       super.writeValue(buffer, value);
     }
@@ -69,6 +72,9 @@ class _TestHostVideoPlayerApiCodec extends StandardMessageCodec {
       case 134:
         return VolumeMessage.decode(readValue(buffer)!);
 
+      case 135:
+        return AudioSessionMessage.decode(readValue(buffer)!);
+
       default:
         return super.readValueOfType(type, buffer);
     }
@@ -89,6 +95,7 @@ abstract class TestHostVideoPlayerApi {
   void seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  void setupAudioSession(AudioSessionMessage msg);
   static void setup(TestHostVideoPlayerApi? api,
       {BinaryMessenger? binaryMessenger}) {
     {
@@ -295,6 +302,27 @@ abstract class TestHostVideoPlayerApi {
           assert(arg_msg != null,
               'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.setMixWithOthers was null, expected non-null MixWithOthersMessage.');
           api.setMixWithOthers(arg_msg!);
+          return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.AVFoundationVideoPlayerApi.setupAudioSession',
+          codec,
+          binaryMessenger: binaryMessenger);
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.setupAudioSession was null.');
+          final List<Object?> args = (message as List<Object?>?)!;
+          final AudioSessionMessage? arg_msg =
+              (args[0] as AudioSessionMessage?);
+          assert(arg_msg != null,
+              'Argument for dev.flutter.pigeon.AVFoundationVideoPlayerApi.setupAudioSession was null, expected non-null AmbientMixMessage.');
+          api.setupAudioSession(arg_msg!);
           return <Object?, Object?>{};
         });
       }

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.4
+* Adds `bypassAudioSetup` to `VideoPlayerOptions`.
+* Adds `setupAudioSession` method to `VideoPlayerApi`.
+
 ## 5.1.3
 
 * Updates references to the obsolete master branch.

--- a/packages/video_player/video_player_platform_interface/lib/messages.dart
+++ b/packages/video_player/video_player_platform_interface/lib/messages.dart
@@ -146,6 +146,19 @@ class MixWithOthersMessage {
   }
 }
 
+class AudioSessionMessage {
+  Object encode() {
+    final Map<Object?, Object?> pigeonMap = <Object?, Object?>{};
+    return pigeonMap;
+  }
+
+  static AudioSessionMessage decode(Object message) {
+    final Map<Object?, Object?> pigeonMap = message as Map<Object?, Object?>;
+    final AudioSessionMessage msg = AudioSessionMessage();
+    return msg;
+  }
+}
+
 class VideoPlayerApi {
   Future<void> initialize() async {
     const BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
@@ -401,6 +414,32 @@ class VideoPlayerApi {
     final Object encoded = arg.encode();
     const BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.VideoPlayerApi.setMixWithOthers',
+        StandardMessageCodec());
+    final Map<Object?, Object?>? replyMap =
+        await channel.send(encoded) as Map<Object?, Object?>?;
+    if (replyMap == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+        details: null,
+      );
+    } else if (replyMap['error'] != null) {
+      final Map<Object?, Object?> error =
+          replyMap['error'] as Map<Object?, Object?>;
+      throw PlatformException(
+        code: error['code'] as String,
+        message: error['message'] as String?,
+        details: error['details'],
+      );
+    } else {
+      // noop
+    }
+  }
+
+  Future<void> setupAudioSession(AudioSessionMessage arg) async {
+    final Object encoded = arg.encode();
+    const BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.VideoPlayerApi.setupAudioSession',
         StandardMessageCodec());
     final Map<Object?, Object?>? replyMap =
         await channel.send(encoded) as Map<Object?, Object?>?;

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -149,6 +149,12 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
     );
   }
 
+  @override
+  Future<void> setupAudioSession(AudioSession config) {
+    final msg = AudioSessionMessage();
+    return _api.setupAudioSession(msg);
+  }
+
   EventChannel _eventChannelFor(int textureId) {
     return EventChannel('flutter.io/videoPlayer/videoEvents$textureId');
   }

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -103,6 +103,14 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   Future<void> setMixWithOthers(bool mixWithOthers) {
     throw UnimplementedError('setMixWithOthers() has not been implemented.');
   }
+
+  Future<void> setupAudioSession(AudioSession config) {
+    throw UnimplementedError('setupAudioSession() has not been implemented.');
+  }
+}
+
+class AudioSession {
+  AudioSession();
 }
 
 /// Description of the data source used to create an instance of
@@ -358,6 +366,7 @@ class VideoPlayerOptions {
   VideoPlayerOptions({
     this.mixWithOthers = false,
     this.allowBackgroundPlayback = false,
+    this.bypassAudioSetup = false,
   });
 
   /// Set this to true to keep playing video in background, when app goes in background.
@@ -370,4 +379,6 @@ class VideoPlayerOptions {
   /// Note: This option will be silently ignored in the web platform (there is
   /// currently no way to implement this feature in this platform).
   final bool mixWithOthers;
+
+  final bool bypassAudioSetup;
 }

--- a/packages/video_player/video_player_platform_interface/pigeons/messages.dart
+++ b/packages/video_player/video_player_platform_interface/pigeons/messages.dart
@@ -42,6 +42,8 @@ class MixWithOthersMessage {
   bool mixWithOthers;
 }
 
+class AudioSessionMessage {}
+
 @HostApi(dartHostTestHandler: 'TestHostVideoPlayerApi')
 abstract class VideoPlayerApi {
   void initialize();
@@ -55,6 +57,7 @@ abstract class VideoPlayerApi {
   void seekTo(PositionMessage msg);
   void pause(TextureMessage msg);
   void setMixWithOthers(MixWithOthersMessage msg);
+  void setupAudioSession(AudioSessionMessage msg);
 }
 
 void configurePigeon(PigeonOptions opts) {

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/video_player/v
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 5.1.3
+version: 5.1.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -21,6 +21,7 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   VolumeMessage? volumeMessage;
   PlaybackSpeedMessage? playbackSpeedMessage;
   MixWithOthersMessage? mixWithOthersMessage;
+  AudioSessionMessage? audioSessionMessage;
 
   @override
   TextureMessage create(CreateMessage arg) {
@@ -56,6 +57,12 @@ class _ApiLogger implements TestHostVideoPlayerApi {
   void setMixWithOthers(MixWithOthersMessage arg) {
     log.add('setMixWithOthers');
     mixWithOthersMessage = arg;
+  }
+
+  @override
+  void setupAudioSession(AudioSessionMessage arg) {
+    log.add('setupAudioSession');
+    audioSessionMessage = arg;
   }
 
   @override

--- a/packages/video_player/video_player_platform_interface/test/test.dart
+++ b/packages/video_player/video_player_platform_interface/test/test.dart
@@ -24,6 +24,7 @@ abstract class TestHostVideoPlayerApi {
   void seekTo(PositionMessage arg);
   void pause(TextureMessage arg);
   void setMixWithOthers(MixWithOthersMessage arg);
+  void setupAudioSession(AudioSessionMessage arg);
   static void setup(TestHostVideoPlayerApi? api) {
     {
       const BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
@@ -191,6 +192,23 @@ abstract class TestHostVideoPlayerApi {
           final MixWithOthersMessage input =
               MixWithOthersMessage.decode(message!);
           api.setMixWithOthers(input);
+          return <Object?, Object?>{};
+        });
+      }
+    }
+    {
+      const BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+          'dev.flutter.pigeon.VideoPlayerApi.setupAudioSession',
+          StandardMessageCodec());
+      if (api == null) {
+        channel.setMockMessageHandler(null);
+      } else {
+        channel.setMockMessageHandler((Object? message) async {
+          assert(message != null,
+              'Argument for dev.flutter.pigeon.VideoPlayerApi.setupAudioSession was null. Expected AudioSessionMessage.');
+          final AudioSessionMessage input =
+              AudioSessionMessage.decode(message!);
+          api.setupAudioSession(input);
           return <Object?, Object?>{};
         });
       }

--- a/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/video_player_options_test.dart
@@ -20,4 +20,11 @@ void main() {
       expect(options.mixWithOthers, false);
     },
   );
+  test(
+    'VideoPlayerOptions bypassAudioSetup defaults to false',
+    () {
+      final VideoPlayerOptions options = VideoPlayerOptions();
+      expect(options.bypassAudioSetup, false);
+    },
+  );
 }

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.11
+
+* Adds `setupAudioSession` method to `VideoPlayerPlugin`.
+
 ## 2.0.10
 
 * Minor fixes for new analysis options.

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -146,4 +146,8 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
   /// Sets the audio mode to mix with other sources (ignored)
   @override
   Future<void> setMixWithOthers(bool mixWithOthers) => Future<void>.value();
+
+  ///
+  @override
+  Future<void> setupAudioSession(AudioSession conf) => Future<void>.value();
 }

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.10
+version: 2.0.11
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -26,3 +26,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+dependency_overrides:
+   video_player_platform_interface:
+     path:
+       ../video_player_platform_interface/


### PR DESCRIPTION
This PR adds support for bypassing the audio setup. On iOS, the platform **initialize** method reconfigures
the global audio setup ( forcefully ) each time the plugin instance gets created or after each restart.

The support is also added to configure audio session in future versions via a message.

**bypassAudioSetup** option is added to **VideoPlayerOptions**. When set to _true_, it prevents
any changes to audio session, essentially bypassing it. By default, it is set to _false_ and the behaviour
is exactly production version

```dart
VideoPlayerOptions({bypassAudioSetup: true})
```

This PR fixes issue [#94328](https://github.com/flutter/flutter/issues/94328).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] All existing and new tests are passing.