### PR TITLE
[camera]bump default camera_web package version

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* **BREAKING CHANGE**: Bumps default camera_web package version to 0.3.0.
+
 ## 0.9.7+1
 
 * Moves streaming implementation to the platform interface package.

--- a/packages/camera/camera/README.md
+++ b/packages/camera/camera/README.md
@@ -98,7 +98,7 @@ Here is a list of all permission error codes that can be thrown:
 
 - `AudioAccessRestricted`: iOS only for now. Thrown when audio access is restricted and users cannot grant permission (parental control).
 
-- `cameraPermission`: Android and Web only. A legacy error code for all kinds of camera permission errors.
+- `cameraPermission`: Android only. A legacy error code for all kinds of camera permission errors.
 
 ### Example
 

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -709,7 +709,7 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           showInSnackBar('Audio access is restricted.');
           break;
         case 'cameraPermission':
-          // Android & web only
+          // Android only
           showInSnackBar('Unknown permission error.');
           break;
         default:

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -23,7 +23,7 @@ flutter:
 
 dependencies:
   camera_platform_interface: ^2.2.0
-  camera_web: ^0.2.1
+  camera_web: ^0.3.0
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2


### PR DESCRIPTION
Follow up [this PR](https://github.com/flutter/plugins/pull/5784) that updates permission exceptions for camera_web package. 

This should be landed together with the Android change since both are breaking changes. 

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/97199

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
