### PR TITLE
[video_player] fix misvalue at `isPlaying` after unplug earphone

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -392,6 +392,9 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
+        case VideoEventType.disconnectedAudioIO:
+          pause();
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -98,6 +98,11 @@ static void *playbackBufferFullContext = &playbackBufferFullContext;
                                            selector:@selector(itemDidPlayToEndTime:)
                                                name:AVPlayerItemDidPlayToEndTimeNotification
                                              object:item];
+
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(handleRouteChange:)
+                                               name:AVAudioSessionRouteChangeNotification
+                                             object:[AVAudioSession sharedInstance]];
 }
 
 - (void)itemDidPlayToEndTime:(NSNotification *)notification {
@@ -109,6 +114,22 @@ static void *playbackBufferFullContext = &playbackBufferFullContext;
       _eventSink(@{@"event" : @"completed"});
     }
   }
+}
+
+- (void)handleRouteChange:(NSNotification *)notification
+{
+    UInt8 reasonValue = [[notification.userInfo valueForKey:AVAudioSessionRouteChangeReasonKey] intValue];
+    AVAudioSessionRouteDescription *routeDescription = [notification.userInfo valueForKey:AVAudioSessionRouteChangePreviousRouteKey];
+    switch (reasonValue) {
+        case AVAudioSessionRouteChangeReasonOldDeviceUnavailable:
+            if (_eventSink != nil) {
+                _eventSink(@{
+              @"event" : @"didPauseInternally",
+                });}
+            break;
+        default:
+            NSLog(@"Reason not mapped");
+    }
 }
 
 const int64_t TIME_UNSET = -9223372036854775807;

--- a/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
+++ b/packages/video_player/video_player_platform_interface/lib/method_channel_video_player.dart
@@ -131,6 +131,8 @@ class MethodChannelVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
+        case 'disconnectedAudioIO':
+          return VideoEvent(eventType: VideoEventType.disconnectedAudioIO);
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -278,6 +278,9 @@ enum VideoEventType {
   /// The video stopped to buffer.
   bufferingEnd,
 
+  /// An input or output has been disconnected.
+  disconnectedAudioIO,
+
   /// An unknown event has been received.
   unknown,
 }


### PR DESCRIPTION
- [ ] add tests
- [ ] add Android platform channel code (if necessary)
_____________
This PR fixes the following open issue:
- https://github.com/flutter/flutter/issues/49081

This bug exists because there's no response from both `FLTVideoPlayerPlugin` and `FLTVideoPlayer` when a route change happens.

The proposed solution is to:
- add a route change notification from `AVAudioSession`;
- send the notification to the dart layer as a `EventSink`;
- then fire `pause()` from the dart layer.


Example app before this PR:
- when disconnecting the earphone, the video stops running, but the video_player state is maintained as `isPlaying`
- then, by tapping at a first time at the player, the `isPlaying` state goes from `true` to `false`;
- the "play" button is shown;
- then, by tapping a second time, the `isPlaying` state goes from `false` to `true`;
- the video reproduces again.

https://user-images.githubusercontent.com/10662585/171498096-f278b9ff-1bd5-481c-a690-550f586f7a4a.mov


Example app after this PR:
- when disconnecting the earphone, the video stops running, and the `isPlaying` state is set to false;
- notice that the "play" button is shown right away;
- then, by tapping at a first time at the player, the `isPlaying` state goes from `false` to `true`;
- the video reproduces again.

https://user-images.githubusercontent.com/10662585/171498791-b9582a8d-7278-4f54-9c8e-ef771e1c15ab.mov


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
