### PR TITLE
[image_picker_android] Remove `jetifier` and `enableUnitTestBinaryResources` from gradle properties

### DIFF
--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -40,7 +40,7 @@ android {
         testImplementation 'junit:junit:4.12'
         testImplementation 'org.mockito:mockito-core:3.10.0'
         testImplementation 'androidx.test:core:1.2.0'
-        testImplementation "org.robolectric:robolectric:4.3.1"
+        testImplementation "org.robolectric:robolectric:4.8.1"
     }
 
     compileOptions {

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -40,7 +40,7 @@ android {
         testImplementation 'junit:junit:4.12'
         testImplementation 'org.mockito:mockito-core:3.10.0'
         testImplementation 'androidx.test:core:1.2.0'
-        testImplementation "org.robolectric:robolectric:4.8.1"
+        testImplementation "org.robolectric:robolectric:4.3.1"
     }
 
     compileOptions {

--- a/packages/image_picker/image_picker_android/example/android/gradle.properties
+++ b/packages/image_picker/image_picker_android/example/android/gradle.properties
@@ -1,5 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
 android.useAndroidX=true
-android.enableJetifier=true
-android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105182

Only Jetifier needs to be removed, but keeping `enableUnitTestBinaryResources` would print out:

```
> Configure project :image_picker_android
WARNING: The option setting 'android.enableUnitTestBinaryResources=true' is experimental and unsupported.
The current default is 'false'.
```

No version change: Only updates gradle properties for example app

No CHANGELOG change: Only updates gradle properties for example app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
