### PR TITLE
[local_auth] Add option to AuthenticationOptions to force strong biometrics only.

### DIFF
--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+* Adds `strongBiometricsOnly` flag to platform specific AndroidAuthenticationOptions for forcing 
+  strong authentication.
+
 ## 1.0.5
 
 * Updates references to the obsolete master branch.

--- a/packages/local_auth/local_auth_android/android/build.gradle
+++ b/packages/local_auth/local_auth_android/android/build.gradle
@@ -46,6 +46,10 @@ android {
             }
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 dependencies {
@@ -53,6 +57,7 @@ dependencies {
     api "androidx.biometric:biometric:1.1.0"
     api "androidx.fragment:fragment:1.3.2"
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:4.5'
     testImplementation 'org.mockito:mockito-inline:3.9.0'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -21,6 +21,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.fragment.app.FragmentActivity;
@@ -71,23 +72,6 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
   private boolean activityPaused = false;
   private BiometricPrompt biometricPrompt;
 
-  @Deprecated
-  AuthenticationHelper(
-      Lifecycle lifecycle,
-      FragmentActivity activity,
-      MethodCall call,
-      AuthCompletionHandler completionHandler,
-      boolean allowCredentials) {
-    this(
-        lifecycle,
-        activity,
-        call,
-        completionHandler,
-        allowCredentials
-            ? new int[] {BiometricManager.Authenticators.DEVICE_CREDENTIAL}
-            : new int[0]);
-  }
-
   AuthenticationHelper(
       Lifecycle lifecycle,
       FragmentActivity activity,
@@ -114,7 +98,6 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
             .setDescription((String) call.argument("localizedReason"))
             .setTitle((String) call.argument("signInTitle"))
             .setSubtitle((String) call.argument("biometricHint"))
-            .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"))
             .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"));
 
     // Use setAllowedAuthenticators on API 30 and above.
@@ -130,8 +113,8 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
       }
     }
     // Use setDeviceCredentialAllowed on API 29 and below.
-    else if (deviceCredentialAllowed) {
-      promptBuilder.setDeviceCredentialAllowed(true);
+    else {
+      promptBuilder.setDeviceCredentialAllowed(deviceCredentialAllowed);
     }
     if (!deviceCredentialAllowed) {
       promptBuilder.setNegativeButtonText((String) call.argument("cancelButton"));
@@ -337,5 +320,10 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
     public void execute(Runnable command) {
       handler.post(command);
     }
+  }
+
+  @VisibleForTesting
+  public BiometricPrompt.PromptInfo getPromptInfo() {
+    return promptInfo;
   }
 }

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelperFactory.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelperFactory.java
@@ -1,0 +1,20 @@
+package io.flutter.plugins.localauth;
+
+import androidx.annotation.VisibleForTesting;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+import io.flutter.plugin.common.MethodCall;
+
+/** Factory class that assists in creating a {@link AuthenticationHelper} instance. */
+class AuthenticationHelperFactory {
+  @VisibleForTesting
+  public static AuthenticationHelper create(
+      Lifecycle lifecycle,
+      FragmentActivity activity,
+      MethodCall call,
+      AuthenticationHelper.AuthCompletionHandler completionHandler,
+      int[] allowedAuthenticators) {
+    return new AuthenticationHelper(
+        lifecycle, activity, call, completionHandler, allowedAuthenticators);
+  }
+}

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelperFactory.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelperFactory.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.localauth;
 
 import androidx.annotation.VisibleForTesting;

--- a/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/AuthenticationHelperTests.java
+++ b/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/AuthenticationHelperTests.java
@@ -1,0 +1,140 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.localauth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.hardware.biometrics.BiometricManager;
+import android.os.Build;
+import androidx.biometric.BiometricPrompt;
+import androidx.fragment.app.FragmentActivity;
+import androidx.lifecycle.Lifecycle;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugins.localauth.utils.TestUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class AuthenticationHelperTests {
+
+  @Test
+  public void authenticationHelper_shouldBuildBasicPromptInfo() {
+    Lifecycle mockLifecycle = mock(Lifecycle.class);
+    FragmentActivity mockActivity = mock(FragmentActivity.class);
+    MethodCall mockMethodCall = mock(MethodCall.class);
+    AuthenticationHelper.AuthCompletionHandler mockHandler =
+        mock(AuthenticationHelper.AuthCompletionHandler.class);
+    when(mockMethodCall.argument("stickyAuth")).thenReturn(false);
+    when(mockMethodCall.argument("localizedReason")).thenReturn("localizedReasonValue");
+    when(mockMethodCall.argument("signInTitle")).thenReturn("signInTitleValue");
+    when(mockMethodCall.argument("biometricHint")).thenReturn("biometricHintValue");
+    when(mockMethodCall.argument("sensitiveTransaction")).thenReturn(false);
+    when(mockMethodCall.argument("cancelButton")).thenReturn("cancelButtonValue");
+    AuthenticationHelper helper =
+        new AuthenticationHelper(
+            mockLifecycle, mockActivity, mockMethodCall, mockHandler, new int[] {});
+    BiometricPrompt.PromptInfo promptInfo = helper.getPromptInfo();
+    assertEquals("localizedReasonValue", promptInfo.getDescription());
+    assertEquals("signInTitleValue", promptInfo.getTitle());
+    assertEquals("biometricHintValue", promptInfo.getSubtitle());
+    assertEquals(false, promptInfo.isConfirmationRequired());
+    assertEquals("cancelButtonValue", promptInfo.getNegativeButtonText());
+  }
+
+  @Test
+  public void authenticationHelper_shouldSetAllowedAuthenticatorsOnAPI30AndAbove() {
+    Lifecycle mockLifecycle = mock(Lifecycle.class);
+    FragmentActivity mockActivity = mock(FragmentActivity.class);
+    MethodCall mockMethodCall = mock(MethodCall.class);
+    AuthenticationHelper.AuthCompletionHandler mockHandler =
+        mock(AuthenticationHelper.AuthCompletionHandler.class);
+    when(mockMethodCall.argument("stickyAuth")).thenReturn(false);
+    when(mockMethodCall.argument("localizedReason")).thenReturn("localizedReasonValue");
+    when(mockMethodCall.argument("signInTitle")).thenReturn("signInTitleValue");
+    when(mockMethodCall.argument("biometricHint")).thenReturn("biometricHintValue");
+    when(mockMethodCall.argument("sensitiveTransaction")).thenReturn(false);
+    when(mockMethodCall.argument("cancelButton")).thenReturn("cancelButtonValue");
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.R);
+    AuthenticationHelper helper =
+        new AuthenticationHelper(
+            mockLifecycle,
+            mockActivity,
+            mockMethodCall,
+            mockHandler,
+            new int[] {
+              BiometricManager.Authenticators.BIOMETRIC_WEAK,
+              BiometricManager.Authenticators.BIOMETRIC_STRONG,
+            });
+    BiometricPrompt.PromptInfo promptInfo = helper.getPromptInfo();
+    assertEquals(
+        BiometricManager.Authenticators.BIOMETRIC_WEAK
+            | BiometricManager.Authenticators.BIOMETRIC_STRONG,
+        promptInfo.getAllowedAuthenticators());
+    assertEquals(false, promptInfo.isDeviceCredentialAllowed());
+  }
+
+  @Test
+  public void authenticationHelper_shouldSetDeviceCredentialsAllowedBelowAPI30() {
+    Lifecycle mockLifecycle = mock(Lifecycle.class);
+    FragmentActivity mockActivity = mock(FragmentActivity.class);
+    MethodCall mockMethodCall = mock(MethodCall.class);
+    AuthenticationHelper.AuthCompletionHandler mockHandler =
+        mock(AuthenticationHelper.AuthCompletionHandler.class);
+    when(mockMethodCall.argument("stickyAuth")).thenReturn(false);
+    when(mockMethodCall.argument("localizedReason")).thenReturn("localizedReasonValue");
+    when(mockMethodCall.argument("signInTitle")).thenReturn("signInTitleValue");
+    when(mockMethodCall.argument("biometricHint")).thenReturn("biometricHintValue");
+    when(mockMethodCall.argument("sensitiveTransaction")).thenReturn(false);
+    when(mockMethodCall.argument("cancelButton")).thenReturn("cancelButtonValue");
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.Q);
+    AuthenticationHelper helper =
+        new AuthenticationHelper(
+            mockLifecycle,
+            mockActivity,
+            mockMethodCall,
+            mockHandler,
+            new int[] {
+              BiometricManager.Authenticators.DEVICE_CREDENTIAL,
+              BiometricManager.Authenticators.BIOMETRIC_WEAK,
+              BiometricManager.Authenticators.BIOMETRIC_STRONG,
+            });
+    BiometricPrompt.PromptInfo promptInfo = helper.getPromptInfo();
+    assertEquals(0, promptInfo.getAllowedAuthenticators());
+    assertTrue(promptInfo.isDeviceCredentialAllowed());
+    assertEquals("", promptInfo.getNegativeButtonText());
+  }
+
+  @Test
+  public void authenticationHelper_shouldSetNegativeButtonText_whenDeviceCredentialsNotAllowed() {
+    Lifecycle mockLifecycle = mock(Lifecycle.class);
+    FragmentActivity mockActivity = mock(FragmentActivity.class);
+    MethodCall mockMethodCall = mock(MethodCall.class);
+    AuthenticationHelper.AuthCompletionHandler mockHandler =
+        mock(AuthenticationHelper.AuthCompletionHandler.class);
+    when(mockMethodCall.argument("stickyAuth")).thenReturn(false);
+    when(mockMethodCall.argument("localizedReason")).thenReturn("localizedReasonValue");
+    when(mockMethodCall.argument("signInTitle")).thenReturn("signInTitleValue");
+    when(mockMethodCall.argument("biometricHint")).thenReturn("biometricHintValue");
+    when(mockMethodCall.argument("sensitiveTransaction")).thenReturn(false);
+    when(mockMethodCall.argument("cancelButton")).thenReturn("cancelButtonValue");
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.Q);
+    AuthenticationHelper helper =
+        new AuthenticationHelper(
+            mockLifecycle,
+            mockActivity,
+            mockMethodCall,
+            mockHandler,
+            new int[] {
+              BiometricManager.Authenticators.BIOMETRIC_WEAK,
+              BiometricManager.Authenticators.BIOMETRIC_STRONG,
+            });
+    BiometricPrompt.PromptInfo promptInfo = helper.getPromptInfo();
+    assertEquals("cancelButtonValue", promptInfo.getNegativeButtonText());
+  }
+}

--- a/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/LocalAuthTest.java
+++ b/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/LocalAuthTest.java
@@ -6,78 +6,20 @@ package io.flutter.plugins.localauth;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import android.content.Context;
-import androidx.biometric.BiometricManager;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import java.util.ArrayList;
-import java.util.Collections;
 import org.junit.Test;
 
 public class LocalAuthTest {
-  @Test
-  public void isDeviceSupportedReturnsFalse() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    plugin.onMethodCall(new MethodCall("isDeviceSupported", null), mockResult);
-    verify(mockResult).success(false);
-  }
-
-  @Test
-  public void deviceSupportsBiometrics_returnsTrueForPresentNonEnrolledBiometrics() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate())
-        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
-    plugin.setBiometricManager(mockBiometricManager);
-    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
-    verify(mockResult).success(true);
-  }
-
-  @Test
-  public void deviceSupportsBiometrics_returnsTrueForPresentEnrolledBiometrics() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate()).thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
-    plugin.setBiometricManager(mockBiometricManager);
-    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
-    verify(mockResult).success(true);
-  }
-
-  @Test
-  public void deviceSupportsBiometrics_returnsFalseForNoBiometricHardware() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate())
-        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
-    plugin.setBiometricManager(mockBiometricManager);
-    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
-    verify(mockResult).success(false);
-  }
-
-  @Test
-  public void deviceSupportsBiometrics_returnsFalseForNullBiometricManager() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    plugin.setBiometricManager(null);
-    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
-    verify(mockResult).success(false);
-  }
 
   @Test
   public void onDetachedFromActivity_ShouldReleaseActivity() {
@@ -108,123 +50,5 @@ public class LocalAuthTest {
 
     plugin.onDetachedFromActivity();
     assertNull(plugin.getActivity());
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldReturnError_whenNoActivity() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult)
-        .error("no_activity", "local_auth plugin requires a foreground activity", null);
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldReturnError_whenFinishingActivity() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final Activity mockActivity = buildMockActivity();
-    when(mockActivity.isFinishing()).thenReturn(true);
-    setPluginActivity(plugin, mockActivity);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult)
-        .error("no_activity", "local_auth plugin requires a foreground activity", null);
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldReturnEmptyList_withoutHardwarePresent() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    setPluginActivity(plugin, buildMockActivity());
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate(anyInt()))
-        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
-    plugin.setBiometricManager(mockBiometricManager);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult).success(Collections.emptyList());
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldReturnEmptyList_withNoMethodsEnrolled() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    setPluginActivity(plugin, buildMockActivity());
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate(anyInt()))
-        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
-    plugin.setBiometricManager(mockBiometricManager);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult).success(Collections.emptyList());
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldOnlyAddEnrolledBiometrics() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    setPluginActivity(plugin, buildMockActivity());
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK))
-        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
-    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG))
-        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
-    plugin.setBiometricManager(mockBiometricManager);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult)
-        .success(
-            new ArrayList<String>() {
-              {
-                add("weak");
-              }
-            });
-  }
-
-  @Test
-  public void getEnrolledBiometrics_shouldAddStrongBiometrics() {
-    final LocalAuthPlugin plugin = new LocalAuthPlugin();
-    setPluginActivity(plugin, buildMockActivity());
-    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
-    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK))
-        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
-    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG))
-        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
-    plugin.setBiometricManager(mockBiometricManager);
-
-    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
-    verify(mockResult)
-        .success(
-            new ArrayList<String>() {
-              {
-                add("weak");
-                add("strong");
-              }
-            });
-  }
-
-  private Activity buildMockActivity() {
-    final Activity mockActivity = mock(Activity.class);
-    final Context mockContext = mock(Context.class);
-    when(mockActivity.getBaseContext()).thenReturn(mockContext);
-    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
-    return mockActivity;
-  }
-
-  private void setPluginActivity(LocalAuthPlugin plugin, Activity activity) {
-    final HiddenLifecycleReference mockLifecycleReference = mock(HiddenLifecycleReference.class);
-    final FlutterPluginBinding mockPluginBinding = mock(FlutterPluginBinding.class);
-    final ActivityPluginBinding mockActivityBinding = mock(ActivityPluginBinding.class);
-    final FlutterEngine mockFlutterEngine = mock(FlutterEngine.class);
-    final DartExecutor mockDartExecutor = mock(DartExecutor.class);
-    when(mockPluginBinding.getFlutterEngine()).thenReturn(mockFlutterEngine);
-    when(mockFlutterEngine.getDartExecutor()).thenReturn(mockDartExecutor);
-    when(mockActivityBinding.getActivity()).thenReturn(activity);
-    when(mockActivityBinding.getLifecycle()).thenReturn(mockLifecycleReference);
-    plugin.onAttachedToEngine(mockPluginBinding);
-    plugin.onAttachedToActivity(mockActivityBinding);
   }
 }

--- a/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/LocalAuthTestRobolectric.java
+++ b/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/LocalAuthTestRobolectric.java
@@ -1,0 +1,729 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.localauth;
+
+import static androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG;
+import static androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK;
+import static androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.app.KeyguardManager;
+import android.content.Context;
+import android.content.Intent;
+import android.hardware.fingerprint.FingerprintManager;
+import android.os.Build;
+import androidx.biometric.BiometricManager;
+import androidx.fragment.app.FragmentActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.embedding.engine.plugins.lifecycle.HiddenLifecycleReference;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugins.localauth.utils.TestUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.AdditionalMatchers;
+import org.mockito.MockedStatic;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class LocalAuthTestRobolectric {
+
+  @Test
+  public void authenticate_resultsInErrorWhenInProgress() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    plugin.setAuthInProgress(true);
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult).error("auth_in_progress", "Authentication in progress", null);
+  }
+
+  @Test
+  public void authenticate_resultsInErrorOnNullActivity() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult)
+        .error("no_activity", "local_auth plugin requires a foreground activity", null);
+  }
+
+  @Test
+  public void authenticate_resultsInErrorOnFinishingActivity() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockActivityy();
+    when(activity.isFinishing()).thenReturn(true);
+    setPluginActivity(plugin, activity);
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult)
+        .error("no_activity", "local_auth plugin requires a foreground activity", null);
+  }
+
+  @Test
+  public void authenticate_resultsInErrorOnNonFragmentActivity() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockActivityy();
+    setPluginActivity(plugin, activity);
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult)
+        .error(
+            "no_fragment_activity",
+            "local_auth plugin requires activity to be a FragmentActivity.",
+            null);
+  }
+
+  @Test
+  public void authenticate_resultsInErrorOnNonSupportedDevice() {
+    // Without keyguard manager.
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    setPluginActivity(plugin, buildMockFragmentActivity());
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult).error("NotAvailable", "Required security features not enabled", null);
+
+    // On API 22 and below.
+    setPluginActivity(plugin, buildMockFragmentActivityWithKeyguardManager(true));
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.LOLLIPOP_MR1);
+    mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult).error("NotAvailable", "Required security features not enabled", null);
+
+    // On insecure keyguard manager.
+    setPluginActivity(plugin, buildMockFragmentActivityWithKeyguardManager(false));
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+    mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("authenticate", null), mockResult);
+    verify(mockResult).error("NotAvailable", "Required security features not enabled", null);
+  }
+
+  @Test
+  public void authenticate_strongBiometricsIgnoredBelowAPI30() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 29.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.Q);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", true);
+                  put("biometricOnly", false);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is never called with only strong biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () ->
+              AuthenticationHelperFactory.create(
+                  any(),
+                  any(),
+                  any(),
+                  any(),
+                  AdditionalMatchers.aryEq(
+                      new int[] {
+                        BIOMETRIC_STRONG,
+                      })),
+          never());
+    }
+  }
+
+  @Test
+  public void authenticate_withStrongBiometricsOnly_shouldReturnError_whenNoHardware() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 30.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.R);
+    // No strong biometric hardware present.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(BIOMETRIC_STRONG))
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", true);
+                }
+              }),
+          mockResult);
+
+      verify(mockResult).error("NoHardware", "No strong biometric hardware found", null);
+    }
+  }
+
+  @Test
+  public void authenticate_withStrongBiometricsOnly_shouldReturnError_whenNoHardwareEnrolled() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 30.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.R);
+    // No strong biometric hardware enrolled.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(BIOMETRIC_STRONG))
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", true);
+                }
+              }),
+          mockResult);
+
+      verify(mockResult)
+          .error("NotEnrolled", "No strong biometrics enrolled on this device.", null);
+    }
+  }
+
+  @Test
+  public void authenticate_canLimitToStrongBiometrics() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 30.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.R);
+    // Set correct hardware present.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(BIOMETRIC_STRONG))
+        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", true);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called with only strong biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () ->
+              AuthenticationHelperFactory.create(
+                  any(),
+                  any(),
+                  any(),
+                  any(),
+                  AdditionalMatchers.aryEq(
+                      new int[] {
+                        BIOMETRIC_STRONG,
+                      })));
+    }
+  }
+
+  @Test
+  public void authenticate_withBiometricsOnly_shouldReturnError_whenNoHardware() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // No strong biometric hardware present.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate())
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", true);
+                }
+              }),
+          mockResult);
+
+      verify(mockResult).error("NoHardware", "No biometric hardware found", null);
+    }
+  }
+
+  @Test
+  public void authenticate_withBiometricsOnly_shouldReturnError_whenNoHardwareEnrolled() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // No strong biometric hardware enrolled.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate())
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", true);
+                }
+              }),
+          mockResult);
+
+      verify(mockResult).error("NotEnrolled", "No biometrics enrolled on this device.", null);
+    }
+  }
+
+  @Test
+  public void authenticate_canLimitToBiometric() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set correct hardware present.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate()).thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", true);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called with only biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () ->
+              AuthenticationHelperFactory.create(
+                  any(),
+                  any(),
+                  any(),
+                  any(),
+                  AdditionalMatchers.aryEq(
+                      new int[] {
+                        BIOMETRIC_WEAK, BIOMETRIC_STRONG,
+                      })));
+    }
+  }
+
+  @Test
+  public void authenticate_onAPI29AndAbove() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 23.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.Q);
+    // Set correct hardware present.
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate()).thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", false);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called.
+      mockedAuthenticationHelperFactory.verify(
+          () ->
+              AuthenticationHelperFactory.create(
+                  any(),
+                  any(),
+                  any(),
+                  any(),
+                  AdditionalMatchers.aryEq(
+                      new int[] {
+                        DEVICE_CREDENTIAL, BIOMETRIC_WEAK, BIOMETRIC_STRONG,
+                      })));
+    }
+  }
+
+  @Test
+  public void authenticate_onAPI23To28_withNoHardware() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity = buildMockFragmentActivityWithKeyguardManager(true);
+    setPluginActivity(plugin, activity);
+    // Set API 23.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", false);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called with only biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () -> AuthenticationHelperFactory.create(any(), any(), any(), any(), any()), never());
+    }
+    // Verify activity started for device credential authentication.
+    verify(activity).startActivityForResult(isNotNull(), eq(221));
+  }
+
+  @Test
+  public void authenticate_onAPI23To28_withNoHardwareEnrolled() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity =
+        buildMockFragmentActivityWithKeyguardManagerAndFingerprintManager(true, false);
+    setPluginActivity(plugin, activity);
+    // Set API 23.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", false);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called with only biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () -> AuthenticationHelperFactory.create(any(), any(), any(), any(), any()), never());
+    }
+    // Verify activity started for device credential authentication.
+    verify(activity).startActivityForResult(isNotNull(), eq(221));
+  }
+
+  @Test
+  public void authenticate_onAPI23To28() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    Activity activity =
+        buildMockFragmentActivityWithKeyguardManagerAndFingerprintManager(true, true);
+    setPluginActivity(plugin, activity);
+    // Set API 23.
+    TestUtils.setFinalStatic(Build.VERSION.class, "SDK_INT", Build.VERSION_CODES.M);
+
+    try (MockedStatic<AuthenticationHelperFactory> mockedAuthenticationHelperFactory =
+        mockStatic(AuthenticationHelperFactory.class)) {
+      mockAuthenticationHelper(mockedAuthenticationHelperFactory);
+      final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+      // Call authenticate.
+      plugin.onMethodCall(
+          new MethodCall(
+              "authenticate",
+              new HashMap<String, Object>() {
+                {
+                  put("strongBiometricsOnly", false);
+                  put("biometricOnly", false);
+                }
+              }),
+          mockResult);
+      // Verify auth helper is called with only biometrics.
+      mockedAuthenticationHelperFactory.verify(
+          () ->
+              AuthenticationHelperFactory.create(
+                  any(),
+                  any(),
+                  any(),
+                  any(),
+                  AdditionalMatchers.aryEq(
+                      new int[] {
+                        BIOMETRIC_WEAK, BIOMETRIC_STRONG,
+                      })));
+    }
+  }
+
+  @Test
+  public void isDeviceSupportedReturnsFalse() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.onMethodCall(new MethodCall("isDeviceSupported", null), mockResult);
+    verify(mockResult).success(false);
+  }
+
+  @Test
+  public void deviceSupportsBiometrics_returnsTrueForPresentNonEnrolledBiometrics() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate())
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
+    plugin.setBiometricManager(mockBiometricManager);
+    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
+    verify(mockResult).success(true);
+  }
+
+  @Test
+  public void deviceSupportsBiometrics_returnsTrueForPresentEnrolledBiometrics() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate()).thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    plugin.setBiometricManager(mockBiometricManager);
+    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
+    verify(mockResult).success(true);
+  }
+
+  @Test
+  public void deviceSupportsBiometrics_returnsFalseForNoBiometricHardware() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate())
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
+    plugin.setBiometricManager(mockBiometricManager);
+    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
+    verify(mockResult).success(false);
+  }
+
+  @Test
+  public void deviceSupportsBiometrics_returnsFalseForNullBiometricManager() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    plugin.setBiometricManager(null);
+    plugin.onMethodCall(new MethodCall("deviceSupportsBiometrics", null), mockResult);
+    verify(mockResult).success(false);
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldReturnError_whenNoActivity() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult)
+        .error("no_activity", "local_auth plugin requires a foreground activity", null);
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldReturnError_whenFinishingActivity() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final Activity mockActivity = buildMockActivityy();
+    when(mockActivity.isFinishing()).thenReturn(true);
+    setPluginActivity(plugin, mockActivity);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult)
+        .error("no_activity", "local_auth plugin requires a foreground activity", null);
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldReturnEmptyList_withoutHardwarePresent() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    setPluginActivity(plugin, buildMockActivityy());
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(anyInt()))
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult).success(Collections.emptyList());
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldReturnEmptyList_withNoMethodsEnrolled() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    setPluginActivity(plugin, buildMockActivityy());
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(anyInt()))
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult).success(Collections.emptyList());
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldOnlyAddEnrolledBiometrics() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    setPluginActivity(plugin, buildMockActivityy());
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK))
+        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG))
+        .thenReturn(BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult)
+        .success(
+            new ArrayList<String>() {
+              {
+                add("weak");
+              }
+            });
+  }
+
+  @Test
+  public void getEnrolledBiometrics_shouldAddStrongBiometrics() {
+    final LocalAuthPlugin plugin = new LocalAuthPlugin();
+    setPluginActivity(plugin, buildMockActivityy());
+    final MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    final BiometricManager mockBiometricManager = mock(BiometricManager.class);
+    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_WEAK))
+        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    when(mockBiometricManager.canAuthenticate(BiometricManager.Authenticators.BIOMETRIC_STRONG))
+        .thenReturn(BiometricManager.BIOMETRIC_SUCCESS);
+    plugin.setBiometricManager(mockBiometricManager);
+
+    plugin.onMethodCall(new MethodCall("getEnrolledBiometrics", null), mockResult);
+    verify(mockResult)
+        .success(
+            new ArrayList<String>() {
+              {
+                add("weak");
+                add("strong");
+              }
+            });
+  }
+
+  private Activity buildMockActivityy() {
+    Activity mockActivity = mock(Activity.class);
+    final Context mockContext = mock(Context.class);
+    when(mockActivity.getBaseContext()).thenReturn(mockContext);
+    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
+    return mockActivity;
+  }
+
+  private Activity buildMockFragmentActivity() {
+    Activity mockActivity = mock(FragmentActivity.class);
+    final Context mockContext = mock(Context.class);
+    when(mockActivity.getBaseContext()).thenReturn(mockContext);
+    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
+    return mockActivity;
+  }
+
+  private Activity buildMockFragmentActivityWithKeyguardManager(boolean secure) {
+    Activity mockActivity = mock(FragmentActivity.class);
+    final Context mockContext = mock(Context.class);
+    when(mockActivity.getBaseContext()).thenReturn(mockContext);
+    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
+    final KeyguardManager mockKeyguardManager = mock(KeyguardManager.class);
+    when(mockKeyguardManager.isDeviceSecure()).thenReturn(secure);
+    final Intent mockDeviceCredentialIntent = mock(Intent.class);
+    when(mockKeyguardManager.createConfirmDeviceCredentialIntent(any(), any()))
+        .thenReturn(mockDeviceCredentialIntent);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(mockKeyguardManager);
+    return mockActivity;
+  }
+
+  private Activity buildMockFragmentActivityWithKeyguardManagerAndFingerprintManager(
+      boolean secure, boolean enrolledFingerprints) {
+    Activity mockActivity = mock(FragmentActivity.class);
+    final Context mockContext = mock(Context.class);
+    when(mockActivity.getBaseContext()).thenReturn(mockContext);
+    when(mockActivity.getApplicationContext()).thenReturn(mockContext);
+    final FingerprintManager mockFingerprintManager = mock(FingerprintManager.class);
+    when(mockFingerprintManager.hasEnrolledFingerprints()).thenReturn(enrolledFingerprints);
+    when(mockContext.getSystemService(Context.FINGERPRINT_SERVICE))
+        .thenReturn(mockFingerprintManager);
+    final KeyguardManager mockKeyguardManager = mock(KeyguardManager.class);
+    when(mockKeyguardManager.isDeviceSecure()).thenReturn(secure);
+    final Intent mockDeviceCredentialIntent = mock(Intent.class);
+    when(mockKeyguardManager.createConfirmDeviceCredentialIntent(any(), any()))
+        .thenReturn(mockDeviceCredentialIntent);
+    when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(mockKeyguardManager);
+    return mockActivity;
+  }
+
+  private void setPluginActivity(LocalAuthPlugin plugin, Activity activity) {
+    final HiddenLifecycleReference mockLifecycleReference = mock(HiddenLifecycleReference.class);
+    final FlutterPluginBinding mockPluginBinding = mock(FlutterPluginBinding.class);
+    final ActivityPluginBinding mockActivityBinding = mock(ActivityPluginBinding.class);
+    final FlutterEngine mockFlutterEngine = mock(FlutterEngine.class);
+    final DartExecutor mockDartExecutor = mock(DartExecutor.class);
+    when(mockPluginBinding.getFlutterEngine()).thenReturn(mockFlutterEngine);
+    when(mockFlutterEngine.getDartExecutor()).thenReturn(mockDartExecutor);
+    when(mockActivityBinding.getActivity()).thenReturn(activity);
+    when(mockActivityBinding.getLifecycle()).thenReturn(mockLifecycleReference);
+    plugin.onAttachedToEngine(mockPluginBinding);
+    plugin.onAttachedToActivity(mockActivityBinding);
+  }
+
+  private void mockAuthenticationHelper(MockedStatic<AuthenticationHelperFactory> factory) {
+    factory
+        .when(
+            new MockedStatic.Verification() {
+              @Override
+              public void apply() throws Throwable {
+                AuthenticationHelperFactory.create(any(), any(), any(), any(), any());
+              }
+            })
+        .thenReturn(mock(AuthenticationHelper.class));
+  }
+}

--- a/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/utils/TestUtils.java
+++ b/packages/local_auth/local_auth_android/android/src/test/java/io/flutter/plugins/localauth/utils/TestUtils.java
@@ -1,0 +1,47 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugins.localauth.utils;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.junit.Assert;
+
+public class TestUtils {
+  public static <T> void setFinalStatic(Class<T> classToModify, String fieldName, Object newValue) {
+    try {
+      Field field = classToModify.getField(fieldName);
+      field.setAccessible(true);
+
+      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      modifiersField.setAccessible(true);
+      modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+
+      field.set(null, newValue);
+    } catch (Exception e) {
+      Assert.fail("Unable to mock static field: " + fieldName);
+    }
+  }
+
+  public static <T> void setPrivateField(T instance, String fieldName, Object newValue) {
+    try {
+      Field field = instance.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      field.set(instance, newValue);
+    } catch (Exception e) {
+      Assert.fail("Unable to mock private field: " + fieldName);
+    }
+  }
+
+  public static <T> Object getPrivateField(T instance, String fieldName) {
+    try {
+      Field field = instance.getClass().getDeclaredField(fieldName);
+      field.setAccessible(true);
+      return field.get(instance);
+    } catch (Exception e) {
+      Assert.fail("Unable to mock private field: " + fieldName);
+      return null;
+    }
+  }
+}

--- a/packages/local_auth/local_auth_android/example/lib/main.dart
+++ b/packages/local_auth/local_auth_android/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:local_auth_android/local_auth_android.dart';
+import 'package:local_auth_android/types/android_authentication_options.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
 
 void main() {
@@ -109,7 +110,8 @@ class _MyAppState extends State<MyApp> {
         () => _authorized = authenticated ? 'Authorized' : 'Not Authorized');
   }
 
-  Future<void> _authenticateWithBiometrics() async {
+  Future<void> _authenticateWithBiometrics(
+      {bool strongBiometricsOnly = false}) async {
     bool authenticated = false;
     try {
       setState(() {
@@ -120,10 +122,11 @@ class _MyAppState extends State<MyApp> {
         localizedReason:
             'Scan your fingerprint (or face or whatever) to authenticate',
         authMessages: <AuthMessages>[const AndroidAuthMessages()],
-        options: const AuthenticationOptions(
+        options: AndroidAuthenticationOptions(
           useErrorDialogs: true,
           stickyAuth: true,
           biometricOnly: true,
+          strongBiometricsOnly: strongBiometricsOnly,
         ),
       );
       setState(() {
@@ -219,6 +222,19 @@ class _MyAppState extends State<MyApp> {
                             Text(_isAuthenticating
                                 ? 'Cancel'
                                 : 'Authenticate: biometrics only'),
+                            const Icon(Icons.fingerprint),
+                          ],
+                        ),
+                      ),
+                      ElevatedButton(
+                        onPressed: () => _authenticateWithBiometrics(
+                            strongBiometricsOnly: true),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            Text(_isAuthenticating
+                                ? 'Cancel'
+                                : 'Authenticate: strong biometrics only'),
                             const Icon(Icons.fingerprint),
                           ],
                         ),

--- a/packages/local_auth/local_auth_android/lib/local_auth_android.dart
+++ b/packages/local_auth/local_auth_android/lib/local_auth_android.dart
@@ -6,9 +6,6 @@ import 'package:flutter/services.dart';
 import 'package:local_auth_android/types/android_authentication_options.dart';
 import 'package:local_auth_android/types/auth_messages_android.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
-import 'package:local_auth_platform_interface/types/auth_messages.dart';
-import 'package:local_auth_platform_interface/types/auth_options.dart';
-import 'package:local_auth_platform_interface/types/biometric_type.dart';
 
 export 'package:local_auth_android/types/auth_messages_android.dart';
 export 'package:local_auth_platform_interface/types/auth_messages.dart';

--- a/packages/local_auth/local_auth_android/lib/local_auth_android.dart
+++ b/packages/local_auth/local_auth_android/lib/local_auth_android.dart
@@ -3,8 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:flutter/services.dart';
+import 'package:local_auth_android/types/android_authentication_options.dart';
 import 'package:local_auth_android/types/auth_messages_android.dart';
 import 'package:local_auth_platform_interface/local_auth_platform_interface.dart';
+import 'package:local_auth_platform_interface/types/auth_messages.dart';
+import 'package:local_auth_platform_interface/types/auth_options.dart';
+import 'package:local_auth_platform_interface/types/biometric_type.dart';
 
 export 'package:local_auth_android/types/auth_messages_android.dart';
 export 'package:local_auth_platform_interface/types/auth_messages.dart';
@@ -25,15 +29,20 @@ class LocalAuthAndroid extends LocalAuthPlatform {
   Future<bool> authenticate({
     required String localizedReason,
     required Iterable<AuthMessages> authMessages,
-    AuthenticationOptions options = const AuthenticationOptions(),
+    AuthenticationOptions options = const AndroidAuthenticationOptions(),
   }) async {
     assert(localizedReason.isNotEmpty);
+    bool strongBiometricsOnly = false;
+    if (options is AndroidAuthenticationOptions) {
+      strongBiometricsOnly = options.strongBiometricsOnly;
+    }
     final Map<String, Object> args = <String, Object>{
       'localizedReason': localizedReason,
       'useErrorDialogs': options.useErrorDialogs,
       'stickyAuth': options.stickyAuth,
       'sensitiveTransaction': options.sensitiveTransaction,
       'biometricOnly': options.biometricOnly,
+      'strongBiometricsOnly': strongBiometricsOnly,
     };
     args.addAll(const AndroidAuthMessages().args);
     for (final AuthMessages messages in authMessages) {

--- a/packages/local_auth/local_auth_android/lib/types/android_authentication_options.dart
+++ b/packages/local_auth/local_auth_android/lib/types/android_authentication_options.dart
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:local_auth_android/local_auth_android.dart';
+
+/// Android specific options wrapper for [LocalAuthPlatform.authenticate] parameters.
+class AndroidAuthenticationOptions extends AuthenticationOptions {
+  /// Constructs a new instance.
+  const AndroidAuthenticationOptions({
+    bool useErrorDialogs = true,
+    bool stickyAuth = false,
+    bool sensitiveTransaction = true,
+    bool biometricOnly = false,
+    this.strongBiometricsOnly = false,
+  }) : super(
+            useErrorDialogs: useErrorDialogs,
+            stickyAuth: stickyAuth,
+            sensitiveTransaction: sensitiveTransaction,
+            biometricOnly: biometricOnly);
+
+  /// Prevent authentications from using non-biometric local authentication
+  /// methods such as pin, passcode, or pattern, as well as weak biometric
+  /// methods.
+  /// Overrides [biometricOnly] when set to true.
+  /// Only supported on API level 30 and above, ignored otherwise.
+  final bool strongBiometricsOnly;
+}

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
   intl: ^0.17.0
-  local_auth_platform_interface: ^1.0.0
+  local_auth_platform_interface: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.5
+version: 1.1.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth_android/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth_android/test/local_auth_test.dart
@@ -96,6 +96,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': true,
+                  'strongBiometricsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -121,6 +122,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': false,
                   'biometricOnly': true,
+                  'strongBiometricsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -143,6 +145,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': true,
                   'biometricOnly': false,
+                  'strongBiometricsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );
@@ -167,6 +170,7 @@ void main() {
                   'stickyAuth': false,
                   'sensitiveTransaction': false,
                   'biometricOnly': false,
+                  'strongBiometricsOnly': false,
                 }..addAll(const AndroidAuthMessages().args)),
           ],
         );


### PR DESCRIPTION
This PR adds a `strongBiometricsOnly` flag to the AuthenticationOptions on Android, to enable authenticating with strong biometrics only.

_Note: I have tested this on a device with strong biometrics present. While the appropriate error responses should be returned on a device with only weak biometrics, I have not been able to test this as I have not yet found any hardware that meets this criteria._

~~This PR still lacks tests and pubspec/changelog updates, I'll take care of this tomorrow.~~

Relevant issue:
 - flutter/flutter#81169

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. 