### PR TITLE
[tools] Check integration tests for `test`

### DIFF
--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -70,7 +70,8 @@ void main() {
   ];
 
   for (final StorageDirectory? type in _allDirs) {
-    testWidgets('getExternalStorageDirectories (type: $type)', () async {
+    testWidgets('getExternalStorageDirectories (type: $type)',
+        (WidgetTester tester) async {
       if (Platform.isIOS) {
         final Future<List<Directory>?> result =
             getExternalStorageDirectories(type: null);

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -70,7 +70,7 @@ void main() {
   ];
 
   for (final StorageDirectory? type in _allDirs) {
-    test('getExternalStorageDirectories (type: $type)', () async {
+    testWidgets('getExternalStorageDirectories (type: $type)', () async {
       if (Platform.isIOS) {
         final Future<List<Directory>?> result =
             getExternalStorageDirectories(type: null);

--- a/packages/path_provider/path_provider_android/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_android/example/integration_test/path_provider_test.dart
@@ -61,7 +61,8 @@ void main() {
   ];
 
   for (final StorageDirectory? type in _allDirs) {
-    testWidgets('getExternalStorageDirectories (type: $type)', () async {
+    testWidgets('getExternalStorageDirectories (type: $type)',
+        (WidgetTester tester) async {
       final PathProviderPlatform provider = PathProviderPlatform.instance;
 
       final List<String>? directories =

--- a/packages/path_provider/path_provider_android/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider_android/example/integration_test/path_provider_test.dart
@@ -61,7 +61,7 @@ void main() {
   ];
 
   for (final StorageDirectory? type in _allDirs) {
-    test('getExternalStorageDirectories (type: $type)', () async {
+    testWidgets('getExternalStorageDirectories (type: $type)', () async {
       final PathProviderPlatform provider = PathProviderPlatform.instance;
 
       final List<String>? directories =

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 - Supports empty custom analysis allow list files.
+- `drive-examples` now validates files to ensure that they don't accidentally
+  use `test(...)`.
 
 ## 0.8.6
 


### PR DESCRIPTION
Ensures that tests in integration test files are written with
`testWidgets` instead of `test`, as the latter won't correctly report
failures in an integration test.

No CHANGELOG change: Only affects tests when run in our CI, so not worth mentioning.

See https://github.com/flutter/flutter/issues/105055

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
