### PR TITLE
Ignore upcoming warnings

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/105648).
+
 ## 6.1.3
 
 * Updates README section about query permissions to better reflect changes to

--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
+// TODO(a14n): remove this import once Flutter 3.1 or later reaches stable (including flutter/flutter#105648)
+// ignore: unnecessary_import
+import 'dart:ui' show Brightness;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show PlatformException;


### PR DESCRIPTION
This PR will prevent warnings once https://github.com/flutter/flutter/pull/105648 has landed.

No version change: only import cleanup.