### PR TITLE
Ignore deprecation for `styleFrom` button APIs

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.8+1
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.9.8
 
 * Moves Android and iOS implementations to federated packages.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -371,11 +371,15 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _exposureModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: controller?.value.exposureMode == ExposureMode.auto
           ? Colors.orange
           : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: controller?.value.exposureMode == ExposureMode.locked
           ? Colors.orange
           : Colors.blue,
@@ -456,11 +460,15 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
   Widget _focusModeControlRowWidget() {
     final ButtonStyle styleAuto = TextButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: controller?.value.focusMode == FocusMode.auto
           ? Colors.orange
           : Colors.blue,
     );
     final ButtonStyle styleLocked = TextButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: controller?.value.focusMode == FocusMode.locked
           ? Colors.orange
           : Colors.blue,

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.8
+version: 0.9.8+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.8.4+3
 
 * Improves API docs and examples.

--- a/packages/file_selector/file_selector/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector/example/lib/get_directory_page.dart
@@ -37,7 +37,10 @@ class GetDirectoryPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to ask user to choose a directory'),

--- a/packages/file_selector/file_selector/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector/example/lib/home_page.dart
@@ -12,7 +12,10 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: Colors.blue,
+      // ignore: deprecated_member_use
       onPrimary: Colors.white,
     );
     return Scaffold(

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -47,7 +47,10 @@ class OpenImagePage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open an image file(png, jpg)'),

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -50,7 +50,10 @@ class OpenMultipleImagesPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open multiple images (png, jpg)'),

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -50,7 +50,10 @@ class OpenTextPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open a text file (json, txt)'),

--- a/packages/file_selector/file_selector/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/save_text_page.dart
@@ -75,7 +75,10 @@ class SaveTextPage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to save a text file'),

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.8.2+2
 
 * Updates references to the obsolete master branch.

--- a/packages/file_selector/file_selector_macos/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_directory_page.dart
@@ -39,7 +39,10 @@ class GetDirectoryPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to ask user to choose a directory'),

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -12,7 +12,10 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: Colors.blue,
+      // ignore: deprecated_member_use
       onPrimary: Colors.white,
     );
     return Scaffold(

--- a/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
@@ -46,7 +46,10 @@ class OpenImagePage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open an image file(png, jpg)'),

--- a/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
@@ -50,7 +50,10 @@ class OpenMultipleImagesPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open multiple images (png, jpg)'),

--- a/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
@@ -43,7 +43,10 @@ class OpenTextPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open a text file (json, txt)'),

--- a/packages/file_selector/file_selector_macos/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/save_text_page.dart
@@ -67,7 +67,10 @@ class SaveTextPage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               onPressed: _saveFile,

--- a/packages/file_selector/file_selector_windows/CHANGELOG.md
+++ b/packages/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.8.2+2
 
 * Updates references to the obsolete master branch.

--- a/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/get_directory_page.dart
@@ -39,7 +39,10 @@ class GetDirectoryPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to ask user to choose a directory'),

--- a/packages/file_selector/file_selector_windows/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/home_page.dart
@@ -12,7 +12,10 @@ class HomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = ElevatedButton.styleFrom(
+      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+      // ignore: deprecated_member_use
       primary: Colors.blue,
+      // ignore: deprecated_member_use
       onPrimary: Colors.white,
     );
     return Scaffold(

--- a/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
@@ -46,7 +46,10 @@ class OpenImagePage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open an image file(png, jpg)'),

--- a/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
@@ -50,7 +50,10 @@ class OpenMultipleImagesPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open multiple images (png, jpg)'),

--- a/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
@@ -43,7 +43,10 @@ class OpenTextPage extends StatelessWidget {
           children: <Widget>[
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               child: const Text('Press to open a text file (json, txt)'),

--- a/packages/file_selector/file_selector_windows/example/lib/save_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/save_text_page.dart
@@ -67,7 +67,10 @@ class SaveTextPage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
                 primary: Colors.blue,
+                // ignore: deprecated_member_use
                 onPrimary: Colors.white,
               ),
               onPressed: _saveFile,

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.6
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 3.0.5
 
 * Updates references to the obsolete master branch.

--- a/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
@@ -260,6 +260,8 @@ class _MyAppState extends State<_MyApp> {
               : TextButton(
                   style: TextButton.styleFrom(
                     backgroundColor: Colors.green[800],
+                    // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                    // ignore: deprecated_member_use
                     primary: Colors.white,
                   ),
                   onPressed: () {
@@ -362,6 +364,8 @@ class _MyAppState extends State<_MyApp> {
           TextButton(
             style: TextButton.styleFrom(
               backgroundColor: Theme.of(context).primaryColor,
+              // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+              // ignore: deprecated_member_use
               primary: Colors.white,
             ),
             onPressed: () => _inAppPurchase.restorePurchases(),

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.0.5
+version: 3.0.6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+8
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.2.2+7
 
 * Updates references to the obsolete master branch.

--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -266,6 +266,8 @@ class _MyAppState extends State<_MyApp> {
                 : TextButton(
                     style: TextButton.styleFrom(
                       backgroundColor: Colors.green[800],
+                      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                      // ignore: deprecated_member_use
                       primary: Colors.white,
                     ),
                     onPressed: () {

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.2+7
+version: 0.2.2+8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+10
+
+* Ignores deprecation warnings for upcoming styleFrom button API changes.
+
 ## 0.3.0+9
 
 * Updates references to the obsolete master branch.

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -261,6 +261,8 @@ class _MyAppState extends State<_MyApp> {
                 : TextButton(
                     style: TextButton.styleFrom(
                       backgroundColor: Colors.green[800],
+                      // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                      // ignore: deprecated_member_use
                       primary: Colors.white,
                     ),
                     onPressed: () {
@@ -339,6 +341,8 @@ class _MyAppState extends State<_MyApp> {
           TextButton(
             style: TextButton.styleFrom(
               backgroundColor: Theme.of(context).primaryColor,
+              // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+              // ignore: deprecated_member_use
               primary: Colors.white,
             ),
             onPressed: () => _iapStoreKitPlatform.restorePurchases(),

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.0+9
+version: 0.3.0+10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
There are updated APIs for the button `styleFrom` methods coming in https://github.com/flutter/flutter/pull/105291. In order to land that we need to ignore several deprecation warnings in the plugins repo. There is an [issue](https://github.com/flutter/flutter/issues/105724) tracking this so that when the PR lands on stable we can go back and migrate the plugins and remove the ignore comments.

See: https://github.com/flutter/flutter/issues/105724 and https://github.com/flutter/flutter/pull/105291 for more details.
