### PR TITLE
[url_launcher] Fixes call to setState after dispose.

### DIFF
--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.12
+
+* Fixes call to `setState` after dispose on the `Link` widget.
+[Issue](https://github.com/flutter/flutter/issues/102741).
+* Removes unused `BuildContext` from the `LinkViewController`.
+
 ## 2.0.11
 
 * Minor fixes for new analysis options.

--- a/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
+++ b/packages/url_launcher/url_launcher_web/example/integration_test/link_widget_test.dart
@@ -123,6 +123,36 @@ void main() {
       final html.Element anchor = _findSingleAnchor();
       expect(anchor.hasAttribute('href'), false);
     });
+
+    testWidgets('can be created and disposed', (WidgetTester tester) async {
+      final Uri uri = Uri.parse('http://foobar');
+      const int itemCount = 500;
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: ListView.builder(
+              itemCount: itemCount,
+              itemBuilder: (_, int index) => WebLinkDelegate(TestLinkInfo(
+                uri: uri,
+                target: LinkTarget.defaultTarget,
+                builder: (BuildContext context, FollowLink? followLink) =>
+                    Text('#$index', textAlign: TextAlign.center),
+              )),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.scrollUntilVisible(
+        find.text('#${itemCount - 1}'),
+        2500,
+        maxScrolls: 1000,
+      );
+    });
   });
 }
 

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -118,7 +118,13 @@ class LinkViewController extends PlatformViewController {
     final int viewId = params.id;
     final LinkViewController controller = LinkViewController(viewId, context);
     controller._initialize().then((_) {
-      params.onPlatformViewCreated(viewId);
+      /// Because _initialize is async, it can happen that [LinkViewController.dispose]
+      /// may get called before this `then` callback.
+      /// Check that the `controller` that was created by this factory is not
+      /// disposed before calling `onPlatformViewCreated`.
+      if (_instances[viewId] == controller) {
+        params.onPlatformViewCreated(viewId);
+      }
     });
     return controller;
   }

--- a/packages/url_launcher/url_launcher_web/lib/src/link.dart
+++ b/packages/url_launcher/url_launcher_web/lib/src/link.dart
@@ -76,7 +76,7 @@ class WebLinkDelegateState extends State<WebLinkDelegate> {
           child: PlatformViewLink(
             viewType: linkViewType,
             onCreatePlatformView: (PlatformViewCreationParams params) {
-              _controller = LinkViewController.fromParams(params, context);
+              _controller = LinkViewController.fromParams(params);
               return _controller
                 ..setUri(widget.link.uri)
                 ..setTarget(widget.link.target);
@@ -100,7 +100,7 @@ class WebLinkDelegateState extends State<WebLinkDelegate> {
 /// Controls link views.
 class LinkViewController extends PlatformViewController {
   /// Creates a [LinkViewController] instance with the unique [viewId].
-  LinkViewController(this.viewId, this.context) {
+  LinkViewController(this.viewId) {
     if (_instances.isEmpty) {
       // This is the first controller being created, attach the global click
       // listener.
@@ -113,10 +113,9 @@ class LinkViewController extends PlatformViewController {
   /// platform view [params].
   factory LinkViewController.fromParams(
     PlatformViewCreationParams params,
-    BuildContext context,
   ) {
     final int viewId = params.id;
-    final LinkViewController controller = LinkViewController(viewId, context);
+    final LinkViewController controller = LinkViewController(viewId);
     controller._initialize().then((_) {
       /// Because _initialize is async, it can happen that [LinkViewController.dispose]
       /// may get called before this `then` callback.
@@ -165,9 +164,6 @@ class LinkViewController extends PlatformViewController {
   @override
   final int viewId;
 
-  /// The context of the [Link] widget that created this controller.
-  final BuildContext context;
-
   late html.Element _element;
 
   bool get _isInitialized => _element != null;
@@ -214,7 +210,7 @@ class LinkViewController extends PlatformViewController {
     // browser handle it.
     event.preventDefault();
     final String routeName = _uri.toString();
-    pushRouteNameToFramework(context, routeName);
+    pushRouteNameToFramework(null, routeName);
   }
 
   Uri? _uri;

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.11
+version: 2.0.12
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
@kristoffer-zliide found [a very subtle issue with the current `Link` implementation](https://github.com/flutter/flutter/issues/102741): it may call `onPlatformViewCreated` after it's been `dispose`d by the framework.

The problem is a race condition between the time a Link `controller` initializes and it notifies the framework that it's completely created, because the `PlatformViewLink` widget that is being used as a base for the Platform View of the widget doesn't allow for `async` Platform View Creation callbacks.

The web initialization, however, _needs_ an `async` callback, because of the way that Platform Views are created there. Since the creation callback cannot be async, the current `factory` method creates the Link widget `controller` and calls its `init` as an "unawaited" future (pretty much).
 
The current implementation has a subtle bug where the `controller` initialization and disposal can be triggered out of order, because of a race condition with the framework. In this case:

1. An app adds a large amount of `Link` widgets to the a page, in a scrollable list.
2. The user flings the view.
3. The framework starts disposing and creating big batches of new widgets to repaint the page.
4. Because of the unawaited `async` initialization, some of the batches of widgets may get `dispose`d in the time it takes the framework to `await invokeMethod<void>('create', args)`.
5. This causes that when the code attempts to notify the framework that the view has been created (`onPlatformViewCreated(viewId)`), the view has already been disposed (because the page continued scrolling), and the code fails as described in the issue.

This PR:

* checks that any given widget `controller` hasn't been disposed before calling `onPlatformViewCreated`. 
* removes a `BuildContext context` parameter that is [no longer needed](https://github.com/flutter/plugins/blob/main/packages/url_launcher/url_launcher_platform_interface/lib/link.dart#L88).

This is a simplified version of Kristoffer's PR: https://github.com/flutter/plugins/pull/5431. I cherry-picked the commit where Kristoffer added the unit test for this PR.

## Issues

* Fixes https://github.com/flutter/flutter/issues/102741
* Closes https://github.com/flutter/plugins/pull/5431

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
