### PR TITLE
[image_picker] Implement `getRecentMedia` function on Android.

### DIFF
--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerCache.java
@@ -13,6 +13,7 @@ import io.flutter.plugin.common.MethodCall;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -104,7 +105,7 @@ class ImagePickerCache {
   }
 
   void saveResult(
-      @Nullable ArrayList<String> path, @Nullable String errorCode, @Nullable String errorMessage) {
+      @Nullable List<String> path, @Nullable String errorCode, @Nullable String errorMessage) {
 
     Set<String> imageSet = new HashSet<>();
     imageSet.addAll(path);

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -248,6 +248,7 @@ public class ImagePickerDelegate
     Integer limit = methodCall.argument("limit");
     String type = methodCall.argument("type");
     if (limit == null) limit = 1;
+    if (type == null) type = "unknown";
 
     List<Cursor> cursors = new ArrayList<>();
     Cursor cursor;

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerPlugin.java
@@ -178,6 +178,7 @@ public class ImagePickerPlugin
   }
 
   static final String METHOD_CALL_IMAGE = "pickImage";
+  static final String METHOD_CALL_RECENT_MEDIA = "pickRecentMedia";
   static final String METHOD_CALL_MULTI_IMAGE = "pickMultiImage";
   static final String METHOD_CALL_VIDEO = "pickVideo";
   private static final String METHOD_CALL_RETRIEVE = "retrieve";
@@ -380,6 +381,9 @@ public class ImagePickerPlugin
           default:
             throw new IllegalArgumentException("Invalid video source: " + imageSource);
         }
+        break;
+      case METHOD_CALL_RECENT_MEDIA:
+        delegate.getRecentMedia(call, result);
         break;
       case METHOD_CALL_RETRIEVE:
         delegate.retrieveLostImage(result);

--- a/packages/image_picker/image_picker_android/example/lib/main.dart
+++ b/packages/image_picker/image_picker_android/example/lib/main.dart
@@ -346,6 +346,36 @@ class _MyHomePageState extends State<MyHomePage> {
               child: const Icon(Icons.videocam),
             ),
           ),
+          Padding(
+            padding: const EdgeInsets.only(top: 16.0),
+            child: FloatingActionButton(
+              backgroundColor: Colors.red,
+              onPressed: () {
+                isVideo = true;
+                _onImageButtonPressed(ImageSource.camera);
+              },
+              heroTag: 'video1',
+              tooltip: 'Take a Video',
+              child: const Icon(Icons.videocam),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 16.0),
+            child: FloatingActionButton(
+              backgroundColor: Colors.green,
+              onPressed: () async {
+                final List<XFile>? imageFiles = await _picker.getRecentMedia(
+                    type: RetrieveType.image, limit: 3);
+                final List<XFile>? videoFiles = await _picker.getRecentMedia(
+                    type: RetrieveType.video, limit: 3);
+                print(imageFiles!.map((XFile file) => file.path).toList());
+                print(videoFiles!.map((XFile file) => file.path).toList());
+              },
+              heroTag: 'video1',
+              tooltip: 'Get Recents',
+              child: const Icon(Icons.access_time_filled),
+            ),
+          ),
         ],
       ),
     );

--- a/packages/image_picker/image_picker_android/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/example/pubspec.yaml
@@ -17,7 +17,9 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  image_picker_platform_interface: ^2.3.0
+#  image_picker_platform_interface: ^2.3.0
+  image_picker_platform_interface:
+    path: ../../image_picker_platform_interface
   video_player: ^2.1.4
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -20,7 +20,9 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  image_picker_platform_interface: ^2.3.0
+#  image_picker_platform_interface: ^2.3.0
+  image_picker_platform_interface:
+    path: ../image_picker_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.0
+
+* Adds `getRecentMedia` function for directly retrieving recent media items. 
+
 ## 2.5.0
 
 * Deprecates `getImage` in favor of a new method `getImageFromSource`.

--- a/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/method_channel/method_channel_image_picker.dart
@@ -200,6 +200,47 @@ class MethodChannelImagePicker extends ImagePickerPlatform {
   }
 
   @override
+  Future<List<XFile>?> getRecentMedia({
+    required RetrieveType type,
+    double? maxImageWidth,
+    double? maxImageHeight,
+    int? imageQuality,
+    int limit = 1,
+  }) async {
+    if (imageQuality != null && (imageQuality < 0 || imageQuality > 100)) {
+      throw ArgumentError.value(
+          imageQuality, 'imageQuality', 'must be between 0 and 100');
+    }
+
+    if (maxImageWidth != null && maxImageWidth < 0) {
+      throw ArgumentError.value(
+          maxImageWidth, 'maxWidth', 'cannot be negative');
+    }
+
+    if (maxImageHeight != null && maxImageHeight < 0) {
+      throw ArgumentError.value(
+          maxImageHeight, 'maxHeight', 'cannot be negative');
+    }
+
+    if (limit <= 0) {
+      throw ArgumentError.value(limit, 'limit', 'must be larger than 0');
+    }
+
+    final List<dynamic>? paths = await _channel.invokeMethod<List<dynamic>?>(
+      'pickRecentMedia',
+      <String, dynamic>{
+        'type': serializeRetrieveType(type),
+        'maxWidth': maxImageWidth,
+        'maxHeight': maxImageHeight,
+        'imageQuality': imageQuality,
+        'limit': limit,
+      },
+    );
+
+    return paths?.map((dynamic path) => XFile(path as String)).toList();
+  }
+
+  @override
   Future<XFile?> getImageFromSource({
     required ImageSource source,
     ImagePickerOptions options = const ImagePickerOptions(),

--- a/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/platform_interface/image_picker_platform.dart
@@ -186,6 +186,33 @@ abstract class ImagePickerPlatform extends PlatformInterface {
     throw UnimplementedError('getImage() has not been implemented.');
   }
 
+  /// Returns a [List<XFile>] with the most recent images or videos
+  /// from the user's gallery.
+  ///
+  /// If specified, images will be at most `maxWidth` wide and
+  /// `maxHeight` tall. Otherwise images will be returned at their
+  /// original width and height.
+  ///
+  /// The `imageQuality` argument modifies the quality of images, ranging from 0-100
+  /// where 100 is the original/max quality. If `imageQuality` is null, the
+  /// images will be returned with their original quality. Compression is only
+  /// supported for certain image types such as JPEG. If compression is not supported
+  /// for the image that is picked, a warning message will be logged.
+  ///
+  /// The `limit` argument specifies how many items will be returned at most.
+  /// By default, this is 1 item.
+  ///
+  /// The `allowedType` argument specifies which types of media can be returned.
+  Future<List<XFile>?> getRecentMedia({
+    required RetrieveType type,
+    double? maxImageWidth,
+    double? maxImageHeight,
+    int? imageQuality,
+    int limit = 1,
+  }) async {
+    throw UnimplementedError('getRecentMedia() has not been implemented.');
+  }
+
   /// Returns a [List<XFile>] with the images that were picked.
   ///
   /// The images come from the [ImageSource.gallery].

--- a/packages/image_picker/image_picker_platform_interface/lib/src/types/retrieve_type.dart
+++ b/packages/image_picker/image_picker_platform_interface/lib/src/types/retrieve_type.dart
@@ -10,3 +10,13 @@ enum RetrieveType {
   /// A video. See [ImagePicker.pickVideo].
   video
 }
+
+/// Serializes the value of the [RetrieveType] enum.
+String serializeRetrieveType(RetrieveType type) {
+  switch (type) {
+    case RetrieveType.image:
+      return 'image';
+    case RetrieveType.video:
+      return 'video';
+  }
+}

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/i
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.5.0
+version: 2.6.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -937,6 +937,306 @@ void main() {
       });
     });
 
+    group('#getRecentMedia', () {
+      test('calls the method correctly', () async {
+        returnValue = <dynamic>['0', '1'];
+        await picker.getRecentMedia(type: RetrieveType.image);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'maxWidth': null,
+              'maxHeight': null,
+              'imageQuality': null,
+              'limit': 1,
+              'type': 'image',
+            }),
+          ],
+        );
+      });
+
+      test('passes the limit correctly', () async {
+        returnValue = <dynamic>['0', '1'];
+        await picker.getRecentMedia(type: RetrieveType.image, limit: 5);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'maxWidth': null,
+              'maxHeight': null,
+              'imageQuality': null,
+              'limit': 5,
+              'type': 'image',
+            }),
+          ],
+        );
+      });
+
+      test('passes the type correctly', () async {
+        returnValue = <dynamic>['0', '1'];
+        await picker.getRecentMedia(type: RetrieveType.video);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'maxWidth': null,
+              'maxHeight': null,
+              'imageQuality': null,
+              'limit': 1,
+              'type': 'video',
+            }),
+          ],
+        );
+      });
+
+      test('passes the width and height arguments correctly', () async {
+        returnValue = <dynamic>['0', '1'];
+        await picker.getRecentMedia(type: RetrieveType.image);
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageWidth: 10.0,
+        );
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageHeight: 10.0,
+        );
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageWidth: 10.0,
+          maxImageHeight: 20.0,
+        );
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageWidth: 10.0,
+          imageQuality: 70,
+        );
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageHeight: 10.0,
+          imageQuality: 70,
+        );
+        await picker.getRecentMedia(
+          type: RetrieveType.image,
+          maxImageWidth: 10.0,
+          maxImageHeight: 20.0,
+          imageQuality: 70,
+        );
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': null,
+              'maxHeight': null,
+              'imageQuality': null,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': 10.0,
+              'maxHeight': null,
+              'imageQuality': null,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': null,
+              'maxHeight': 10.0,
+              'imageQuality': null,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': 10.0,
+              'maxHeight': 20.0,
+              'imageQuality': null,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': 10.0,
+              'maxHeight': null,
+              'imageQuality': 70,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': null,
+              'maxHeight': 10.0,
+              'imageQuality': 70,
+            }),
+            isMethodCall('pickRecentMedia', arguments: <String, dynamic>{
+              'type': 'image',
+              'limit': 1,
+              'maxWidth': 10.0,
+              'maxHeight': 20.0,
+              'imageQuality': 70,
+            }),
+          ],
+        );
+      });
+
+      test('does not accept a 0 or negative limit argument', () {
+        returnValue = <dynamic>['0', '1'];
+        expect(
+          () => picker.getRecentMedia(type: RetrieveType.image, limit: -1),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => picker.getRecentMedia(type: RetrieveType.image, limit: 0),
+          throwsArgumentError,
+        );
+      });
+
+      test('does not accept a negative width or height argument', () {
+        returnValue = <dynamic>['0', '1'];
+        expect(
+          () => picker.getRecentMedia(
+              type: RetrieveType.image, maxImageWidth: -1.0),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => picker.getRecentMedia(
+              type: RetrieveType.image, maxImageHeight: -1.0),
+          throwsArgumentError,
+        );
+      });
+
+      test('does not accept an invalid imageQuality argument', () {
+        returnValue = <dynamic>['0', '1'];
+        expect(
+          () =>
+              picker.getRecentMedia(type: RetrieveType.image, imageQuality: -1),
+          throwsArgumentError,
+        );
+
+        expect(
+          () => picker.getRecentMedia(
+              type: RetrieveType.image, imageQuality: 101),
+          throwsArgumentError,
+        );
+      });
+
+      test('handles a null image path response gracefully', () async {
+        picker.channel
+            .setMockMethodCallHandler((MethodCall methodCall) => null);
+
+        expect(await picker.getRecentMedia(type: RetrieveType.image), isNull);
+      });
+    });
+
+    group('#getVideo', () {
+      test('passes the image source argument correctly', () async {
+        await picker.getVideo(source: ImageSource.camera);
+        await picker.getVideo(source: ImageSource.gallery);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'cameraDevice': 0,
+              'maxDuration': null,
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 1,
+              'cameraDevice': 0,
+              'maxDuration': null,
+            }),
+          ],
+        );
+      });
+
+      test('passes the duration argument correctly', () async {
+        await picker.getVideo(source: ImageSource.camera);
+        await picker.getVideo(
+          source: ImageSource.camera,
+          maxDuration: const Duration(seconds: 10),
+        );
+        await picker.getVideo(
+          source: ImageSource.camera,
+          maxDuration: const Duration(minutes: 1),
+        );
+        await picker.getVideo(
+          source: ImageSource.camera,
+          maxDuration: const Duration(hours: 1),
+        );
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'maxDuration': null,
+              'cameraDevice': 0,
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'maxDuration': 10,
+              'cameraDevice': 0,
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'maxDuration': 60,
+              'cameraDevice': 0,
+            }),
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'maxDuration': 3600,
+              'cameraDevice': 0,
+            }),
+          ],
+        );
+      });
+
+      test('handles a null video path response gracefully', () async {
+        picker.channel
+            .setMockMethodCallHandler((MethodCall methodCall) => null);
+
+        expect(await picker.getVideo(source: ImageSource.gallery), isNull);
+        expect(await picker.getVideo(source: ImageSource.camera), isNull);
+      });
+
+      test('camera position defaults to back', () async {
+        await picker.getVideo(source: ImageSource.camera);
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'cameraDevice': 0,
+              'maxDuration': null,
+            }),
+          ],
+        );
+      });
+
+      test('camera position can set to front', () async {
+        await picker.getVideo(
+          source: ImageSource.camera,
+          preferredCameraDevice: CameraDevice.front,
+        );
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('pickVideo', arguments: <String, dynamic>{
+              'source': 0,
+              'maxDuration': null,
+              'cameraDevice': 1,
+            }),
+          ],
+        );
+      });
+    });
+
     group('#getLostData', () {
       test('getLostData get success response', () async {
         picker.channel.setMockMethodCallHandler((MethodCall methodCall) async {


### PR DESCRIPTION
This PR implements the `getRecentMedia` function added to the platform interface in #5979 on Android.

This PR currently remains in draft mode because:
 - No tests have yet been written
 - #5979 has not been merged or published yet, which is required to update the dependency.
 - Changelog and pubspec version have not yet been updated.

Relevant PR:
 - flutter/flutter#19563

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- x ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
