### PR TITLE
[url_launcher_android] Enables Android WebView to open non-https urls, e.g. `mailto:`, `sms:`

### DIFF
--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.1.4
 
+* Enables Android WebView to open non-https urls, e.g. `mailto:`, `sms:`
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/105648).
 
 ## 6.1.3

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for launching a URL. Supports
   web, phone, SMS, and email schemes.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.1.3
+version: 6.1.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -44,3 +44,9 @@ dev_dependencies:
   mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
   test: ^1.16.3
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  url_launcher_android:
+    path: ../../url_launcher/url_launcher_android

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 6.0.18
 
 * Enables Android WebView to open non-https urls, e.g. `mailto:`, `sms:`
 

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Enables Android WebView to open non-https urls, e.g. `mailto:`, `sms:`
+
 ## 6.0.17
 
 * Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors

--- a/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
+++ b/packages/url_launcher/url_launcher_android/android/src/main/java/io/flutter/plugins/urllauncher/WebViewActivity.java
@@ -10,6 +10,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
@@ -58,7 +59,13 @@ public class WebViewActivity extends Activity {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, String url) {
           if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            view.loadUrl(url);
+            if (url.startsWith("http") || url.startsWith("https")) {
+              view.loadUrl(url);
+            } else {
+              Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+              view.getContext().startActivity(intent);
+              return true;
+            }
             return false;
           }
           return super.shouldOverrideUrlLoading(view, url);
@@ -68,7 +75,14 @@ public class WebViewActivity extends Activity {
         @Override
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.loadUrl(request.getUrl().toString());
+            String url = request.getUrl().toString();
+            if (url.startsWith("http") || url.startsWith("https")) {
+              view.loadUrl(url);
+            } else {
+              Intent intent = new Intent(Intent.ACTION_VIEW, request.getUrl());
+              view.getContext().startActivity(intent);
+              return true;
+            }
           }
           return false;
         }

--- a/packages/url_launcher/url_launcher_android/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/example/pubspec.yaml
@@ -27,3 +27,9 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  url_launcher_android:
+    path: ../../../url_launcher/url_launcher_android

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.17
+version: 6.0.18
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Currently, webview opened with `openUrl` on Android cannot open non-http/https hyperlinks like `mailto:` or `sms:`, this PR changes that it preserves current behavior in webview for `https` and `http` links but starts an intent for others.

Resolves [#106331](https://github.com/flutter/flutter/issues/106331)

Effect:

https://user-images.githubusercontent.com/16286046/174770671-d424ded4-b8d0-47e9-bea1-dff9c86ad725.mp4



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
