### PR TITLE
[tools] Allow skipping packages by Dart version

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,9 +1,12 @@
-## NEXT
+## 0.8.7
 
 - Supports empty custom analysis allow list files.
 - `drive-examples` now validates files to ensure that they don't accidentally
   use `test(...)`.
 - Adds a new `dependabot-check` command to ensure complete Dependabot coverage.
+- Adds `skip-if-not-supporting-dart-version` to allow for the same use cases
+  as `skip-if-not-supporting-flutter-version` but for packages without Flutter
+  constraints.
 
 ## 0.8.6
 

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.8.6
+version: 0.8.7
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -340,7 +340,7 @@ void main() {
       }
     });
 
-    test('skips unsupported versions when requested', () async {
+    test('skips unsupported Flutter versions when requested', () async {
       final RepositoryPackage excluded = createFakePlugin(
           'a_plugin', packagesDir,
           flutterConstraint: '>=2.10.0');
@@ -368,6 +368,37 @@ void main() {
             '${_startHeadingColor}Running for a_package...$_endColor',
             '${_startHeadingColor}Running for a_plugin...$_endColor',
             '$_startSkipColor  SKIPPING: Does not support Flutter 2.5.0$_endColor',
+          ]));
+    });
+
+    test('skips unsupported Dart versions when requested', () async {
+      final RepositoryPackage excluded = createFakePackage(
+          'excluded_package', packagesDir,
+          isFlutter: false, dartConstraint: '>=2.17.0 <3.0.0');
+      final RepositoryPackage included = createFakePackage(
+          'a_package', packagesDir,
+          isFlutter: false, dartConstraint: '>=2.14.0 <3.0.0');
+
+      final TestPackageLoopingCommand command = createTestCommand(
+          packageLoopingType: PackageLoopingType.includeAllSubpackages,
+          hasLongOutput: false);
+      final List<String> output = await runCommand(command,
+          arguments: <String>['--skip-if-not-supporting-dart-version=2.14.0']);
+
+      expect(
+          command.checkedPackages,
+          unorderedEquals(<String>[
+            included.path,
+            getExampleDir(included).path,
+          ]));
+      expect(command.checkedPackages, isNot(contains(excluded.path)));
+
+      expect(
+          output,
+          containsAllInOrder(<String>[
+            '${_startHeadingColor}Running for a_package...$_endColor',
+            '${_startHeadingColor}Running for excluded_package...$_endColor',
+            '$_startSkipColor  SKIPPING: Does not support Dart 2.14.0$_endColor',
           ]));
     });
   });

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -23,6 +23,9 @@ import 'mocks.dart';
 
 export 'package:flutter_plugin_tools/src/common/repository_package.dart';
 
+const String _defaultDartConstraint = '>=2.14.0 <3.0.0';
+const String _defaultFlutterConstraint = '>=2.5.0';
+
 /// Returns the exe name that command will use when running Flutter on
 /// [platform].
 String getFlutterCommand(Platform platform) =>
@@ -97,14 +100,19 @@ RepositoryPackage createFakePlugin(
   Map<String, PlatformDetails> platformSupport =
       const <String, PlatformDetails>{},
   String? version = '0.0.1',
-  String flutterConstraint = '>=2.5.0',
+  String flutterConstraint = _defaultFlutterConstraint,
+  String dartConstraint = _defaultDartConstraint,
 }) {
-  final RepositoryPackage package = createFakePackage(name, parentDirectory,
-      isFlutter: true,
-      examples: examples,
-      extraFiles: extraFiles,
-      version: version,
-      flutterConstraint: flutterConstraint);
+  final RepositoryPackage package = createFakePackage(
+    name,
+    parentDirectory,
+    isFlutter: true,
+    examples: examples,
+    extraFiles: extraFiles,
+    version: version,
+    flutterConstraint: flutterConstraint,
+    dartConstraint: dartConstraint,
+  );
 
   createFakePubspec(
     package,
@@ -114,6 +122,7 @@ RepositoryPackage createFakePlugin(
     platformSupport: platformSupport,
     version: version,
     flutterConstraint: flutterConstraint,
+    dartConstraint: dartConstraint,
   );
 
   return package;
@@ -136,7 +145,8 @@ RepositoryPackage createFakePackage(
   List<String> extraFiles = const <String>[],
   bool isFlutter = false,
   String? version = '0.0.1',
-  String flutterConstraint = '>=2.5.0',
+  String flutterConstraint = _defaultFlutterConstraint,
+  String dartConstraint = _defaultDartConstraint,
   bool includeCommonFiles = true,
   String? directoryName,
   String? publishTo,
@@ -150,7 +160,8 @@ RepositoryPackage createFakePackage(
       name: name,
       isFlutter: isFlutter,
       version: version,
-      flutterConstraint: flutterConstraint);
+      flutterConstraint: flutterConstraint,
+      dartConstraint: dartConstraint);
   if (includeCommonFiles) {
     package.changelogFile.writeAsStringSync('''
 ## $version
@@ -167,7 +178,8 @@ RepositoryPackage createFakePackage(
         includeCommonFiles: false,
         isFlutter: isFlutter,
         publishTo: 'none',
-        flutterConstraint: flutterConstraint);
+        flutterConstraint: flutterConstraint,
+        dartConstraint: dartConstraint);
   } else if (examples.isNotEmpty) {
     final Directory examplesDirectory = getExampleDir(package)..createSync();
     for (final String exampleName in examples) {
@@ -176,7 +188,8 @@ RepositoryPackage createFakePackage(
           includeCommonFiles: false,
           isFlutter: isFlutter,
           publishTo: 'none',
-          flutterConstraint: flutterConstraint);
+          flutterConstraint: flutterConstraint,
+          dartConstraint: dartConstraint);
     }
   }
 
@@ -189,7 +202,7 @@ RepositoryPackage createFakePackage(
   return package;
 }
 
-/// Creates a `pubspec.yaml` file with a flutter dependency.
+/// Creates a `pubspec.yaml` file for [package].
 ///
 /// [platformSupport] is a map of platform string to the support details for
 /// that platform. If empty, no `plugin` entry will be created unless `isPlugin`
@@ -203,8 +216,8 @@ void createFakePubspec(
       const <String, PlatformDetails>{},
   String? publishTo,
   String? version,
-  String dartConstraint = '>=2.0.0 <3.0.0',
-  String flutterConstraint = '>=2.5.0',
+  String dartConstraint = _defaultDartConstraint,
+  String flutterConstraint = _defaultFlutterConstraint,
 }) {
   isPlugin |= platformSupport.isNotEmpty;
 


### PR DESCRIPTION
Adds a `skip-if-not-supporting-dart-version` corresponding to the
existing `skip-if-not-supporting-dart-version` but for packages without
Flutter constraints. The need for this has come up several times in
flutter/packages.

This uses a new flag instead of adding a Flutter->Dart version mapping
because it means that we can continue to update the legacy test
configurations just by adjusting the CI scripts, rather than needing to
make a new tool change to update the mapping every time we roll the
legacy tests forward a version.

Fixes https://github.com/flutter/flutter/issues/100389

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
