### PR TITLE
[google_maps] delay mapView destruction by one frame to prevent NullpointerException

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+
+* Fixes `NullPointerException` that crashes the app, triggered by immediately disposing widget after its creation.
 
 ## 2.1.12
 

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,7 +1,3 @@
-## NEXT
-
-* Fixes `NullPointerException` that crashes the app, triggered by immediately disposing widget after its creation.
-
 ## 2.1.12
 
 * Fixes violations of new analysis option use_named_constants.

--- a/packages/google_maps_flutter/google_maps_flutter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/google_maps_flutter/google_maps_flutter/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+* Add workaround for NullPointerException triggered by map destruction.
 * Fixes violations of new analysis option use_named_constants.
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,6 +1,6 @@
-## NEXT
+## 2.1.11
 
-* Add workaround for NullPointerException triggered by map destruction.
+* Adds workaround for NullPointerException triggered by map destruction.
 * Fixes violations of new analysis option use_named_constants.
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -890,10 +890,11 @@ final class GoogleMapController
     }
     // This fixes an issue where the mapView is still being used by the render thread after disposal.
     // Delaying the actual mapView disposal to the next frame avoids the issue.
-    postFrameCallback(() -> {
-      mapView.onDestroy();
-      mapView = null;
-    });
+    postFrameCallback(
+        () -> {
+          mapView.onDestroy();
+          mapView = null;
+        });
   }
 
   public void setIndoorEnabled(boolean indoorEnabled) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -890,25 +890,29 @@ final class GoogleMapController
     if (mapView == null) {
       return;
     }
-    
-    MapsInitializer.initialize(context, null, (renderer -> {
-      if(renderer == MapsInitializer.Renderer.LEGACY){
-        // This fixes an issue where the mapView is still being used by the render thread after disposal.
-        // Delaying the actual mapView disposal to the next frame avoids the issue.
-        Handler handler = new Handler();
-        Runnable r = new Runnable() {
-          @Override
-          public void run() {
+
+    MapsInitializer.initialize(
+        context,
+        null,
+        (renderer -> {
+          if (renderer == MapsInitializer.Renderer.LEGACY) {
+            // This fixes an issue where the mapView is still being used by the render thread after disposal.
+            // Delaying the actual mapView disposal to the next frame avoids the issue.
+            Handler handler = new Handler();
+            Runnable r =
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    mapView.onDestroy();
+                    mapView = null;
+                  }
+                };
+            handler.postDelayed(r, 100);
+          } else {
             mapView.onDestroy();
             mapView = null;
           }
-        };
-        handler.postDelayed(r, 100);
-      } else {
-        mapView.onDestroy();
-        mapView = null;
-      }
-    }));
+        }));
   }
 
   public void setIndoorEnabled(boolean indoorEnabled) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -888,8 +888,10 @@ final class GoogleMapController
     if (mapView == null) {
       return;
     }
-    mapView.onDestroy();
-    mapView = null;
+    postFrameCallback(() -> {
+      mapView.onDestroy();
+      mapView = null;
+    });
   }
 
   public void setIndoorEnabled(boolean indoorEnabled) {

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -891,6 +891,8 @@ final class GoogleMapController
       return;
     }
 
+    final MapView mapReference = mapView;
+    mapView = null;
     MapsInitializer.initialize(
         context,
         null,
@@ -903,14 +905,12 @@ final class GoogleMapController
                 new Runnable() {
                   @Override
                   public void run() {
-                    mapView.onDestroy();
-                    mapView = null;
+                    mapReference.onDestroy();
                   }
                 };
             handler.postDelayed(r, 100);
           } else {
-            mapView.onDestroy();
-            mapView = null;
+            mapReference.onDestroy();
           }
         }));
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -888,6 +888,8 @@ final class GoogleMapController
     if (mapView == null) {
       return;
     }
+    // This fixes an issue where the mapView is still being used by the render thread after disposal.
+    // Delaying the actual mapView disposal to the next frame avoids the issue.
     postFrameCallback(() -> {
       mapView.onDestroy();
       mapView = null;

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MapsInitializerFunction.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MapsInitializerFunction.java
@@ -1,0 +1,15 @@
+package io.flutter.plugins.googlemaps;
+
+import android.content.Context;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import com.google.android.gms.maps.MapsInitializer;
+import com.google.android.gms.maps.OnMapsSdkInitializedCallback;
+
+@FunctionalInterface
+public interface MapsInitializerFunction {
+  int initialize(
+      @NonNull Context context,
+      @Nullable MapsInitializer.Renderer preferredRenderer,
+      @Nullable OnMapsSdkInitializedCallback callback);
+}

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MapsInitializerFunction.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MapsInitializerFunction.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugins.googlemaps;
 
 import android.content.Context;


### PR DESCRIPTION
This PR fixes an issue where the google_maps_flutter packages throws a platform error, which causes the app to crash.

Most of the explanation below can also be read here, as well as the discussions around it: https://github.com/flutter/flutter/issues/105965

This is the error that is thrown:
```
E/AndroidRuntime( 5262): FATAL EXCEPTION: GLThread 7073
E/AndroidRuntime( 5262): Process: org.vinitor.app, PID: 5262
E/AndroidRuntime( 5262): java.lang.NullPointerException: Attempt to get length of null array
E/AndroidRuntime( 5262): 	at java.nio.ByteBufferAsIntBuffer.put(ByteBufferAsIntBuffer.java:122)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.buffer.n.i(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):2)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.buffer.n.d(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):3)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.drawable.y.s(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):16)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.gl.drawable.ao.s(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):11)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.bz.s(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):29)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.bs.b(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):151)
E/AndroidRuntime( 5262): 	at com.google.maps.api.android.lib6.gmm6.vector.av.run(:com.google.android.gms.dynamite_mapsdynamite@222413104@22.24.13 (190800-0):48)
I/Process ( 5262): Sending signal. PID: 5262 SIG: 9
```

It seems that this problem is caused by disposing the `GoogleMap` Widget to quickly after creating it. This can be the case, if the widget is inside a tab and tabs are quickly switched or inside a route where the route is popped quickly after navigation.

I have created a repo to demonstrate and reproduce this issue here: https://github.com/lukaskurz/gmaps_crash_demo
Using the example app, I noticed that the bug is related to the initalPosition, namely if the initialPosition has zoomLevel set, which (i assume) requires a camera animation after creating the widget. Tab 1 and 2 have a zoomLevel set, while 3 and 4 have not. One can observe that switching between 3-4 quickly does not cause any issues, while 1 and 2 will trigger the bug.

https://user-images.githubusercontent.com/22956519/178498796-64469b74-816f-424c-8e5c-571e6f789449.mp4

After doing some more debugging (i.e. putting hundreds of Log.d calls everywhere in the code), I figured out that removing the `mapView.onDestroy()` stops the issue from happening.

[GoogleMapsController.java:890](https://github.com/flutter/plugins/blob/68cdc58aa67b82209c9eeb832d3e95c9734e3983/packages/google_maps_flutter/google_maps_flutter/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java#L890)
```java
  private void destroyMapViewIfNecessary() {
    Log.d("ShortyDebug", "destroyMapViewIfNecessary");
    if (mapView == null) {
      return;
    }
    //mapView.onDestroy();
    mapView = null;
    Log.d("ShortyDebug", "destroyMapViewIfNecessary done");
  }
```

Which makes sense, since the bug is likely triggered by the GL renderer accessing an array, which has already been garbage collected, so by not triggering the GC for the mapView, the bug does not happen. This is hardly a fix though, since we now probably have a memory leak on our hands.

A comment in the code, mentioned by @martin-braun, talks about using a 2 frame delay for some animation related stuff, which got me the idea of delaying the `onDestroy` by 1 frame, which as it turns out fixes the bug. Since the `mapView.onDestroy()` leads into the proprietary part of the code, which I cannot see or read, I can now only speculate why and how this fixes the problem:

The GL renderer is likely still accessing the view and its variable, not knowing that view is on it's way to be marked for GC (since this likely happens a bit further down the codepath). It triggers a camera animation (or something similar) for the initialPosition, which will not throw any error or be cancelled immediately, because the view is still not marked for GC (but will be a few steps later). But if we mark everything as disposed, while delaying the actual `onDestroy` of the view by 1 frame, then during the next frame calculation, the animation code in the rendered can see that it should cancel the animation, since the widget is being disposed and only after that cancelling do we actually destroy the view.

Atleast that's how I imagined/pieced this together in my head, with the little understanding about engine rendering loops I have from some old game engine experience. I don't actually know what happens here and the background, but the fix seems to work, so I guess there might be something to my theory :sweat_smile: 

**TLDR;** Quickly pushing and popping pages containing a `GoogleMaps` Widget, can trigger a NullpointerException in it's rendering code causing the app to crash. This is likely caused by part of the disposal code eagerly destroying stuff, while part of the initialization is still running and using now GCed variables. The fix delays part of the disposal code by 1 frame, giving the initialization enough time to realize stuff is no longer available and it has to stop.

Fixes https://github.com/flutter/flutter/issues/105965
There also plenty of issues regarding this on the google maps issue tracker (mentioned in above issue). So there is likely a problem inside Google's code, which they have to fix themselves.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
