### PR TITLE
[file_selector] Add `allowsAny` to `XTypeGroup`

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 2.1.0
 
-* Removes unnecessary imports.
+* Adds `allowsAny` to `XTypeGroup` as a simple and future-proof way of identifying
+  wildcard groups.
 
 ## 2.0.4
 

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -42,6 +42,14 @@ class XTypeGroup {
     };
   }
 
+  /// True if this type group should allow any file.
+  bool get allowsAny {
+    return (extensions?.isEmpty ?? true) &&
+        (mimeTypes?.isEmpty ?? true) &&
+        (macUTIs?.isEmpty ?? true) &&
+        (webWildCards?.isEmpty ?? true);
+  }
+
   static List<String>? _removeLeadingDots(List<String>? exts) => exts
       ?.map((String ext) => ext.startsWith('.') ? ext.substring(1) : ext)
       .toList();

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.4
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -40,6 +40,35 @@ void main() {
       expect(jsonMap['mimeTypes'], null);
       expect(jsonMap['macUTIs'], null);
       expect(jsonMap['webWildCards'], null);
+      expect(group.allowsAny, true);
+    });
+
+    test('allowsAny treats empty arrays the same as null', () {
+      final XTypeGroup group = XTypeGroup(
+        label: 'Any',
+        extensions: <String>[],
+        mimeTypes: <String>[],
+        macUTIs: <String>[],
+        webWildCards: <String>[],
+      );
+
+      expect(group.allowsAny, true);
+    });
+
+    test('allowsAny returns false if anything is set', () {
+      final XTypeGroup extensionOnly =
+          XTypeGroup(label: 'extensions', extensions: <String>['txt']);
+      final XTypeGroup mimeOnly =
+          XTypeGroup(label: 'mime', mimeTypes: <String>['text/plain']);
+      final XTypeGroup utiOnly =
+          XTypeGroup(label: 'utis', macUTIs: <String>['public.text']);
+      final XTypeGroup webOnly =
+          XTypeGroup(label: 'web', webWildCards: <String>['.txt']);
+
+      expect(extensionOnly.allowsAny, false);
+      expect(mimeOnly.allowsAny, false);
+      expect(utiOnly.allowsAny, false);
+      expect(webOnly.allowsAny, false);
     });
 
     test('Leading dots are removed from extensions', () {


### PR DESCRIPTION
It's come up several time in implementations that we want to identify
wildcard groups in order to handle them specially. The logic for it is
somewhat cumbersome, especially since the collections were unfortunately
made nullable (meaning there's two different ways for them to be empty),
and it's also not future-proof as other types could potentially be added
in the future.

This consolidates that logic into the group itself, so that it can be
updated centrally in the future.

Part of https://github.com/flutter/flutter/issues/107469

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
