### PR TITLE
fix payment discount (iOS Promotional Offers) into being actually usable

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -273,7 +273,7 @@
     return nil;
   }
 
-  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || [timestamp intValue] <= 0) {
+  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || timestamp <= 0) {
     if (error) {
       *error = @"When specifying a payment discount the 'timestamp' field is mandatory.";
     }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -233,7 +233,7 @@
 
 + (SKPaymentDiscount *)getSKPaymentDiscountFromMap:(NSDictionary *)map
                                          withError:(NSString **)error {
-  if (!map || map.count <= 0) {
+  if (!map || [map isKindOfClass:[NSNull class]] || map.count <= 0) {
     return nil;
   }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -81,6 +81,20 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
     return true; // There's no error feedback from iOS here to return.
   }
 
+  static Future<bool> buyNonConsumableWithDiscount(
+      {required PurchaseParam purchaseParam, SKPaymentDiscountWrapper? discount}) async {
+    await _skPaymentQueueWrapper.addPayment(SKPaymentWrapper(
+      productIdentifier: purchaseParam.productDetails.id,
+      quantity: purchaseParam is AppStorePurchaseParam ? purchaseParam.quantity : 1,
+      applicationUsername: purchaseParam.applicationUserName,
+      simulatesAskToBuyInSandbox: purchaseParam is AppStorePurchaseParam && purchaseParam.simulatesAskToBuyInSandbox,
+      requestData: null,
+      paymentDiscount: discount,
+    ));
+
+    return true; // There's no error feedback from iOS here to return.
+  }
+
   @override
   Future<bool> buyConsumable(
       {required PurchaseParam purchaseParam, bool autoConsume = true}) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -405,7 +405,8 @@ class SKPaymentWrapper {
       'applicationUsername': applicationUsername,
       'requestData': requestData,
       'quantity': quantity,
-      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox
+      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox,
+      'paymentDiscount': paymentDiscount?.toMap(),
     };
   }
 


### PR DESCRIPTION
Make iOS Promotional Offers in in_app_purchase plugin usable

Resolves: [[in-app-purchase][iOS] Promotional Offers in iOS not working](https://github.com/flutter/flutter/issues/107533#issue-1303299545)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
