### PR TITLE
[webview_flutter_wkwebvew] Fix UIScrollView regression for inset behavior

### DIFF
--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.1
+
+* Fixes regression where the behavior for the `UIScrollView` insets were removed.
+
 ## 2.9.0
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
@@ -411,7 +411,7 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   XCTAssertEqualObjects(errorData.localizedDescription, @"description");
 }
 
-- (void)testWebViewContentInsetBehaviorShouldBeNeverOnIOS11 {
+- (void)testWebViewContentInsetBehaviorShouldBeNeverOnIOS11 API_AVAILABLE(ios(11.0)) {
   FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
   FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
       initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
@@ -423,13 +423,12 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   [hostAPI createWithIdentifier:@1 configurationIdentifier:@0 error:&error];
   FWFWebView *webView = (FWFWebView *)[instanceManager instanceForIdentifier:1];
 
-  if (@available(iOS 11, *)) {
-    XCTAssertEqual(webView.scrollView.contentInsetAdjustmentBehavior,
-                   UIScrollViewContentInsetAdjustmentNever);
-  }
+  XCTAssertEqual(webView.scrollView.contentInsetAdjustmentBehavior,
+                 UIScrollViewContentInsetAdjustmentNever);
 }
 
-- (void)testScrollViewsAutomaticallyAdjustsScrollIndicatorInsetsShouldbeNoOnIOS13 {
+- (void)testScrollViewsAutomaticallyAdjustsScrollIndicatorInsetsShouldbeNoOnIOS13 API_AVAILABLE(
+    ios(13.0)) {
   FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
   FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
       initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
@@ -441,9 +440,7 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   [hostAPI createWithIdentifier:@1 configurationIdentifier:@0 error:&error];
   FWFWebView *webView = (FWFWebView *)[instanceManager instanceForIdentifier:1];
 
-  if (@available(iOS 13, *)) {
-    XCTAssertFalse(webView.scrollView.automaticallyAdjustsScrollIndicatorInsets);
-  }
+  XCTAssertFalse(webView.scrollView.automaticallyAdjustsScrollIndicatorInsets);
 }
 
 - (void)testContentInsetsSumAlwaysZeroAfterSetFrame {

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
@@ -429,7 +429,7 @@ static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
   }
 }
 
-- (void)testWebViewScrollIndicatorAticautomaticallyAdjustsScrollIndicatorInsetsShouldbeNoOnIOS13 {
+- (void)testScrollViewsAutomaticallyAdjustsScrollIndicatorInsetsShouldbeNoOnIOS13 {
   FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
   FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
       initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/ios/RunnerTests/FWFWebViewHostApiTests.m
@@ -8,6 +8,8 @@
 
 #import <OCMock/OCMock.h>
 
+static bool feq(CGFloat a, CGFloat b) { return fabs(b - a) < FLT_EPSILON; }
+
 @interface FWFWebViewHostApiTests : XCTestCase
 @end
 
@@ -407,5 +409,64 @@
   XCTAssertEqualObjects(errorData.code, @0);
   XCTAssertEqualObjects(errorData.domain, @"errorDomain");
   XCTAssertEqualObjects(errorData.localizedDescription, @"description");
+}
+
+- (void)testWebViewContentInsetBehaviorShouldBeNeverOnIOS11 {
+  FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
+  FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
+      initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
+              instanceManager:instanceManager];
+
+  [instanceManager addDartCreatedInstance:[[WKWebViewConfiguration alloc] init] withIdentifier:0];
+
+  FlutterError *error;
+  [hostAPI createWithIdentifier:@1 configurationIdentifier:@0 error:&error];
+  FWFWebView *webView = (FWFWebView *)[instanceManager instanceForIdentifier:1];
+
+  if (@available(iOS 11, *)) {
+    XCTAssertEqual(webView.scrollView.contentInsetAdjustmentBehavior,
+                   UIScrollViewContentInsetAdjustmentNever);
+  }
+}
+
+- (void)testWebViewScrollIndicatorAticautomaticallyAdjustsScrollIndicatorInsetsShouldbeNoOnIOS13 {
+  FWFInstanceManager *instanceManager = [[FWFInstanceManager alloc] init];
+  FWFWebViewHostApiImpl *hostAPI = [[FWFWebViewHostApiImpl alloc]
+      initWithBinaryMessenger:OCMProtocolMock(@protocol(FlutterBinaryMessenger))
+              instanceManager:instanceManager];
+
+  [instanceManager addDartCreatedInstance:[[WKWebViewConfiguration alloc] init] withIdentifier:0];
+
+  FlutterError *error;
+  [hostAPI createWithIdentifier:@1 configurationIdentifier:@0 error:&error];
+  FWFWebView *webView = (FWFWebView *)[instanceManager instanceForIdentifier:1];
+
+  if (@available(iOS 13, *)) {
+    XCTAssertFalse(webView.scrollView.automaticallyAdjustsScrollIndicatorInsets);
+  }
+}
+
+- (void)testContentInsetsSumAlwaysZeroAfterSetFrame {
+  FWFWebView *webView = [[FWFWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 400)
+                                            configuration:[[WKWebViewConfiguration alloc] init]];
+
+  webView.scrollView.contentInset = UIEdgeInsetsMake(0, 0, 300, 0);
+  XCTAssertFalse(UIEdgeInsetsEqualToEdgeInsets(webView.scrollView.contentInset, UIEdgeInsetsZero));
+
+  webView.frame = CGRectMake(0, 0, 300, 200);
+  XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(webView.scrollView.contentInset, UIEdgeInsetsZero));
+  XCTAssertTrue(CGRectEqualToRect(webView.frame, CGRectMake(0, 0, 300, 200)));
+
+  if (@available(iOS 11, *)) {
+    // After iOS 11, we need to make sure the contentInset compensates the adjustedContentInset.
+    UIScrollView *partialMockScrollView = OCMPartialMock(webView.scrollView);
+    UIEdgeInsets insetToAdjust = UIEdgeInsetsMake(0, 0, 300, 0);
+    OCMStub(partialMockScrollView.adjustedContentInset).andReturn(insetToAdjust);
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(webView.scrollView.contentInset, UIEdgeInsetsZero));
+
+    webView.frame = CGRectMake(0, 0, 300, 100);
+    XCTAssertTrue(feq(webView.scrollView.contentInset.bottom, -insetToAdjust.bottom));
+    XCTAssertTrue(CGRectEqualToRect(webView.frame, CGRectMake(0, 0, 300, 100)));
+  }
 }
 @end

--- a/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.m
+++ b/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FWFWebViewHostApi.m
@@ -20,6 +20,12 @@
   if (self) {
     _objectApi = [[FWFObjectFlutterApiImpl alloc] initWithBinaryMessenger:binaryMessenger
                                                           instanceManager:instanceManager];
+    if (@available(iOS 11.0, *)) {
+      self.scrollView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
+      if (@available(iOS 13.0, *)) {
+        self.scrollView.automaticallyAdjustsScrollIndicatorInsets = NO;
+      }
+    }
   }
   return self;
 }

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.9.0
+version: 2.9.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
It looks like these lines were missed when creating the new implementation: https://github.com/flutter/plugins/blob/bdec9bad73da186c30f42eb105b84e6b17eeaf31/packages/webview_flutter/webview_flutter_wkwebview/ios/Classes/FlutterWebView.m#L128-L133

This PR adds them to `FWFWebView` and adds the tests from the old implementation to verify these settings.

Fixes: https://github.com/flutter/flutter/issues/107639

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
