### PR TITLE
[camera_windows] Allow retrying after initialization failure

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+4
+
+* Allows retrying camera initialization after error.
+
 ## 0.1.0+3
 
 * Updates the README to better explain how to use the unendorsed package.

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.1.0+3
+version: 0.1.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/windows/camera.cpp
+++ b/packages/camera/camera_windows/windows/camera.cpp
@@ -28,17 +28,17 @@ CameraImpl::~CameraImpl() {
                              "Plugin disposed before request was handled");
 }
 
-void CameraImpl::InitCamera(flutter::TextureRegistrar* texture_registrar,
+bool CameraImpl::InitCamera(flutter::TextureRegistrar* texture_registrar,
                             flutter::BinaryMessenger* messenger,
                             bool record_audio,
                             ResolutionPreset resolution_preset) {
   auto capture_controller_factory =
       std::make_unique<CaptureControllerFactoryImpl>();
-  InitCamera(std::move(capture_controller_factory), texture_registrar,
-             messenger, record_audio, resolution_preset);
+  return InitCamera(std::move(capture_controller_factory), texture_registrar,
+                    messenger, record_audio, resolution_preset);
 }
 
-void CameraImpl::InitCamera(
+bool CameraImpl::InitCamera(
     std::unique_ptr<CaptureControllerFactory> capture_controller_factory,
     flutter::TextureRegistrar* texture_registrar,
     flutter::BinaryMessenger* messenger, bool record_audio,
@@ -47,8 +47,8 @@ void CameraImpl::InitCamera(
   messenger_ = messenger;
   capture_controller_ =
       capture_controller_factory->CreateCaptureController(this);
-  capture_controller_->InitCaptureDevice(texture_registrar, device_id_,
-                                         record_audio, resolution_preset);
+  return capture_controller_->InitCaptureDevice(
+      texture_registrar, device_id_, record_audio, resolution_preset);
 }
 
 bool CameraImpl::AddPendingResult(

--- a/packages/camera/camera_windows/windows/camera.h
+++ b/packages/camera/camera_windows/windows/camera.h
@@ -63,7 +63,9 @@ class Camera : public CaptureControllerListener {
   virtual camera_windows::CaptureController* GetCaptureController() = 0;
 
   // Initializes this camera and its associated capture controller.
-  virtual void InitCamera(flutter::TextureRegistrar* texture_registrar,
+  //
+  // Returns false if initialization fails.
+  virtual bool InitCamera(flutter::TextureRegistrar* texture_registrar,
                           flutter::BinaryMessenger* messenger,
                           bool record_audio,
                           ResolutionPreset resolution_preset) = 0;
@@ -116,7 +118,7 @@ class CameraImpl : public Camera {
   camera_windows::CaptureController* GetCaptureController() override {
     return capture_controller_.get();
   }
-  void InitCamera(flutter::TextureRegistrar* texture_registrar,
+  bool InitCamera(flutter::TextureRegistrar* texture_registrar,
                   flutter::BinaryMessenger* messenger, bool record_audio,
                   ResolutionPreset resolution_preset) override;
 
@@ -124,7 +126,9 @@ class CameraImpl : public Camera {
   //
   // This is a convenience method called by |InitCamera| but also used in
   // tests.
-  void InitCamera(
+  //
+  // Returns false if initialization fails.
+  bool InitCamera(
       std::unique_ptr<CaptureControllerFactory> capture_controller_factory,
       flutter::TextureRegistrar* texture_registrar,
       flutter::BinaryMessenger* messenger, bool record_audio,

--- a/packages/camera/camera_windows/windows/camera_plugin.cpp
+++ b/packages/camera/camera_windows/windows/camera_plugin.cpp
@@ -398,9 +398,11 @@ void CameraPlugin::CreateMethodHandler(
       resolution_preset = ResolutionPreset::kAuto;
     }
 
-    camera->InitCamera(texture_registrar_, messenger_, *record_audio,
-                       resolution_preset);
-    cameras_.push_back(std::move(camera));
+    bool initialized = camera->InitCamera(texture_registrar_, messenger_,
+                                          *record_audio, resolution_preset);
+    if (initialized) {
+      cameras_.push_back(std::move(camera));
+    }
   }
 }
 

--- a/packages/camera/camera_windows/windows/capture_controller.cpp
+++ b/packages/camera/camera_windows/windows/capture_controller.cpp
@@ -288,17 +288,19 @@ void CaptureControllerImpl::ResetCaptureController() {
   texture_handler_ = nullptr;
 }
 
-void CaptureControllerImpl::InitCaptureDevice(
+bool CaptureControllerImpl::InitCaptureDevice(
     flutter::TextureRegistrar* texture_registrar, const std::string& device_id,
     bool record_audio, ResolutionPreset resolution_preset) {
   assert(capture_controller_listener_);
 
   if (IsInitialized()) {
-    return capture_controller_listener_->OnCreateCaptureEngineFailed(
+    capture_controller_listener_->OnCreateCaptureEngineFailed(
         "Capture device already initialized");
+    return false;
   } else if (capture_engine_state_ == CaptureEngineState::kInitializing) {
-    return capture_controller_listener_->OnCreateCaptureEngineFailed(
+    capture_controller_listener_->OnCreateCaptureEngineFailed(
         "Capture device already initializing");
+    return false;
   }
 
   capture_engine_state_ = CaptureEngineState::kInitializing;
@@ -315,7 +317,7 @@ void CaptureControllerImpl::InitCaptureDevice(
       capture_controller_listener_->OnCreateCaptureEngineFailed(
           "Failed to create camera");
       ResetCaptureController();
-      return;
+      return false;
     }
 
     media_foundation_started_ = true;
@@ -326,8 +328,10 @@ void CaptureControllerImpl::InitCaptureDevice(
     capture_controller_listener_->OnCreateCaptureEngineFailed(
         "Failed to create camera");
     ResetCaptureController();
-    return;
+    return false;
   }
+
+  return true;
 }
 
 void CaptureControllerImpl::TakePicture(const std::string& file_path) {

--- a/packages/camera/camera_windows/windows/capture_controller.h
+++ b/packages/camera/camera_windows/windows/capture_controller.h
@@ -75,6 +75,9 @@ class CaptureController {
 
   // Initializes the capture controller with the specified device id.
   //
+  // Returns false if the capture controller could not be initialized
+  // or is already initialized.
+  //
   // texture_registrar: Pointer to Flutter TextureRegistrar instance. Used to
   //                    register texture for capture preview.
   // device_id:         A string that holds information of camera device id to
@@ -82,7 +85,7 @@ class CaptureController {
   // record_audio:      A boolean value telling if audio should be captured on
   //                    video recording.
   // resolution_preset: Maximum capture resolution height.
-  virtual void InitCaptureDevice(TextureRegistrar* texture_registrar,
+  virtual bool InitCaptureDevice(TextureRegistrar* texture_registrar,
                                  const std::string& device_id,
                                  bool record_audio,
                                  ResolutionPreset resolution_preset) = 0;
@@ -132,7 +135,7 @@ class CaptureControllerImpl : public CaptureController,
   CaptureControllerImpl& operator=(const CaptureControllerImpl&) = delete;
 
   // CaptureController
-  void InitCaptureDevice(TextureRegistrar* texture_registrar,
+  bool InitCaptureDevice(TextureRegistrar* texture_registrar,
                          const std::string& device_id, bool record_audio,
                          ResolutionPreset resolution_preset) override;
   uint32_t GetPreviewWidth() const override { return preview_frame_width_; }

--- a/packages/camera/camera_windows/windows/test/mocks.h
+++ b/packages/camera/camera_windows/windows/test/mocks.h
@@ -182,7 +182,7 @@ class MockCamera : public Camera {
   MOCK_METHOD(camera_windows::CaptureController*, GetCaptureController, (),
               (override));
 
-  MOCK_METHOD(void, InitCamera,
+  MOCK_METHOD(bool, InitCamera,
               (flutter::TextureRegistrar * texture_registrar,
                flutter::BinaryMessenger* messenger, bool record_audio,
                ResolutionPreset resolution_preset),
@@ -212,7 +212,7 @@ class MockCaptureController : public CaptureController {
  public:
   ~MockCaptureController() = default;
 
-  MOCK_METHOD(void, InitCaptureDevice,
+  MOCK_METHOD(bool, InitCaptureDevice,
               (flutter::TextureRegistrar * texture_registrar,
                const std::string& device_id, bool record_audio,
                ResolutionPreset resolution_preset),


### PR DESCRIPTION
*My C++ is incredibly rusty. Please feel free to provide any and all suggestions kindly 😄*

Currently, a camera becomes "stuck" in a bad state if a camera fails to initialize once on Windows. For example, you will need to relaunch your app if the camera fails to initialize due to a permissions error - you cannot enable camera access and retry creating the camera.

This issue happens because the plugin incorrectly keeps cameras even if they failed to initialize: https://github.com/flutter/plugins/blob/28eff0a8c167d146d73d62aa21a7d93d95bc2578/packages/camera/camera_windows/windows/camera_plugin.cpp#L401-L403

Fixes https://github.com/flutter/flutter/issues/107858

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
