### PR TITLE
[tool] Bypass version/changelog checks for some PRs

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## NEXT
+
+- Bypasses version and CHANGELOG checks for Dependabot PRs for packages
+  that are known not to be client-affecting.
+
 ## 0.8.8
 
 - Allows pre-release versions in `version-check`.

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -625,7 +625,7 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
       return false;
     }
 
-    // A string that is in all Dependabot PRs, but extreemly unlikely to be in
+    // A string that is in all Dependabot PRs, but extremely unlikely to be in
     // any other PR, to identify Dependabot PRs.
     const String dependabotMarker = 'Dependabot commands and options';
     // Expression to extract the name of the dependency being updated.

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -569,11 +569,15 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
     }
 
     if (state.needsVersionChange) {
-      if (_getChangeDescription().split('\n').any((String line) =>
+      final String changeDescription = _getChangeDescription();
+      if (changeDescription.split('\n').any((String line) =>
           line.startsWith(_missingVersionChangeJustificationMarker))) {
         logWarning('Ignoring lack of version change due to '
             '"$_missingVersionChangeJustificationMarker" in the '
             'change description.');
+      } else if (_isAllowedDependabotChange(package, changeDescription)) {
+        logWarning('Ignoring lack of version change for Dependabot change to '
+            'a known internal dependency.');
       } else {
         printError(
             'No version change found, but the change to this package could '
@@ -587,11 +591,15 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
     }
 
     if (!state.hasChangelogChange) {
-      if (_getChangeDescription().split('\n').any((String line) =>
+      final String changeDescription = _getChangeDescription();
+      if (changeDescription.split('\n').any((String line) =>
           line.startsWith(_missingChangelogChangeJustificationMarker))) {
         logWarning('Ignoring lack of CHANGELOG update due to '
             '"$_missingChangelogChangeJustificationMarker" in the '
             'change description.');
+      } else if (_isAllowedDependabotChange(package, changeDescription)) {
+        logWarning('Ignoring lack of CHANGELOG update for Dependabot change to '
+            'a known internal dependency.');
       } else {
         printError(
             'No CHANGELOG change found. If this PR needs an exemption from '
@@ -604,5 +612,47 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
     }
 
     return null;
+  }
+
+  /// Returns true if [changeDescription] matches a Dependabot change for a
+  /// dependency roll that should bypass the normal version and CHANGELOG change
+  /// checks (for dependencies that are known not to have client impact).
+  bool _isAllowedDependabotChange(
+      RepositoryPackage package, String changeDescription) {
+    // Espresso exports some dependencies that are normally just internal test
+    // utils, so always require reviewers to check that.
+    if (package.directory.basename == 'espresso') {
+      return false;
+    }
+
+    // A string that is in all Dependabot PRs, but extreemly unlikely to be in
+    // any other PR, to identify Dependabot PRs.
+    const String dependabotMarker = 'Dependabot commands and options';
+    // Expression to extract the name of the dependency being updated.
+    final RegExp dependencyRegex =
+        RegExp(r'Bumps? \[(.*?)\]\(.*?\) from [\d.]+ to [\d.]+');
+
+    // Allowed exact dependency names.
+    const Set<String> allowedDependencies = <String>{
+      'junit',
+      'robolectric',
+    };
+    const Set<String> allowedDependencyPrefixes = <String>{
+      'mockito-' // mockito-core, mockito-inline, etc.
+    };
+
+    if (changeDescription.contains(dependabotMarker)) {
+      final Match? match = dependencyRegex.firstMatch(changeDescription);
+      if (match != null) {
+        final String dependency = match.group(1)!;
+        if (allowedDependencies.contains(dependency) ||
+            allowedDependencyPrefixes
+                .any((String prefix) => dependency.startsWith(prefix))) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 }

--- a/script/tool/test/version_check_command_test.dart
+++ b/script/tool/test/version_check_command_test.dart
@@ -40,6 +40,55 @@ void testAllowedVersion(
   }
 }
 
+String _generateFakeDependabotPRDescription(String package) {
+  return '''
+Bumps [$package](https://github.com/foo/$package) from 1.0.0 to 2.0.0.
+<details>
+<summary>Release notes</summary>
+<p><em>Sourced from <a href="https://github.com/foo/$package">$package's releases</a>.</em></p>
+<blockquote>
+...
+</blockquote>
+</details>
+<details>
+<summary>Commits</summary>
+<ul>
+<li>...</li>
+</ul>
+</details>
+<br />
+
+
+[![Dependabot compatibility score](https://dependabot-badges.githubapp.com/badges/compatibility_score?dependency-name=$package&package-manager=gradle&previous-version=1.0.0&new-version=2.0.0)](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)
+
+Dependabot will resolve any conflicts with this PR as long as you don't alter it yourself. You can also trigger a rebase manually by commenting `@dependabot rebase`.
+
+[//]: # (dependabot-automerge-start)
+[//]: # (dependabot-automerge-end)
+
+---
+
+<details>
+<summary>Dependabot commands and options</summary>
+<br />
+
+You can trigger Dependabot actions by commenting on this PR:
+- `@dependabot rebase` will rebase this PR
+- `@dependabot recreate` will recreate this PR, overwriting any edits that have been made to it
+- `@dependabot merge` will merge this PR after your CI passes on it
+- `@dependabot squash and merge` will squash and merge this PR after your CI passes on it
+- `@dependabot cancel merge` will cancel a previously requested merge and block automerging
+- `@dependabot reopen` will reopen this PR if it is closed
+- `@dependabot close` will close this PR and stop Dependabot recreating it. You can achieve the same result by closing it manually
+- `@dependabot ignore this major version` will close this PR and stop Dependabot creating any more for this major version (unless you reopen the PR or upgrade to it yourself)
+- `@dependabot ignore this minor version` will close this PR and stop Dependabot creating any more for this minor version (unless you reopen the PR or upgrade to it yourself)
+- `@dependabot ignore this dependency` will close this PR and stop Dependabot creating any more for this dependency (unless you reopen the PR or upgrade to it yourself)
+
+
+</details>
+''';
+}
+
 class MockProcessResult extends Mock implements io.ProcessResult {}
 
 void main() {
@@ -1077,6 +1126,170 @@ No CHANGELOG change: Code change is only to implementation comments.
                 '"No CHANGELOG change:" in the change description.'),
           ]),
         );
+      });
+
+      group('dependabot', () {
+        test('allows missing version and CHANGELOG change for mockito',
+            () async {
+          final RepositoryPackage plugin =
+              createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+          const String changelog = '''
+## 1.0.0
+* Some changes.
+''';
+          plugin.changelogFile.writeAsStringSync(changelog);
+          processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
+            MockProcess(stdout: 'version: 1.0.0'),
+          ];
+          processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
+            MockProcess(stdout: '''
+packages/plugin/android/build.gradle
+'''),
+          ];
+
+          final File changeDescriptionFile =
+              fileSystem.file('change_description.txt');
+          changeDescriptionFile.writeAsStringSync(
+              _generateFakeDependabotPRDescription('mockito-core'));
+
+          final List<String> output =
+              await _runWithMissingChangeDetection(<String>[
+            '--change-description-file=${changeDescriptionFile.path}'
+          ]);
+
+          expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Ignoring lack of version change for Dependabot '
+                  'change to a known internal dependency.'),
+              contains('Ignoring lack of CHANGELOG update for Dependabot '
+                  'change to a known internal dependency.'),
+            ]),
+          );
+        });
+
+        test('allows missing version and CHANGELOG change for robolectric',
+            () async {
+          final RepositoryPackage plugin =
+              createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+          const String changelog = '''
+## 1.0.0
+* Some changes.
+''';
+          plugin.changelogFile.writeAsStringSync(changelog);
+          processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
+            MockProcess(stdout: 'version: 1.0.0'),
+          ];
+          processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
+            MockProcess(stdout: '''
+packages/plugin/android/build.gradle
+'''),
+          ];
+
+          final File changeDescriptionFile =
+              fileSystem.file('change_description.txt');
+          changeDescriptionFile.writeAsStringSync(
+              _generateFakeDependabotPRDescription('robolectric'));
+
+          final List<String> output =
+              await _runWithMissingChangeDetection(<String>[
+            '--change-description-file=${changeDescriptionFile.path}'
+          ]);
+
+          expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Ignoring lack of version change for Dependabot '
+                  'change to a known internal dependency.'),
+              contains('Ignoring lack of CHANGELOG update for Dependabot '
+                  'change to a known internal dependency.'),
+            ]),
+          );
+        });
+
+        test('allows missing version and CHANGELOG change for junit', () async {
+          final RepositoryPackage plugin =
+              createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+          const String changelog = '''
+## 1.0.0
+* Some changes.
+''';
+          plugin.changelogFile.writeAsStringSync(changelog);
+          processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
+            MockProcess(stdout: 'version: 1.0.0'),
+          ];
+          processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
+            MockProcess(stdout: '''
+packages/plugin/android/build.gradle
+'''),
+          ];
+
+          final File changeDescriptionFile =
+              fileSystem.file('change_description.txt');
+          changeDescriptionFile
+              .writeAsStringSync(_generateFakeDependabotPRDescription('junit'));
+
+          final List<String> output =
+              await _runWithMissingChangeDetection(<String>[
+            '--change-description-file=${changeDescriptionFile.path}'
+          ]);
+
+          expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Ignoring lack of version change for Dependabot '
+                  'change to a known internal dependency.'),
+              contains('Ignoring lack of CHANGELOG update for Dependabot '
+                  'change to a known internal dependency.'),
+            ]),
+          );
+        });
+
+        test('fails for dependencies that are not explicitly allowed',
+            () async {
+          final RepositoryPackage plugin =
+              createFakePlugin('plugin', packagesDir, version: '1.0.0');
+
+          const String changelog = '''
+## 1.0.0
+* Some changes.
+''';
+          plugin.changelogFile.writeAsStringSync(changelog);
+          processRunner.mockProcessesForExecutable['git-show'] = <io.Process>[
+            MockProcess(stdout: 'version: 1.0.0'),
+          ];
+          processRunner.mockProcessesForExecutable['git-diff'] = <io.Process>[
+            MockProcess(stdout: '''
+packages/plugin/android/build.gradle
+'''),
+          ];
+
+          final File changeDescriptionFile =
+              fileSystem.file('change_description.txt');
+          changeDescriptionFile.writeAsStringSync(
+              _generateFakeDependabotPRDescription('somethingelse'));
+
+          Error? commandError;
+          final List<String> output =
+              await _runWithMissingChangeDetection(<String>[
+            '--change-description-file=${changeDescriptionFile.path}'
+          ], errorHandler: (Error e) {
+            commandError = e;
+          });
+
+          expect(commandError, isA<ToolExit>());
+          expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('No version change found'),
+              contains('plugin:\n'
+                  '    Missing version change'),
+            ]),
+          );
+        });
       });
     });
 


### PR DESCRIPTION
Dependabot PRs currently always need manual intervention to add either
version/CHANGELOG bumps, or overriddes so that they can be landed
without them, which adds friction to landing those PRs.

Several commonly-updated dependencies are only for internal testing, so
never need version or CHANGELOG changes. This adds an explict allow-list
for Dependabot PRs for those packages to automatically bypass the usual
checks for missing updates, to make them easier to land.

Fixes https://github.com/flutter/flutter/issues/107942

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
