### PR TITLE
[file_selector] Enable ArgumentErrors for type groups

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,6 +1,18 @@
-## NEXT
+## 0.9.0
 
-* Ignores deprecation warnings for upcoming styleFrom button API changes.
+* **BREAKING CHANGE**: The following methods:
+    * `openFile`
+    * `openFiles`
+    * `getSavePath`
+
+  can throw `ArgumentError`s if called with any `XTypeGroup`s that
+  do not contain appropriate filters for the current platform. For
+  example, an `XTypeGroup` that only specifies `webWildCards` will
+  throw on non-web platforms.
+
+  To avoid runtime errors, ensure that all `XTypeGroup`s (other than
+  wildcards) set filters that cover every platform your application
+  targets. See the README for details.
 
 ## 0.8.4+3
 

--- a/packages/file_selector/file_selector/README.md
+++ b/packages/file_selector/file_selector/README.md
@@ -76,5 +76,21 @@ final XFile textFile =
 await textFile.saveTo(path);
 ```
 
+### Filtering by file types
+
+Different platforms support different type group filter options. To avoid
+`ArgumentError`s on some platforms, ensure that any `XTypeGroup`s you pass set
+filters that cover all platforms you are targeting, or that you conditionally
+pass different `XTypeGroup`s based on `Platform`.
+
+|                | macOS  | Web | Windows     |
+|----------------|--------|-----|-------------|
+| `extensions`   | ✔️      | ✔️   | ✔️           |
+| `mimeTypes`    | ✔️†     | ✔️   |             |
+| `macUTIs`      | ✔️      |     |             |
+| `webWildCards` |        | ✔️   |             |
+
+† `mimeTypes` are not supported on version of macOS earlier than 11 (Big Sur).
+
 [example]:./example
 [entitlement]: https://docs.flutter.dev/desktop#entitlements-and-the-app-sandbox

--- a/packages/file_selector/file_selector/lib/file_selector.dart
+++ b/packages/file_selector/file_selector/lib/file_selector.dart
@@ -17,6 +17,8 @@ export 'package:file_selector_platform_interface/file_selector_platform_interfac
 ///   options.
 /// - On macOS, the union of all types allowed by all of the groups will be
 ///   allowed.
+/// Throws an [ArgumentError] if any type groups do not include filters
+/// supported by the current platform.
 ///
 /// [initialDirectory] is the full path to the directory that will be displayed
 /// when the dialog is opened. When not provided, the platform will pick an
@@ -47,6 +49,8 @@ Future<XFile?> openFile({
 ///   options.
 /// - On macOS, the union of all types allowed by all of the groups will be
 ///   allowed.
+/// Throws an [ArgumentError] if any type groups do not include filters
+/// supported by the current platform.
 ///
 /// [initialDirectory] is the full path to the directory that will be displayed
 /// when the dialog is opened. When not provided, the platform will pick an
@@ -75,6 +79,8 @@ Future<List<XFile>> openFiles({
 ///   options.
 /// - On macOS, the union of all types allowed by all of the groups will be
 ///   allowed.
+/// Throws an [ArgumentError] if any type groups do not include filters
+/// supported by the current platform.
 ///
 /// [initialDirectory] is the full path to the directory that will be displayed
 /// when the dialog is opened. When not provided, the platform will pick an

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.8.4+3
+version: 0.9.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -20,10 +20,10 @@ flutter:
         default_package: file_selector_windows
 
 dependencies:
-  file_selector_macos: ^0.8.2
+  file_selector_macos: ^0.9.0
   file_selector_platform_interface: ^2.0.0
-  file_selector_web: ^0.8.1
-  file_selector_windows: ^0.8.2
+  file_selector_web: ^0.9.0
+  file_selector_windows: ^0.9.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Picks up the breaking changes to each implementation that includes
throwing `ArgumentError`s for unsupported type groups, and updates the
documentation accordingly. This is a breaking change for the app-facing
package.

Fixes https://github.com/flutter/flutter/issues/107469

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
