### PR TITLE
[tool] Handle dependabot commit messages

### DIFF
--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -627,7 +627,12 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
 
     // A string that is in all Dependabot PRs, but extremely unlikely to be in
     // any other PR, to identify Dependabot PRs.
-    const String dependabotMarker = 'Dependabot commands and options';
+    const String dependabotPRDescriptionMarker =
+        'Dependabot commands and options';
+    // The same thing, but for the Dependabot commit message, to work around
+    // https://github.com/cirruslabs/cirrus-ci-docs/issues/1029.
+    const String dependabotCommitMessageMarker =
+        'Signed-off-by: dependabot[bot]';
     // Expression to extract the name of the dependency being updated.
     final RegExp dependencyRegex =
         RegExp(r'Bumps? \[(.*?)\]\(.*?\) from [\d.]+ to [\d.]+');
@@ -641,7 +646,8 @@ ${indentation}The first version listed in CHANGELOG.md is $fromChangeLog.
       'mockito-' // mockito-core, mockito-inline, etc.
     };
 
-    if (changeDescription.contains(dependabotMarker)) {
+    if (changeDescription.contains(dependabotPRDescriptionMarker) ||
+        changeDescription.contains(dependabotCommitMessageMarker)) {
       final Match? match = dependencyRegex.firstMatch(changeDescription);
       if (match != null) {
         final String dependency = match.group(1)!;


### PR DESCRIPTION
Follow-up to https://github.com/flutter/plugins/pull/6124; that version
works if the tooling actually gets the PR description, but due to
https://github.com/cirruslabs/cirrus-ci-docs/issues/1029 we may get the
commit message instead, so we need to detect that as well.

Part of https://github.com/flutter/flutter/issues/107942

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
