### PR TITLE
[video_player_web] Document video scrubbing and range requests.

### DIFF
--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.12
+
+* Updates the `README` with:
+  * Information about a common known issue: "Some videos restart when using the
+  seek bar/progress bar/scrubber" (Issue [#49630](https://github.com/flutter/flutter/issues/49360))
+  * Links to the Autoplay information of all major browsers (Chrome/Edge, Firefox, Safari).
+
 ## 2.0.11
 
 * Improves handling of videos with `Infinity` duration.

--- a/packages/video_player/video_player_web/README.md
+++ b/packages/video_player/video_player_web/README.md
@@ -8,21 +8,34 @@ This package is [endorsed](https://flutter.dev/docs/development/packages-and-plu
 which means you can simply use `video_player` normally. This package will be
 automatically included in your app when you do.
 
-## dart:io
+## Limitations on the Web platform
 
-The Web platform does **not** suppport `dart:io`, so attempts to create a `VideoPlayerController.file`
+Video playback on the Web platform has some limitations that might surprise developers
+more familiar with mobile/desktop targets.
+
+In no particular order:
+
+### dart:io
+
+The web platform does **not** suppport `dart:io`, so attempts to create a `VideoPlayerController.file`
 will throw an `UnimplementedError`.
 
-## Autoplay
+### Autoplay
 
-Playing videos without prior interaction with the site might be prohibited
-by the browser and lead to runtime errors. See also:
+Attempts to start playing videos with an audio track (or not muted) without user
+interaction with the site ("user activation") will be prohibited by the browser
+and cause runtime errors in JS.
+
+See also:
 
 * [Autoplay policy in Chrome](https://developer.chrome.com/blog/autoplay/)
 * MDN > [Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide)
 * Delivering Video Content for Safari > [Enable Video Autoplay](https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030251)
+* More info about "user activation", in general:
+  * [Making user activation consistent across APIs](https://developer.chrome.com/blog/user-activation)
+  * HTML Spec: [Tracking user activation](https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation)
 
-## Some videos restart when using the seek bar/progress bar/scrubber
+### Some videos restart when using the seek bar/progress bar/scrubber
 
 Certain videos will rewind to the beginning when users attempt to `seekTo` (change
 the progress/scrub to) another position, instead of jumping to the desired position.
@@ -38,7 +51,7 @@ stored doesn't support [HTTP range requests](https://developer.mozilla.org/en-US
 See [Issue #49360](https://github.com/flutter/flutter/issues/49360) for more information
 on how to diagnose if a server supports range requests or not.
 
-## Mixing audio with other audio sources
+### Mixing audio with other audio sources
 
 The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least
 at the moment. If you use this option it will be silently ignored.
@@ -61,19 +74,23 @@ there for the users of your particular website(s).
 Here's an abridged version of the data from caniuse, for a Global audience:
 
 #### MPEG-4/H.264
+
 [![Data on Global support for the MPEG-4/H.264 video format](https://caniuse.bitsofco.de/image/mpeg4.png)](https://caniuse.com/#feat=mpeg4)
 
 #### WebM
+
 [![Data on Global support for the WebM video format](https://caniuse.bitsofco.de/image/webm.png)](https://caniuse.com/#feat=webm)
 
 #### Ogg/Theora
+
 [![Data on Global support for the Ogg/Theora video format](https://caniuse.bitsofco.de/image/ogv.png)](https://caniuse.com/#feat=ogv)
 
 #### AV1
+
 [![Data on Global support for the AV1 video format](https://caniuse.bitsofco.de/image/av1.png)](https://caniuse.com/#feat=av1)
 
 #### HEVC/H.265
-[![Data on Global support for the HEVC/H.265 video format](https://caniuse.bitsofco.de/image/hevc.png)](https://caniuse.com/#feat=hevc)
 
+[![Data on Global support for the HEVC/H.265 video format](https://caniuse.bitsofco.de/image/hevc.png)](https://caniuse.com/#feat=hevc)
 
 [1]: ../video_player

--- a/packages/video_player/video_player_web/README.md
+++ b/packages/video_player/video_player_web/README.md
@@ -5,20 +5,43 @@ The web implementation of [`video_player`][1].
 ## Usage
 
 This package is [endorsed](https://flutter.dev/docs/development/packages-and-plugins/developing-packages#endorsed-federated-plugin),
-which means you can simply use `video_player`
-normally. This package will be automatically included in your app when you do.
+which means you can simply use `video_player` normally. This package will be
+automatically included in your app when you do.
 
 ## dart:io
 
-The Web platform does **not** suppport `dart:io`, so attempts to create a `VideoPlayerController.file` will throw an `UnimplementedError`.
+The Web platform does **not** suppport `dart:io`, so attempts to create a `VideoPlayerController.file`
+will throw an `UnimplementedError`.
 
 ## Autoplay
+
 Playing videos without prior interaction with the site might be prohibited
-by the browser and lead to runtime errors. See also: https://goo.gl/xX8pDD.
+by the browser and lead to runtime errors. See also:
+
+* [Autoplay policy in Chrome](https://developer.chrome.com/blog/autoplay/)
+* MDN > [Autoplay guide for media and Web Audio APIs](https://developer.mozilla.org/en-US/docs/Web/Media/Autoplay_guide)
+* Delivering Video Content for Safari > [Enable Video Autoplay](https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030251)
+
+## Some videos restart when using the seek bar/progress bar/scrubber
+
+Certain videos will rewind to the beginning when users attempt to `seekTo` (change
+the progress/scrub to) another position, instead of jumping to the desired position.
+Once the video is fully stored in the browser cache, seeking will work fine after
+a full page reload.
+
+The most common explanation for this issue is that the server where the video is
+stored doesn't support [HTTP range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests).
+
+> **NOTE:** Flutter web's local server (the one that powers `flutter run`) **DOES NOT** support
+> range requests, so all video **assets** in `debug` mode will exhibit this behavior.
+
+See [Issue #49360](https://github.com/flutter/flutter/issues/49360) for more information
+on how to diagnose if a server supports range requests or not.
 
 ## Mixing audio with other audio sources
 
-The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least at the moment. If you use this option it will be silently ignored.
+The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at least
+at the moment. If you use this option it will be silently ignored.
 
 ## Supported Formats
 
@@ -26,11 +49,14 @@ The `VideoPlayerOptions.mixWithOthers` option can't be implemented in web, at le
 
 ### Video codecs?
 
-Check MDN's [**Web video codec guide**](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs) to learn more about the pros and cons of each video codec.
+Check MDN's [**Web video codec guide**](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Video_codecs)
+to learn more about the pros and cons of each video codec.
 
 ### What codecs are supported?
 
-Visit [**caniuse.com: 'video format'**](https://caniuse.com/#search=video%20format) for a breakdown of which browsers support what codecs. You can customize charts there for the users of your particular website(s).
+Visit [**caniuse.com: 'video format'**](https://caniuse.com/#search=video%20format)
+for a breakdown of which browsers support what codecs. You can customize charts
+there for the users of your particular website(s).
 
 Here's an abridged version of the data from caniuse, for a Global audience:
 

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.11
+version: 2.0.12
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
We've had a number of reports that "scrubbing on a video doesn't work", where the root cause is the server that is being used by the user to deliver said videos not supporting range requests.

This change documents this known limitation, adds a couple more links to relevant information about auto-play, and re-formats the file to more-or-less conform to 80 columns.

* Documents: https://github.com/flutter/flutter/issues/107281
* Documents: https://github.com/flutter/flutter/issues/93486
* Documents: https://github.com/flutter/flutter/issues/49360
* (and maybe others)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
