### PR TITLE
[tool] Include `dev_dependencies` in `make-deps-path-based`

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 0.8.9
 
+- Includes `dev_dependencies` when overridding dependencies using
+  `make-deps-path-based`.
 - Bypasses version and CHANGELOG checks for Dependabot PRs for packages
   that are known not to be client-affecting.
 

--- a/script/tool/lib/src/make_deps_path_based_command.dart
+++ b/script/tool/lib/src/make_deps_path_based_command.dart
@@ -154,8 +154,14 @@ class MakeDepsPathBasedCommand extends PluginCommand {
       throw ToolExit(_exitCannotUpdatePubspec);
     }
 
-    final Iterable<String> packagesToOverride = pubspec.dependencies.keys.where(
-        (String packageName) => localDependencies.containsKey(packageName));
+    final Iterable<String> combinedDependencies = <String>[
+      ...pubspec.dependencies.keys,
+      ...pubspec.devDependencies.keys,
+    ];
+    final Iterable<String> packagesToOverride = combinedDependencies
+        .where(
+            (String packageName) => localDependencies.containsKey(packageName))
+        .toList();
     if (packagesToOverride.isNotEmpty) {
       final String commonBasePath = packagesDir.path;
       // Find the relative path to the common base.

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.8.8
+version: 0.8.9
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
When pathifying dependencies using `make-deps-path-based`, consider
`dev_dependencies` in addition to `dependencies`. This handles cases
such as `go_router`/`go_router_builder`.

The lack of this caused https://github.com/flutter/flutter/issues/108274
to slip through presubmit tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
