### PR TITLE
[camera_windows] Improve several error handling scenarios

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+5
+
+* Fixes bugs in in error handling.
+
 ## 0.1.0+4
 
 * Allows retrying camera initialization after error.

--- a/packages/camera/camera_windows/lib/camera_windows.dart
+++ b/packages/camera/camera_windows/lib/camera_windows.dart
@@ -22,7 +22,7 @@ class CameraWindows extends CameraPlatform {
   final MethodChannel pluginChannel =
       const MethodChannel('plugins.flutter.io/camera_windows');
 
-  /// Camera specific method channels to allow comminicating with specific cameras.
+  /// Camera specific method channels to allow communicating with specific cameras.
   final Map<int, MethodChannel> _cameraChannels = <int, MethodChannel>{};
 
   /// The controller that broadcasts events coming from handleCameraMethodCall

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.1.0+4
+version: 0.1.0+5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/windows/camera.cpp
+++ b/packages/camera/camera_windows/windows/camera.cpp
@@ -85,9 +85,9 @@ bool CameraImpl::HasPendingResultByType(PendingResultType type) const {
 }
 
 void CameraImpl::SendErrorForPendingResults(const std::string& error_code,
-                                            const std::string& descripion) {
+                                            const std::string& description) {
   for (const auto& pending_result : pending_results_) {
-    pending_result.second->Error(error_code, descripion);
+    pending_result.second->Error(error_code, description);
   }
   pending_results_.clear();
 }

--- a/packages/camera/camera_windows/windows/camera.h
+++ b/packages/camera/camera_windows/windows/camera.h
@@ -139,9 +139,9 @@ class CameraImpl : public Camera {
   // error ID and description. Pending results are cleared in the process.
   //
   // error_code: A string error code describing the error.
-  // error_message: A user-readable error message (optional).
+  // description: A user-readable error message (optional).
   void SendErrorForPendingResults(const std::string& error_code,
-                                  const std::string& descripion);
+                                  const std::string& description);
 
   // Called when camera is disposed.
   // Sends camera closing message to the cameras method channel.

--- a/packages/camera/camera_windows/windows/capture_controller.cpp
+++ b/packages/camera/camera_windows/windows/capture_controller.cpp
@@ -237,6 +237,8 @@ HRESULT CaptureControllerImpl::CreateCaptureEngine() {
     return hr;
   }
 
+  // Check MF_CAPTURE_ENGINE_INITIALIZED event handling
+  // for response process.
   hr = capture_engine_->Initialize(capture_engine_callback_handler_.Get(),
                                    attributes.Get(), audio_source_.Get(),
                                    video_source_.Get());
@@ -244,7 +246,7 @@ HRESULT CaptureControllerImpl::CreateCaptureEngine() {
 }
 
 void CaptureControllerImpl::ResetCaptureController() {
-  if (record_handler_) {
+  if (record_handler_ && record_handler_->CanStop()) {
     if (record_handler_->IsContinuousRecording()) {
       StopRecord();
     } else if (record_handler_->IsTimedRecording()) {
@@ -391,7 +393,7 @@ uint32_t CaptureControllerImpl::GetMaxPreviewHeight() const {
   }
 }
 
-// Finds best mediat type for given source stream index and max height;
+// Finds best media type for given source stream index and max height;
 bool FindBestMediaType(DWORD source_stream_index, IMFCaptureSource* source,
                        IMFMediaType** target_media_type, uint32_t max_height,
                        uint32_t* target_frame_width,
@@ -533,8 +535,6 @@ void CaptureControllerImpl::StopRecord() {
   // Check MF_CAPTURE_ENGINE_RECORD_STOPPED event handling for response
   // process.
   if (!record_handler_->StopRecord(capture_engine_.Get())) {
-    // Destroy record handler on error cases to make sure state is resetted.
-    record_handler_ = nullptr;
     return OnRecordStopped(false, "Failed to stop video recording");
   }
 }
@@ -578,6 +578,8 @@ void CaptureControllerImpl::StartPreview() {
   texture_handler_->UpdateTextureSize(preview_frame_width_,
                                       preview_frame_height_);
 
+  // TODO(loic-sharma): This does not handle duplicate calls properly.
+  // See: https://github.com/flutter/flutter/issues/108404
   if (!preview_handler_) {
     preview_handler_ = std::make_unique<PreviewHandler>();
   } else if (preview_handler_->IsInitialized()) {
@@ -605,7 +607,7 @@ void CaptureControllerImpl::StartPreview() {
 void CaptureControllerImpl::StopPreview() {
   assert(capture_engine_);
 
-  if (!IsInitialized() && !preview_handler_) {
+  if (!IsInitialized() || !preview_handler_) {
     return;
   }
 
@@ -619,7 +621,7 @@ void CaptureControllerImpl::StopPreview() {
 void CaptureControllerImpl::PausePreview() {
   assert(capture_controller_listener_);
 
-  if (!preview_handler_ && !preview_handler_->IsInitialized()) {
+  if (!preview_handler_ || !preview_handler_->IsInitialized()) {
     return capture_controller_listener_->OnPausePreviewFailed(
         "Preview not started");
   }
@@ -638,7 +640,7 @@ void CaptureControllerImpl::PausePreview() {
 void CaptureControllerImpl::ResumePreview() {
   assert(capture_controller_listener_);
 
-  if (!preview_handler_ && !preview_handler_->IsInitialized()) {
+  if (!preview_handler_ || !preview_handler_->IsInitialized()) {
     return capture_controller_listener_->OnResumePreviewFailed(
         "Preview not started");
   }
@@ -722,6 +724,13 @@ void CaptureControllerImpl::OnPicture(bool success, const std::string& error) {
 void CaptureControllerImpl::OnCaptureEngineInitialized(
     bool success, const std::string& error) {
   if (capture_controller_listener_) {
+    if (!success) {
+      capture_controller_listener_->OnCreateCaptureEngineFailed(
+          "Failed to initialize capture engine");
+      ResetCaptureController();
+      return;
+    }
+
     // Create texture handler and register new texture.
     texture_handler_ = std::make_unique<TextureHandler>(texture_registrar_);
 
@@ -848,7 +857,7 @@ void CaptureControllerImpl::UpdateCaptureTime(uint64_t capture_time_us) {
   }
 
   if (preview_handler_ && preview_handler_->IsStarting()) {
-    // Informs that first frame is captured succeffully and preview has
+    // Informs that first frame is captured successfully and preview has
     // started.
     OnPreviewStarted(true, "");
   }

--- a/packages/camera/camera_windows/windows/photo_handler.h
+++ b/packages/camera/camera_windows/windows/photo_handler.h
@@ -51,7 +51,7 @@ class PhotoHandler {
   bool TakePhoto(const std::string& file_path, IMFCaptureEngine* capture_engine,
                  IMFMediaType* base_media_type);
 
-  // Set the photo handler recording state to: kIdel.
+  // Set the photo handler recording state to: kIdle.
   void OnPhotoTaken();
 
   // Returns true if photo state is kIdle.

--- a/packages/camera/camera_windows/windows/preview_handler.h
+++ b/packages/camera/camera_windows/windows/preview_handler.h
@@ -75,7 +75,7 @@ class PreviewHandler {
 
   // Returns true if preview state is running or paused.
   bool IsInitialized() const {
-    return preview_state_ == PreviewState::kRunning &&
+    return preview_state_ == PreviewState::kRunning ||
            preview_state_ == PreviewState::kPaused;
   }
 

--- a/packages/camera/camera_windows/windows/record_handler.cpp
+++ b/packages/camera/camera_windows/windows/record_handler.cpp
@@ -238,6 +238,7 @@ void RecordHandler::OnRecordStopped() {
     recording_duration_us_ = 0;
     max_video_duration_ms_ = -1;
     recording_state_ = RecordState::kNotStarted;
+    type_ = RecordingType::kNone;
   }
 }
 

--- a/packages/camera/camera_windows/windows/record_handler.h
+++ b/packages/camera/camera_windows/windows/record_handler.h
@@ -16,6 +16,8 @@ namespace camera_windows {
 using Microsoft::WRL::ComPtr;
 
 enum class RecordingType {
+  // Camera is not recording.
+  kNone,
   // Recording continues until it is stopped with a separate stop command.
   kContinuous,
   // Recording stops automatically after requested record time is passed.
@@ -109,7 +111,7 @@ class RecordHandler {
   uint64_t recording_duration_us_ = 0;
   std::string file_path_;
   RecordState recording_state_ = RecordState::kNotStarted;
-  RecordingType type_;
+  RecordingType type_ = RecordingType::kNone;
   ComPtr<IMFCaptureRecordSink> record_sink_;
 };
 

--- a/packages/camera/camera_windows/windows/test/camera_test.cpp
+++ b/packages/camera/camera_windows/windows/test/camera_test.cpp
@@ -131,7 +131,7 @@ TEST(Camera, OnCreateCaptureEngineSucceededReturnsCameraId) {
   camera->OnCreateCaptureEngineSucceeded(texture_id);
 }
 
-TEST(Camera, OnCreateCaptureEngineFailedReturnsError) {
+TEST(Camera, CreateCaptureEngineReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -140,7 +140,7 @@ TEST(Camera, OnCreateCaptureEngineFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kCreateCamera, std::move(result));
 
@@ -169,7 +169,7 @@ TEST(Camera, OnStartPreviewSucceededReturnsFrameSize) {
   camera->OnStartPreviewSucceeded(width, height);
 }
 
-TEST(Camera, OnStartPreviewFailedReturnsError) {
+TEST(Camera, StartPreviewReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -178,7 +178,7 @@ TEST(Camera, OnStartPreviewFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kInitialize, std::move(result));
 
@@ -199,7 +199,7 @@ TEST(Camera, OnPausePreviewSucceededReturnsSuccess) {
   camera->OnPausePreviewSucceeded();
 }
 
-TEST(Camera, OnPausePreviewFailedReturnsError) {
+TEST(Camera, PausePreviewReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -208,7 +208,7 @@ TEST(Camera, OnPausePreviewFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kPausePreview, std::move(result));
 
@@ -230,7 +230,7 @@ TEST(Camera, OnResumePreviewSucceededReturnsSuccess) {
   camera->OnResumePreviewSucceeded();
 }
 
-TEST(Camera, OnResumePreviewFailedReturnsError) {
+TEST(Camera, ResumePreviewReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -239,7 +239,7 @@ TEST(Camera, OnResumePreviewFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kResumePreview,
                            std::move(result));
@@ -261,7 +261,7 @@ TEST(Camera, OnStartRecordSucceededReturnsSuccess) {
   camera->OnStartRecordSucceeded();
 }
 
-TEST(Camera, OnStartRecordFailedReturnsError) {
+TEST(Camera, StartRecordReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -270,7 +270,7 @@ TEST(Camera, OnStartRecordFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kStartRecord, std::move(result));
 
@@ -293,7 +293,7 @@ TEST(Camera, OnStopRecordSucceededReturnsSuccess) {
   camera->OnStopRecordSucceeded(file_path);
 }
 
-TEST(Camera, OnStopRecordFailedReturnsError) {
+TEST(Camera, StopRecordReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -302,7 +302,7 @@ TEST(Camera, OnStopRecordFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kStopRecord, std::move(result));
 
@@ -315,7 +315,7 @@ TEST(Camera, OnTakePictureSucceededReturnsSuccess) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string file_path = "C:\temp\filename.jpeg";
+  std::string file_path = "C:\\temp\\filename.jpeg";
 
   EXPECT_CALL(*result, ErrorInternal).Times(0);
   EXPECT_CALL(*result, SuccessInternal(Pointee(EncodableValue(file_path))));
@@ -325,7 +325,7 @@ TEST(Camera, OnTakePictureSucceededReturnsSuccess) {
   camera->OnTakePictureSucceeded(file_path);
 }
 
-TEST(Camera, OnTakePictureFailedReturnsError) {
+TEST(Camera, TakePictureReportsError) {
   std::unique_ptr<CameraImpl> camera =
       std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
   std::unique_ptr<MockMethodResult> result =
@@ -334,7 +334,7 @@ TEST(Camera, OnTakePictureFailedReturnsError) {
   std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
-  EXPECT_CALL(*result, ErrorInternal(_, Eq(error_text), _));
+  EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
 
   camera->AddPendingResult(PendingResultType::kTakePicture, std::move(result));
 
@@ -350,7 +350,7 @@ TEST(Camera, OnVideoRecordSucceededInvokesCameraChannelEvent) {
   std::unique_ptr<MockBinaryMessenger> binary_messenger =
       std::make_unique<MockBinaryMessenger>();
 
-  std::string file_path = "C:\temp\filename.mp4";
+  std::string file_path = "C:\\temp\\filename.mp4";
   int64_t camera_id = 12345;
   std::string camera_channel =
       std::string("plugins.flutter.io/camera_windows/camera") +

--- a/packages/camera/camera_windows/windows/test/capture_controller_test.cpp
+++ b/packages/camera/camera_windows/windows/test/capture_controller_test.cpp
@@ -70,35 +70,10 @@ void MockInitCaptureController(CaptureControllerImpl* capture_controller,
   engine->CreateFakeEvent(S_OK, MF_CAPTURE_ENGINE_INITIALIZED);
 }
 
-void MockStartPreview(CaptureControllerImpl* capture_controller,
-                      MockCaptureSource* capture_source,
-                      MockCapturePreviewSink* preview_sink,
-                      MockTextureRegistrar* texture_registrar,
-                      MockCaptureEngine* engine, MockCamera* camera,
-                      std::unique_ptr<uint8_t[]> mock_source_buffer,
-                      uint32_t mock_source_buffer_size,
-                      uint32_t mock_preview_width, uint32_t mock_preview_height,
-                      int64_t mock_texture_id) {
-  EXPECT_CALL(*engine, GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_PREVIEW, _))
-      .Times(1)
-      .WillOnce([src_sink = preview_sink](MF_CAPTURE_ENGINE_SINK_TYPE sink_type,
-                                          IMFCaptureSink** target_sink) {
-        *target_sink = src_sink;
-        src_sink->AddRef();
-        return S_OK;
-      });
-
-  EXPECT_CALL(*preview_sink, RemoveAllStreams).Times(1).WillOnce(Return(S_OK));
-  EXPECT_CALL(*preview_sink, AddStream).Times(1).WillOnce(Return(S_OK));
-  EXPECT_CALL(*preview_sink, SetSampleCallback)
-      .Times(1)
-      .WillOnce([sink = preview_sink](
-                    DWORD dwStreamSinkIndex,
-                    IMFCaptureEngineOnSampleCallback* pCallback) -> HRESULT {
-        sink->sample_callback_ = pCallback;
-        return S_OK;
-      });
-
+void MockAvailableMediaTypes(MockCaptureEngine* engine,
+                             MockCaptureSource* capture_source,
+                             uint32_t mock_preview_width,
+                             uint32_t mock_preview_height) {
   EXPECT_CALL(*engine, GetSource)
       .Times(1)
       .WillOnce(
@@ -142,6 +117,39 @@ void MockStartPreview(CaptureControllerImpl* capture_controller,
         (*media_type)->AddRef();
         return S_OK;
       });
+}
+
+void MockStartPreview(CaptureControllerImpl* capture_controller,
+                      MockCapturePreviewSink* preview_sink,
+                      MockTextureRegistrar* texture_registrar,
+                      MockCaptureEngine* engine, MockCamera* camera,
+                      std::unique_ptr<uint8_t[]> mock_source_buffer,
+                      uint32_t mock_source_buffer_size,
+                      uint32_t mock_preview_width, uint32_t mock_preview_height,
+                      int64_t mock_texture_id) {
+  EXPECT_CALL(*engine, GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_PREVIEW, _))
+      .Times(1)
+      .WillOnce([src_sink = preview_sink](MF_CAPTURE_ENGINE_SINK_TYPE sink_type,
+                                          IMFCaptureSink** target_sink) {
+        *target_sink = src_sink;
+        src_sink->AddRef();
+        return S_OK;
+      });
+
+  EXPECT_CALL(*preview_sink, RemoveAllStreams).Times(1).WillOnce(Return(S_OK));
+  EXPECT_CALL(*preview_sink, AddStream).Times(1).WillOnce(Return(S_OK));
+  EXPECT_CALL(*preview_sink, SetSampleCallback)
+      .Times(1)
+      .WillOnce([sink = preview_sink](
+                    DWORD dwStreamSinkIndex,
+                    IMFCaptureEngineOnSampleCallback* pCallback) -> HRESULT {
+        sink->sample_callback_ = pCallback;
+        return S_OK;
+      });
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+  MockAvailableMediaTypes(engine, capture_source.Get(), mock_preview_width,
+                          mock_preview_height);
 
   EXPECT_CALL(*engine, StartPreview()).Times(1).WillOnce(Return(S_OK));
 
@@ -167,6 +175,21 @@ void MockStartPreview(CaptureControllerImpl* capture_controller,
   // SendFake sample
   preview_sink->SendFakeSample(mock_source_buffer.get(),
                                mock_source_buffer_size);
+}
+
+void MockPhotoSink(MockCaptureEngine* engine,
+                   MockCapturePhotoSink* photo_sink) {
+  EXPECT_CALL(*engine, GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_PHOTO, _))
+      .Times(1)
+      .WillOnce([src_sink = photo_sink](MF_CAPTURE_ENGINE_SINK_TYPE sink_type,
+                                        IMFCaptureSink** target_sink) {
+        *target_sink = src_sink;
+        src_sink->AddRef();
+        return S_OK;
+      });
+  EXPECT_CALL(*photo_sink, RemoveAllStreams).Times(1).WillOnce(Return(S_OK));
+  EXPECT_CALL(*photo_sink, AddStream).Times(1).WillOnce(Return(S_OK));
+  EXPECT_CALL(*photo_sink, SetOutputFileName).Times(1).WillOnce(Return(S_OK));
 }
 
 void MockRecordStart(CaptureControllerImpl* capture_controller,
@@ -204,7 +227,7 @@ TEST(CaptureController,
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Init capture controller with mocks and tests
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
@@ -225,7 +248,7 @@ TEST(CaptureController, InitCaptureEngineCanOnlyBeCalledOnce) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Init capture controller once with mocks and tests
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
@@ -264,14 +287,12 @@ TEST(CaptureController, InitCaptureEngineReportsFailure) {
   capture_controller->SetAudioSource(
       reinterpret_cast<IMFMediaSource*>(audio_source.Get()));
 
+  // Cause initialization to fail
+  EXPECT_CALL(*engine.Get(), Initialize).Times(1).WillOnce(Return(E_FAIL));
+
   EXPECT_CALL(*texture_registrar, RegisterTexture).Times(0);
   EXPECT_CALL(*texture_registrar, UnregisterTexture).Times(0);
   EXPECT_CALL(*camera, OnCreateCaptureEngineSucceeded).Times(0);
-
-  EXPECT_CALL(*engine.Get(), Initialize)
-      .Times(1)
-      .WillOnce(Return(E_ACCESSDENIED));
-
   EXPECT_CALL(*camera,
               OnCreateCaptureEngineFailed(Eq("Failed to create camera")))
       .Times(1);
@@ -288,6 +309,60 @@ TEST(CaptureController, InitCaptureEngineReportsFailure) {
   engine = nullptr;
 }
 
+TEST(CaptureController, ReportsInitializedErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  EXPECT_CALL(*camera, OnCreateCaptureEngineFailed(
+                           Eq("Failed to initialize capture engine")))
+      .Times(1);
+  EXPECT_CALL(*camera, OnCreateCaptureEngineSucceeded).Times(0);
+
+  // Send initialization failed event
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_INITIALIZED);
+
+  capture_controller = nullptr;
+  camera = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+}
+
+TEST(CaptureController, ReportsCaptureEngineErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  EXPECT_CALL(*(camera.get()), OnCaptureError(Eq("Unspecified error")))
+      .Times(1);
+
+  // Send error event.
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_ERROR);
+
+  capture_controller = nullptr;
+  camera = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+}
+
 TEST(CaptureController, StartPreviewStartsProcessingSamples) {
   ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
   std::unique_ptr<MockCamera> camera =
@@ -297,14 +372,13 @@ TEST(CaptureController, StartPreviewStartsProcessingSamples) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Initialize capture controller to be able to start preview
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
                             engine.Get(), camera.get(), mock_texture_id);
 
   ComPtr<MockCapturePreviewSink> preview_sink = new MockCapturePreviewSink();
-  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
 
   // Let's keep these small for mock texture data. Two pixels should be
   // enough.
@@ -332,11 +406,10 @@ TEST(CaptureController, StartPreviewStartsProcessingSamples) {
   }
 
   // Start preview and run preview tests
-  MockStartPreview(capture_controller.get(), capture_source.Get(),
-                   preview_sink.Get(), texture_registrar.get(), engine.Get(),
-                   camera.get(), std::move(mock_source_buffer),
-                   mock_texture_data_size, mock_preview_width,
-                   mock_preview_height, mock_texture_id);
+  MockStartPreview(capture_controller.get(), preview_sink.Get(),
+                   texture_registrar.get(), engine.Get(), camera.get(),
+                   std::move(mock_source_buffer), mock_texture_data_size,
+                   mock_preview_width, mock_preview_height, mock_texture_id);
 
   // Test texture processing
   EXPECT_TRUE(texture_registrar->texture_);
@@ -377,6 +450,73 @@ TEST(CaptureController, StartPreviewStartsProcessingSamples) {
   texture_registrar = nullptr;
 }
 
+TEST(CaptureController, ReportsStartPreviewError) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  // Cause start preview to fail
+  EXPECT_CALL(*engine.Get(), GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_PREVIEW, _))
+      .Times(1)
+      .WillOnce(Return(E_FAIL));
+
+  EXPECT_CALL(*engine.Get(), StartPreview).Times(0);
+  EXPECT_CALL(*engine.Get(), StopPreview).Times(0);
+  EXPECT_CALL(*camera, OnStartPreviewSucceeded).Times(0);
+  EXPECT_CALL(*camera,
+              OnStartPreviewFailed(Eq("Failed to start video preview")))
+      .Times(1);
+
+  capture_controller->StartPreview();
+
+  capture_controller = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  texture_registrar = nullptr;
+}
+
+// TODO(loic-sharma): Test duplicate calls to start preview.
+
+TEST(CaptureController, IgnoresStartPreviewErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  EXPECT_CALL(*camera, OnStartPreviewFailed).Times(0);
+  EXPECT_CALL(*camera, OnCreateCaptureEngineSucceeded).Times(0);
+
+  // Send a start preview error event
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_PREVIEW_STARTED);
+
+  capture_controller = nullptr;
+  camera = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+}
+
 TEST(CaptureController, StartRecordSuccess) {
   ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
   std::unique_ptr<MockCamera> camera =
@@ -386,23 +526,16 @@ TEST(CaptureController, StartRecordSuccess) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Initialize capture controller to be able to start preview
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
                             engine.Get(), camera.get(), mock_texture_id);
 
-  ComPtr<MockCapturePreviewSink> preview_sink = new MockCapturePreviewSink();
   ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
 
-  std::unique_ptr<uint8_t[]> mock_source_buffer =
-      std::make_unique<uint8_t[]>(0);
-
-  // Start preview to be able to start record
-  MockStartPreview(capture_controller.get(), capture_source.Get(),
-                   preview_sink.Get(), texture_registrar.get(), engine.Get(),
-                   camera.get(), std::move(mock_source_buffer), 0, 1, 1,
-                   mock_texture_id);
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
 
   // Start record
   ComPtr<MockCaptureRecordSink> record_sink = new MockCaptureRecordSink();
@@ -422,6 +555,109 @@ TEST(CaptureController, StartRecordSuccess) {
   record_sink = nullptr;
 }
 
+TEST(CaptureController, ReportsStartRecordError) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  // Cause start record to fail
+  EXPECT_CALL(*engine.Get(), GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_RECORD, _))
+      .Times(1)
+      .WillOnce(Return(E_FAIL));
+
+  EXPECT_CALL(*engine.Get(), StartRecord).Times(0);
+  EXPECT_CALL(*engine.Get(), StopRecord).Times(0);
+  EXPECT_CALL(*camera, OnStartRecordSucceeded).Times(0);
+  EXPECT_CALL(*camera,
+              OnStartRecordFailed(Eq("Failed to start video recording")))
+      .Times(1);
+
+  capture_controller->StartRecord("mock_path", -1);
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+}
+
+TEST(CaptureController, ReportsStartRecordErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  // Start record
+  ComPtr<MockCaptureRecordSink> record_sink = new MockCaptureRecordSink();
+  std::string mock_path_to_video = "mock_path_to_video";
+
+  EXPECT_CALL(*engine.Get(), StartRecord()).Times(1).WillOnce(Return(S_OK));
+
+  EXPECT_CALL(*engine.Get(), GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_RECORD, _))
+      .Times(1)
+      .WillOnce([src_sink = record_sink](MF_CAPTURE_ENGINE_SINK_TYPE sink_type,
+                                         IMFCaptureSink** target_sink) {
+        *target_sink = src_sink.Get();
+        src_sink->AddRef();
+        return S_OK;
+      });
+
+  EXPECT_CALL(*record_sink.Get(), RemoveAllStreams)
+      .Times(1)
+      .WillOnce(Return(S_OK));
+  EXPECT_CALL(*record_sink.Get(), AddStream)
+      .Times(2)
+      .WillRepeatedly(Return(S_OK));
+  EXPECT_CALL(*record_sink.Get(), SetOutputFileName)
+      .Times(1)
+      .WillOnce(Return(S_OK));
+
+  capture_controller->StartRecord(mock_path_to_video, -1);
+
+  // Send a start record failed event
+  EXPECT_CALL(*camera, OnStartRecordSucceeded).Times(0);
+  EXPECT_CALL(*camera, OnStartRecordFailed(Eq("Unspecified error"))).Times(1);
+
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_RECORD_STARTED);
+
+  // Destructor shouldn't attempt to stop the recording that failed to start.
+  EXPECT_CALL(*engine.Get(), StopRecord).Times(0);
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  record_sink = nullptr;
+}
+
 TEST(CaptureController, StopRecordSuccess) {
   ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
   std::unique_ptr<MockCamera> camera =
@@ -431,23 +667,16 @@ TEST(CaptureController, StopRecordSuccess) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Initialize capture controller to be able to start preview
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
                             engine.Get(), camera.get(), mock_texture_id);
 
-  ComPtr<MockCapturePreviewSink> preview_sink = new MockCapturePreviewSink();
   ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
 
-  std::unique_ptr<uint8_t[]> mock_source_buffer =
-      std::make_unique<uint8_t[]>(0);
-
-  // Start preview to be able to start record
-  MockStartPreview(capture_controller.get(), capture_source.Get(),
-                   preview_sink.Get(), texture_registrar.get(), engine.Get(),
-                   camera.get(), std::move(mock_source_buffer), 0, 1, 1,
-                   mock_texture_id);
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
 
   // Start record
   ComPtr<MockCaptureRecordSink> record_sink = new MockCaptureRecordSink();
@@ -463,7 +692,91 @@ TEST(CaptureController, StopRecordSuccess) {
 
   // OnStopRecordSucceeded should be called with mocked file path
   EXPECT_CALL(*camera, OnStopRecordSucceeded(Eq(mock_path_to_video))).Times(1);
+  EXPECT_CALL(*camera, OnStopRecordFailed).Times(0);
+
   engine->CreateFakeEvent(S_OK, MF_CAPTURE_ENGINE_RECORD_STOPPED);
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  record_sink = nullptr;
+}
+
+TEST(CaptureController, ReportsStopRecordError) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  // Start record
+  ComPtr<MockCaptureRecordSink> record_sink = new MockCaptureRecordSink();
+  MockRecordStart(capture_controller.get(), engine.Get(), record_sink.Get(),
+                  camera.get(), "mock_path_to_video");
+
+  // Cause stop record to fail
+  EXPECT_CALL(*(engine.Get()), StopRecord(true, false))
+      .Times(1)
+      .WillOnce(Return(E_FAIL));
+
+  EXPECT_CALL(*camera, OnStopRecordSucceeded).Times(0);
+  EXPECT_CALL(*camera, OnStopRecordFailed(Eq("Failed to stop video recording")))
+      .Times(1);
+
+  capture_controller->StopRecord();
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  record_sink = nullptr;
+}
+
+TEST(CaptureController, ReportsStopRecordErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  // Start record
+  ComPtr<MockCaptureRecordSink> record_sink = new MockCaptureRecordSink();
+  std::string mock_path_to_video = "mock_path_to_video";
+  MockRecordStart(capture_controller.get(), engine.Get(), record_sink.Get(),
+                  camera.get(), mock_path_to_video);
+
+  // Send a stop record failure event
+  EXPECT_CALL(*camera, OnStopRecordSucceeded).Times(0);
+  EXPECT_CALL(*camera, OnStopRecordFailed(Eq("Unspecified error"))).Times(1);
+
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_RECORD_STOPPED);
 
   capture_controller = nullptr;
   texture_registrar = nullptr;
@@ -481,42 +794,21 @@ TEST(CaptureController, TakePictureSuccess) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
-  // Initialize capture controller to be able to start preview
+  // Initialize capture controller to be able to take picture
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
                             engine.Get(), camera.get(), mock_texture_id);
 
-  ComPtr<MockCapturePreviewSink> preview_sink = new MockCapturePreviewSink();
   ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
 
-  std::unique_ptr<uint8_t[]> mock_source_buffer =
-      std::make_unique<uint8_t[]>(0);
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
 
-  // Start preview to be able to start record
-  MockStartPreview(capture_controller.get(), capture_source.Get(),
-                   preview_sink.Get(), texture_registrar.get(), engine.Get(),
-                   camera.get(), std::move(mock_source_buffer), 0, 1, 1,
-                   mock_texture_id);
-
-  // Init photo sink tests
   ComPtr<MockCapturePhotoSink> photo_sink = new MockCapturePhotoSink();
-  EXPECT_CALL(*(engine.Get()), GetSink(MF_CAPTURE_ENGINE_SINK_TYPE_PHOTO, _))
-      .Times(1)
-      .WillOnce(
-          [src_sink = photo_sink.Get()](MF_CAPTURE_ENGINE_SINK_TYPE sink_type,
-                                        IMFCaptureSink** target_sink) {
-            *target_sink = src_sink;
-            src_sink->AddRef();
-            return S_OK;
-          });
-  EXPECT_CALL(*(photo_sink.Get()), RemoveAllStreams)
-      .Times(1)
-      .WillOnce(Return(S_OK));
-  EXPECT_CALL(*(photo_sink.Get()), AddStream).Times(1).WillOnce(Return(S_OK));
-  EXPECT_CALL(*(photo_sink.Get()), SetOutputFileName)
-      .Times(1)
-      .WillOnce(Return(S_OK));
+
+  // Initialize photo sink
+  MockPhotoSink(engine.Get(), photo_sink.Get());
 
   // Request photo
   std::string mock_path_to_photo = "mock_path_to_photo";
@@ -525,7 +817,92 @@ TEST(CaptureController, TakePictureSuccess) {
 
   // OnTakePictureSucceeded should be called with mocked file path
   EXPECT_CALL(*camera, OnTakePictureSucceeded(Eq(mock_path_to_photo))).Times(1);
+  EXPECT_CALL(*camera, OnTakePictureFailed).Times(0);
   engine->CreateFakeEvent(S_OK, MF_CAPTURE_ENGINE_PHOTO_TAKEN);
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  photo_sink = nullptr;
+}
+
+TEST(CaptureController, ReportsTakePictureError) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to take picture
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  ComPtr<MockCapturePhotoSink> photo_sink = new MockCapturePhotoSink();
+
+  // Initialize photo sink
+  MockPhotoSink(engine.Get(), photo_sink.Get());
+
+  // Cause take picture to fail
+  EXPECT_CALL(*(engine.Get()), TakePhoto).Times(1).WillOnce(Return(E_FAIL));
+
+  EXPECT_CALL(*camera, OnTakePictureSucceeded).Times(0);
+  EXPECT_CALL(*camera, OnTakePictureFailed(Eq("Failed to take photo")))
+      .Times(1);
+
+  capture_controller->TakePicture("mock_path_to_photo");
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+  photo_sink = nullptr;
+}
+
+TEST(CaptureController, ReportsPhotoTakenErrorEvent) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to take picture
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
+
+  // Prepare fake media types
+  MockAvailableMediaTypes(engine.Get(), capture_source.Get(), 1, 1);
+
+  ComPtr<MockCapturePhotoSink> photo_sink = new MockCapturePhotoSink();
+
+  // Initialize photo sink
+  MockPhotoSink(engine.Get(), photo_sink.Get());
+
+  // Request photo
+  std::string mock_path_to_photo = "mock_path_to_photo";
+  EXPECT_CALL(*(engine.Get()), TakePhoto()).Times(1).WillOnce(Return(S_OK));
+  capture_controller->TakePicture(mock_path_to_photo);
+
+  // Send take picture failed event
+  EXPECT_CALL(*camera, OnTakePictureSucceeded).Times(0);
+  EXPECT_CALL(*camera, OnTakePictureFailed(Eq("Unspecified error"))).Times(1);
+
+  engine->CreateFakeEvent(E_FAIL, MF_CAPTURE_ENGINE_PHOTO_TAKEN);
 
   capture_controller = nullptr;
   texture_registrar = nullptr;
@@ -543,28 +920,78 @@ TEST(CaptureController, PauseResumePreviewSuccess) {
   std::unique_ptr<MockTextureRegistrar> texture_registrar =
       std::make_unique<MockTextureRegistrar>();
 
-  uint64_t mock_texture_id = 1234;
+  int64_t mock_texture_id = 1234;
 
   // Initialize capture controller to be able to start preview
   MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
                             engine.Get(), camera.get(), mock_texture_id);
 
   ComPtr<MockCapturePreviewSink> preview_sink = new MockCapturePreviewSink();
-  ComPtr<MockCaptureSource> capture_source = new MockCaptureSource();
 
   std::unique_ptr<uint8_t[]> mock_source_buffer =
       std::make_unique<uint8_t[]>(0);
 
   // Start preview to be able to start record
-  MockStartPreview(capture_controller.get(), capture_source.Get(),
-                   preview_sink.Get(), texture_registrar.get(), engine.Get(),
-                   camera.get(), std::move(mock_source_buffer), 0, 1, 1,
-                   mock_texture_id);
+  MockStartPreview(capture_controller.get(), preview_sink.Get(),
+                   texture_registrar.get(), engine.Get(), camera.get(),
+                   std::move(mock_source_buffer), 0, 1, 1, mock_texture_id);
 
   EXPECT_CALL(*camera, OnPausePreviewSucceeded()).Times(1);
   capture_controller->PausePreview();
 
   EXPECT_CALL(*camera, OnResumePreviewSucceeded()).Times(1);
+  capture_controller->ResumePreview();
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+}
+
+TEST(CaptureController, PausePreviewFailsIfPreviewNotStarted) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  // Pause preview fails if not started
+  EXPECT_CALL(*camera, OnPausePreviewFailed(Eq("Preview not started")))
+      .Times(1);
+
+  capture_controller->PausePreview();
+
+  capture_controller = nullptr;
+  texture_registrar = nullptr;
+  engine = nullptr;
+  camera = nullptr;
+}
+
+TEST(CaptureController, ResumePreviewFailsIfPreviewNotStarted) {
+  ComPtr<MockCaptureEngine> engine = new MockCaptureEngine();
+  std::unique_ptr<MockCamera> camera =
+      std::make_unique<MockCamera>(MOCK_DEVICE_ID);
+  std::unique_ptr<CaptureControllerImpl> capture_controller =
+      std::make_unique<CaptureControllerImpl>(camera.get());
+  std::unique_ptr<MockTextureRegistrar> texture_registrar =
+      std::make_unique<MockTextureRegistrar>();
+  int64_t mock_texture_id = 1234;
+
+  // Initialize capture controller to be able to start preview
+  MockInitCaptureController(capture_controller.get(), texture_registrar.get(),
+                            engine.Get(), camera.get(), mock_texture_id);
+
+  // Resume preview fails if not started.
+  EXPECT_CALL(*camera, OnResumePreviewFailed(Eq("Preview not started")))
+      .Times(1);
+
   capture_controller->ResumePreview();
 
   capture_controller = nullptr;

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -105,6 +105,8 @@ cd <repository root>
 dart run ./script/tool/bin/flutter_plugin_tools.dart native-test --ios --android --no-integration --packages plugin_name
 # Run all tests for macOS:
 dart run ./script/tool/bin/flutter_plugin_tools.dart native-test --macos --packages plugin_name
+# Run all tests for Windows:
+dart run ./script/tool/bin/flutter_plugin_tools.dart native-test --windows --packages plugin_name
 ```
 
 ### Update README.md from Example Sources

--- a/script/tool/lib/src/common/package_state_utils.dart
+++ b/script/tool/lib/src/common/package_state_utils.dart
@@ -35,7 +35,7 @@ class PackageChangeState {
 /// [changedPaths] should be a list of POSIX-style paths from a common root,
 /// and [relativePackagePath] should be the path to [package] from that same
 /// root. Commonly these will come from `gitVersionFinder.getChangedFiles()`
-/// and `getRelativePoixPath(package.directory, gitDir.path)` respectively;
+/// and `getRelativePosixPath(package.directory, gitDir.path)` respectively;
 /// they are arguments mainly to allow for caching the changed paths for an
 /// entire command run.
 PackageChangeState checkPackageChangeState(


### PR DESCRIPTION
This change improves `camera_windows`'s error handling:

* `CaptureControllerImpl`'s destructor no longer tries to stop recording even if recording has already stopped.
* An error is now reported if stop record fails
* Pause/resume/stop preview now fails properly if preview wasn't started

Part of https://github.com/flutter/flutter/issues/102098

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
