### PR TITLE
[camera_windows] Use `CameraAccessDenied` error code for camera permission errors

### DIFF
--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0+1
+
+**BREAKING CHANGES**:
+  * `CameraException.code` now has value `"CameraAccessDenied"` if camera access permission was denied.
+  * `CameraException.code` now has value `"camera_error"` if error occurs during capture.
+
 ## 0.1.0+5
 
 * Fixes bugs in in error handling.

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0+1
+## 0.2.0
 
 **BREAKING CHANGES**:
   * `CameraException.code` now has value `"CameraAccessDenied"` if camera access permission was denied.

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.1.0+5
+version: 0.2.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_windows
 description: A Flutter plugin for getting information about and controlling the camera on Windows.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.2.0+1
+version: 0.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_windows/windows/camera.cpp
+++ b/packages/camera/camera_windows/windows/camera.cpp
@@ -16,6 +16,24 @@ constexpr char kVideoRecordedEvent[] = "video_recorded";
 constexpr char kCameraClosingEvent[] = "camera_closing";
 constexpr char kErrorEvent[] = "error";
 
+// Camera error codes
+constexpr char kCameraAccessDenied[] = "CameraAccessDenied";
+constexpr char kCameraError[] = "camera_error";
+constexpr char kPluginDisposed[] = "plugin_disposed";
+
+std::string GetErrorCode(CameraResult result) {
+  assert(result != CameraResult::kSuccess);
+
+  switch (result) {
+    case CameraResult::kAccessDenied:
+      return kCameraAccessDenied;
+
+    default:
+    case CameraResult::kError:
+      return kCameraError;
+  }
+}
+
 CameraImpl::CameraImpl(const std::string& device_id)
     : device_id_(device_id), Camera(device_id) {}
 
@@ -24,7 +42,7 @@ CameraImpl::~CameraImpl() {
   OnCameraClosing();
 
   capture_controller_ = nullptr;
-  SendErrorForPendingResults("plugin_disposed",
+  SendErrorForPendingResults(kPluginDisposed,
                              "Plugin disposed before request was handled");
 }
 
@@ -121,11 +139,13 @@ void CameraImpl::OnCreateCaptureEngineSucceeded(int64_t texture_id) {
   }
 }
 
-void CameraImpl::OnCreateCaptureEngineFailed(const std::string& error) {
+void CameraImpl::OnCreateCaptureEngineFailed(CameraResult result,
+                                             const std::string& error) {
   auto pending_result =
       GetPendingResultByType(PendingResultType::kCreateCamera);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 }
 
@@ -141,10 +161,12 @@ void CameraImpl::OnStartPreviewSucceeded(int32_t width, int32_t height) {
   }
 };
 
-void CameraImpl::OnStartPreviewFailed(const std::string& error) {
+void CameraImpl::OnStartPreviewFailed(CameraResult result,
+                                      const std::string& error) {
   auto pending_result = GetPendingResultByType(PendingResultType::kInitialize);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 };
 
@@ -156,11 +178,13 @@ void CameraImpl::OnResumePreviewSucceeded() {
   }
 }
 
-void CameraImpl::OnResumePreviewFailed(const std::string& error) {
+void CameraImpl::OnResumePreviewFailed(CameraResult result,
+                                       const std::string& error) {
   auto pending_result =
       GetPendingResultByType(PendingResultType::kResumePreview);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 }
 
@@ -172,11 +196,13 @@ void CameraImpl::OnPausePreviewSucceeded() {
   }
 }
 
-void CameraImpl::OnPausePreviewFailed(const std::string& error) {
+void CameraImpl::OnPausePreviewFailed(CameraResult result,
+                                      const std::string& error) {
   auto pending_result =
       GetPendingResultByType(PendingResultType::kPausePreview);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 }
 
@@ -187,10 +213,12 @@ void CameraImpl::OnStartRecordSucceeded() {
   }
 };
 
-void CameraImpl::OnStartRecordFailed(const std::string& error) {
+void CameraImpl::OnStartRecordFailed(CameraResult result,
+                                     const std::string& error) {
   auto pending_result = GetPendingResultByType(PendingResultType::kStartRecord);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 };
 
@@ -201,10 +229,12 @@ void CameraImpl::OnStopRecordSucceeded(const std::string& file_path) {
   }
 };
 
-void CameraImpl::OnStopRecordFailed(const std::string& error) {
+void CameraImpl::OnStopRecordFailed(CameraResult result,
+                                    const std::string& error) {
   auto pending_result = GetPendingResultByType(PendingResultType::kStopRecord);
   if (pending_result) {
-    pending_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_result->Error(error_code, error);
   }
 };
 
@@ -215,11 +245,13 @@ void CameraImpl::OnTakePictureSucceeded(const std::string& file_path) {
   }
 };
 
-void CameraImpl::OnTakePictureFailed(const std::string& error) {
+void CameraImpl::OnTakePictureFailed(CameraResult result,
+                                     const std::string& error) {
   auto pending_take_picture_result =
       GetPendingResultByType(PendingResultType::kTakePicture);
   if (pending_take_picture_result) {
-    pending_take_picture_result->Error("camera_error", error);
+    std::string error_code = GetErrorCode(result);
+    pending_take_picture_result->Error(error_code, error);
   }
 };
 
@@ -238,9 +270,10 @@ void CameraImpl::OnVideoRecordSucceeded(const std::string& file_path,
   }
 }
 
-void CameraImpl::OnVideoRecordFailed(const std::string& error){};
+void CameraImpl::OnVideoRecordFailed(CameraResult result,
+                                     const std::string& error){};
 
-void CameraImpl::OnCaptureError(const std::string& error) {
+void CameraImpl::OnCaptureError(CameraResult result, const std::string& error) {
   if (messenger_ && camera_id_ >= 0) {
     auto channel = GetMethodChannel();
 
@@ -250,7 +283,8 @@ void CameraImpl::OnCaptureError(const std::string& error) {
     channel->InvokeMethod(kErrorEvent, std::move(message_data));
   }
 
-  SendErrorForPendingResults("capture_error", error);
+  std::string error_code = GetErrorCode(result);
+  SendErrorForPendingResults(error_code, error);
 }
 
 void CameraImpl::OnCameraClosing() {

--- a/packages/camera/camera_windows/windows/camera.cpp
+++ b/packages/camera/camera_windows/windows/camera.cpp
@@ -28,8 +28,9 @@ std::string GetErrorCode(CameraResult result) {
     case CameraResult::kAccessDenied:
       return kCameraAccessDenied;
 
-    default:
+    case CameraResult::kSuccess:
     case CameraResult::kError:
+    default:
       return kCameraError;
   }
 }

--- a/packages/camera/camera_windows/windows/camera.h
+++ b/packages/camera/camera_windows/windows/camera.h
@@ -87,23 +87,31 @@ class CameraImpl : public Camera {
 
   // CaptureControllerListener
   void OnCreateCaptureEngineSucceeded(int64_t texture_id) override;
-  void OnCreateCaptureEngineFailed(const std::string& error) override;
+  void OnCreateCaptureEngineFailed(CameraResult result,
+                                   const std::string& error) override;
   void OnStartPreviewSucceeded(int32_t width, int32_t height) override;
-  void OnStartPreviewFailed(const std::string& error) override;
+  void OnStartPreviewFailed(CameraResult result,
+                            const std::string& error) override;
   void OnPausePreviewSucceeded() override;
-  void OnPausePreviewFailed(const std::string& error) override;
+  void OnPausePreviewFailed(CameraResult result,
+                            const std::string& error) override;
   void OnResumePreviewSucceeded() override;
-  void OnResumePreviewFailed(const std::string& error) override;
+  void OnResumePreviewFailed(CameraResult result,
+                             const std::string& error) override;
   void OnStartRecordSucceeded() override;
-  void OnStartRecordFailed(const std::string& error) override;
+  void OnStartRecordFailed(CameraResult result,
+                           const std::string& error) override;
   void OnStopRecordSucceeded(const std::string& file_path) override;
-  void OnStopRecordFailed(const std::string& error) override;
+  void OnStopRecordFailed(CameraResult result,
+                          const std::string& error) override;
   void OnTakePictureSucceeded(const std::string& file_path) override;
-  void OnTakePictureFailed(const std::string& error) override;
+  void OnTakePictureFailed(CameraResult result,
+                           const std::string& error) override;
   void OnVideoRecordSucceeded(const std::string& file_path,
                               int64_t video_duration) override;
-  void OnVideoRecordFailed(const std::string& error) override;
-  void OnCaptureError(const std::string& error) override;
+  void OnVideoRecordFailed(CameraResult result,
+                           const std::string& error) override;
+  void OnCaptureError(CameraResult result, const std::string& error) override;
 
   // Camera
   bool HasDeviceId(std::string& device_id) const override {

--- a/packages/camera/camera_windows/windows/capture_controller.h
+++ b/packages/camera/camera_windows/windows/capture_controller.h
@@ -207,28 +207,29 @@ class CaptureControllerImpl : public CaptureController,
   void StopTimedRecord();
 
   // Stops preview. Called internally on camera reset and dispose.
-  void StopPreview();
+  HRESULT StopPreview();
 
   // Handles capture engine initalization event.
-  void OnCaptureEngineInitialized(bool success, const std::string& error);
+  void OnCaptureEngineInitialized(CameraResult result,
+                                  const std::string& error);
 
   // Handles capture engine errors.
-  void OnCaptureEngineError(HRESULT hr, const std::string& error);
+  void OnCaptureEngineError(CameraResult result, const std::string& error);
 
   // Handles picture events.
-  void OnPicture(bool success, const std::string& error);
+  void OnPicture(CameraResult result, const std::string& error);
 
   // Handles preview started events.
-  void OnPreviewStarted(bool success, const std::string& error);
+  void OnPreviewStarted(CameraResult result, const std::string& error);
 
   // Handles preview stopped events.
-  void OnPreviewStopped(bool success, const std::string& error);
+  void OnPreviewStopped(CameraResult result, const std::string& error);
 
   // Handles record started events.
-  void OnRecordStarted(bool success, const std::string& error);
+  void OnRecordStarted(CameraResult result, const std::string& error);
 
   // Handles record stopped events.
-  void OnRecordStopped(bool success, const std::string& error);
+  void OnRecordStopped(CameraResult result, const std::string& error);
 
   bool media_foundation_started_ = false;
   bool record_audio_ = false;

--- a/packages/camera/camera_windows/windows/capture_controller_listener.h
+++ b/packages/camera/camera_windows/windows/capture_controller_listener.h
@@ -9,6 +9,18 @@
 
 namespace camera_windows {
 
+// Results that can occur when interacting with the camera.
+enum class CameraResult {
+  // Camera operation succeeded.
+  kSuccess,
+
+  // Camera operation failed.
+  kError,
+
+  // Camera access permission is denied.
+  kAccessDenied,
+};
+
 // Interface for classes that receives callbacks on events from the associated
 // |CaptureController|.
 class CaptureControllerListener {
@@ -22,8 +34,10 @@ class CaptureControllerListener {
 
   // Called by CaptureController if initializing the capture engine fails.
   //
-  // error: A string describing the error.
-  virtual void OnCreateCaptureEngineFailed(const std::string& error) = 0;
+  // result: The kind of result.
+  // error: The error message.
+  virtual void OnCreateCaptureEngineFailed(CameraResult result,
+                                           const std::string& error) = 0;
 
   // Called by CaptureController on successfully started preview.
   //
@@ -33,32 +47,40 @@ class CaptureControllerListener {
 
   // Called by CaptureController if starting the preview fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnStartPreviewFailed(const std::string& error) = 0;
+  virtual void OnStartPreviewFailed(CameraResult result,
+                                    const std::string& error) = 0;
 
   // Called by CaptureController on successfully paused preview.
   virtual void OnPausePreviewSucceeded() = 0;
 
   // Called by CaptureController if pausing the preview fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnPausePreviewFailed(const std::string& error) = 0;
+  virtual void OnPausePreviewFailed(CameraResult result,
+                                    const std::string& error) = 0;
 
   // Called by CaptureController on successfully resumed preview.
   virtual void OnResumePreviewSucceeded() = 0;
 
   // Called by CaptureController if resuming the preview fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnResumePreviewFailed(const std::string& error) = 0;
+  virtual void OnResumePreviewFailed(CameraResult result,
+                                     const std::string& error) = 0;
 
   // Called by CaptureController on successfully started recording.
   virtual void OnStartRecordSucceeded() = 0;
 
   // Called by CaptureController if starting the recording fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnStartRecordFailed(const std::string& error) = 0;
+  virtual void OnStartRecordFailed(CameraResult result,
+                                   const std::string& error) = 0;
 
   // Called by CaptureController on successfully stopped recording.
   //
@@ -67,8 +89,10 @@ class CaptureControllerListener {
 
   // Called by CaptureController if stopping the recording fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnStopRecordFailed(const std::string& error) = 0;
+  virtual void OnStopRecordFailed(CameraResult result,
+                                  const std::string& error) = 0;
 
   // Called by CaptureController on successfully captured picture.
   //
@@ -77,8 +101,10 @@ class CaptureControllerListener {
 
   // Called by CaptureController if taking picture fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnTakePictureFailed(const std::string& error) = 0;
+  virtual void OnTakePictureFailed(CameraResult result,
+                                   const std::string& error) = 0;
 
   // Called by CaptureController when timed recording is successfully recorded.
   //
@@ -89,14 +115,18 @@ class CaptureControllerListener {
 
   // Called by CaptureController if timed recording fails.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnVideoRecordFailed(const std::string& error) = 0;
+  virtual void OnVideoRecordFailed(CameraResult result,
+                                   const std::string& error) = 0;
 
   // Called by CaptureController if capture engine returns error.
   // For example when camera is disconnected while on use.
   //
+  // result: The kind of result.
   // error: A string describing the error.
-  virtual void OnCaptureError(const std::string& error) = 0;
+  virtual void OnCaptureError(CameraResult result,
+                              const std::string& error) = 0;
 };
 
 }  // namespace camera_windows

--- a/packages/camera/camera_windows/windows/capture_controller_listener.h
+++ b/packages/camera/camera_windows/windows/capture_controller_listener.h
@@ -35,7 +35,7 @@ class CaptureControllerListener {
   // Called by CaptureController if initializing the capture engine fails.
   //
   // result: The kind of result.
-  // error: The error message.
+  // error: A string describing the error.
   virtual void OnCreateCaptureEngineFailed(CameraResult result,
                                            const std::string& error) = 0;
 

--- a/packages/camera/camera_windows/windows/photo_handler.cpp
+++ b/packages/camera/camera_windows/windows/photo_handler.cpp
@@ -116,21 +116,23 @@ HRESULT PhotoHandler::InitPhotoSink(IMFCaptureEngine* capture_engine,
   return hr;
 }
 
-bool PhotoHandler::TakePhoto(const std::string& file_path,
-                             IMFCaptureEngine* capture_engine,
-                             IMFMediaType* base_media_type) {
+HRESULT PhotoHandler::TakePhoto(const std::string& file_path,
+                                IMFCaptureEngine* capture_engine,
+                                IMFMediaType* base_media_type) {
   assert(!file_path.empty());
   assert(capture_engine);
   assert(base_media_type);
 
   file_path_ = file_path;
 
-  if (FAILED(InitPhotoSink(capture_engine, base_media_type))) {
-    return false;
+  HRESULT hr = InitPhotoSink(capture_engine, base_media_type);
+  if (FAILED(hr)) {
+    return hr;
   }
 
   photo_state_ = PhotoState::kTakingPhoto;
-  return SUCCEEDED(capture_engine->TakePhoto());
+
+  return capture_engine->TakePhoto();
 }
 
 void PhotoHandler::OnPhotoTaken() {

--- a/packages/camera/camera_windows/windows/photo_handler.h
+++ b/packages/camera/camera_windows/windows/photo_handler.h
@@ -41,15 +41,15 @@ class PhotoHandler {
   // to take photo.
   //
   // Sets photo state to: kTakingPhoto.
-  // Returns false if photo cannot be taken.
   //
   // capture_engine:  A pointer to capture engine instance.
   //                  Called to take the photo.
   // base_media_type: A pointer to base media type used as a base
   //                  for the actual photo capture media type.
   // file_path:       A string that hold file path for photo capture.
-  bool TakePhoto(const std::string& file_path, IMFCaptureEngine* capture_engine,
-                 IMFMediaType* base_media_type);
+  HRESULT TakePhoto(const std::string& file_path,
+                    IMFCaptureEngine* capture_engine,
+                    IMFMediaType* base_media_type);
 
   // Set the photo handler recording state to: kIdle.
   void OnPhotoTaken();

--- a/packages/camera/camera_windows/windows/preview_handler.cpp
+++ b/packages/camera/camera_windows/windows/preview_handler.cpp
@@ -113,29 +113,31 @@ HRESULT PreviewHandler::InitPreviewSink(
   return hr;
 }
 
-bool PreviewHandler::StartPreview(IMFCaptureEngine* capture_engine,
-                                  IMFMediaType* base_media_type,
-                                  CaptureEngineListener* sample_callback) {
+HRESULT PreviewHandler::StartPreview(IMFCaptureEngine* capture_engine,
+                                     IMFMediaType* base_media_type,
+                                     CaptureEngineListener* sample_callback) {
   assert(capture_engine);
   assert(base_media_type);
 
-  if (FAILED(
-          InitPreviewSink(capture_engine, base_media_type, sample_callback))) {
-    return false;
+  HRESULT hr =
+      InitPreviewSink(capture_engine, base_media_type, sample_callback);
+
+  if (FAILED(hr)) {
+    return hr;
   }
 
   preview_state_ = PreviewState::kStarting;
-  return SUCCEEDED(capture_engine->StartPreview());
+  return capture_engine->StartPreview();
 }
 
-bool PreviewHandler::StopPreview(IMFCaptureEngine* capture_engine) {
+HRESULT PreviewHandler::StopPreview(IMFCaptureEngine* capture_engine) {
   if (preview_state_ == PreviewState::kStarting ||
       preview_state_ == PreviewState::kRunning ||
       preview_state_ == PreviewState::kPaused) {
     preview_state_ = PreviewState::kStopping;
-    return SUCCEEDED(capture_engine->StopPreview());
+    return capture_engine->StopPreview();
   }
-  return false;
+  return E_FAIL;
 }
 
 bool PreviewHandler::PausePreview() {

--- a/packages/camera/camera_windows/windows/preview_handler.h
+++ b/packages/camera/camera_windows/windows/preview_handler.h
@@ -45,7 +45,6 @@ class PreviewHandler {
 
   // Initializes preview sink and requests capture engine to start previewing.
   // Sets preview state to: starting.
-  // Returns false if recording cannot be started.
   //
   // capture_engine:  A pointer to capture engine instance. Used to start
   //                  the actual recording.
@@ -53,16 +52,15 @@ class PreviewHandler {
   //                  for the actual video capture media type.
   // sample_callback: A pointer to capture engine listener.
   //                  This is set as sample callback for preview sink.
-  bool StartPreview(IMFCaptureEngine* capture_engine,
-                    IMFMediaType* base_media_type,
-                    CaptureEngineListener* sample_callback);
+  HRESULT StartPreview(IMFCaptureEngine* capture_engine,
+                       IMFMediaType* base_media_type,
+                       CaptureEngineListener* sample_callback);
 
   // Stops existing recording.
-  // Returns false if recording cannot be stopped.
   //
   // capture_engine:  A pointer to capture engine instance. Used to stop
   //                  the ongoing recording.
-  bool StopPreview(IMFCaptureEngine* capture_engine);
+  HRESULT StopPreview(IMFCaptureEngine* capture_engine);
 
   // Set the preview handler recording state to: paused.
   bool PausePreview();

--- a/packages/camera/camera_windows/windows/record_handler.cpp
+++ b/packages/camera/camera_windows/windows/record_handler.cpp
@@ -192,10 +192,10 @@ HRESULT RecordHandler::InitRecordSink(IMFCaptureEngine* capture_engine,
   return hr;
 }
 
-bool RecordHandler::StartRecord(const std::string& file_path,
-                                int64_t max_duration,
-                                IMFCaptureEngine* capture_engine,
-                                IMFMediaType* base_media_type) {
+HRESULT RecordHandler::StartRecord(const std::string& file_path,
+                                   int64_t max_duration,
+                                   IMFCaptureEngine* capture_engine,
+                                   IMFMediaType* base_media_type) {
   assert(!file_path.empty());
   assert(capture_engine);
   assert(base_media_type);
@@ -206,23 +206,21 @@ bool RecordHandler::StartRecord(const std::string& file_path,
   recording_start_timestamp_us_ = -1;
   recording_duration_us_ = 0;
 
-  if (FAILED(InitRecordSink(capture_engine, base_media_type))) {
-    return false;
+  HRESULT hr = InitRecordSink(capture_engine, base_media_type);
+  if (FAILED(hr)) {
+    return hr;
   }
 
   recording_state_ = RecordState::kStarting;
-  capture_engine->StartRecord();
-
-  return true;
+  return capture_engine->StartRecord();
 }
 
-bool RecordHandler::StopRecord(IMFCaptureEngine* capture_engine) {
+HRESULT RecordHandler::StopRecord(IMFCaptureEngine* capture_engine) {
   if (recording_state_ == RecordState::kRunning) {
     recording_state_ = RecordState::kStopping;
-    HRESULT hr = capture_engine->StopRecord(true, false);
-    return SUCCEEDED(hr);
+    return capture_engine->StopRecord(true, false);
   }
-  return false;
+  return E_FAIL;
 }
 
 void RecordHandler::OnRecordStarted() {

--- a/packages/camera/camera_windows/windows/record_handler.h
+++ b/packages/camera/camera_windows/windows/record_handler.h
@@ -45,7 +45,6 @@ class RecordHandler {
   // Initializes record sink and requests capture engine to start recording.
   //
   // Sets record state to: starting.
-  // Returns false if recording cannot be started.
   //
   // file_path:       A string that hold file path for video capture.
   // max_duration:    A int64 value of maximun recording duration.
@@ -55,16 +54,15 @@ class RecordHandler {
   //                  the actual recording.
   // base_media_type: A pointer to base media type used as a base
   //                  for the actual video capture media type.
-  bool StartRecord(const std::string& file_path, int64_t max_duration,
-                   IMFCaptureEngine* capture_engine,
-                   IMFMediaType* base_media_type);
+  HRESULT StartRecord(const std::string& file_path, int64_t max_duration,
+                      IMFCaptureEngine* capture_engine,
+                      IMFMediaType* base_media_type);
 
   // Stops existing recording.
-  // Returns false if recording cannot be stopped.
   //
   // capture_engine:  A pointer to capture engine instance. Used to stop
   //                  the ongoing recording.
-  bool StopRecord(IMFCaptureEngine* capture_engine);
+  HRESULT StopRecord(IMFCaptureEngine* capture_engine);
 
   // Set the record handler recording state to: running.
   void OnRecordStarted();

--- a/packages/camera/camera_windows/windows/test/camera_test.cpp
+++ b/packages/camera/camera_windows/windows/test/camera_test.cpp
@@ -137,7 +137,7 @@ TEST(Camera, CreateCaptureEngineReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -153,7 +153,7 @@ TEST(Camera, CreateCaptureEngineReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -192,7 +192,7 @@ TEST(Camera, StartPreviewReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -208,7 +208,7 @@ TEST(Camera, StartPreviewReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -239,7 +239,7 @@ TEST(Camera, PausePreviewReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -255,7 +255,7 @@ TEST(Camera, PausePreviewReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -287,7 +287,7 @@ TEST(Camera, ResumePreviewReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -304,7 +304,7 @@ TEST(Camera, OnResumePreviewPermissionFailureReturnsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -336,7 +336,7 @@ TEST(Camera, StartRecordReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -352,7 +352,7 @@ TEST(Camera, StartRecordReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -369,7 +369,7 @@ TEST(Camera, OnStopRecordSucceededReturnsSuccess) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string file_path = "C:\temp\filename.mp4";
+  const std::string file_path = "C:\temp\filename.mp4";
 
   EXPECT_CALL(*result, ErrorInternal).Times(0);
   EXPECT_CALL(*result, SuccessInternal(Pointee(EncodableValue(file_path))));
@@ -385,7 +385,7 @@ TEST(Camera, StopRecordReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -401,7 +401,7 @@ TEST(Camera, StopRecordReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -418,7 +418,7 @@ TEST(Camera, OnTakePictureSucceededReturnsSuccess) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string file_path = "C:\\temp\\filename.jpeg";
+  const std::string file_path = "C:\\temp\\filename.jpeg";
 
   EXPECT_CALL(*result, ErrorInternal).Times(0);
   EXPECT_CALL(*result, SuccessInternal(Pointee(EncodableValue(file_path))));
@@ -434,7 +434,7 @@ TEST(Camera, TakePictureReportsError) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result, ErrorInternal(Eq("camera_error"), Eq(error_text), _));
@@ -450,7 +450,7 @@ TEST(Camera, TakePictureReportsAccessDenied) {
   std::unique_ptr<MockMethodResult> result =
       std::make_unique<MockMethodResult>();
 
-  std::string error_text = "error_text";
+  const std::string error_text = "error_text";
 
   EXPECT_CALL(*result, SuccessInternal).Times(0);
   EXPECT_CALL(*result,
@@ -470,12 +470,12 @@ TEST(Camera, OnVideoRecordSucceededInvokesCameraChannelEvent) {
   std::unique_ptr<MockBinaryMessenger> binary_messenger =
       std::make_unique<MockBinaryMessenger>();
 
-  std::string file_path = "C:\\temp\\filename.mp4";
-  int64_t camera_id = 12345;
+  const std::string file_path = "C:\\temp\\filename.mp4";
+  const int64_t camera_id = 12345;
   std::string camera_channel =
       std::string("plugins.flutter.io/camera_windows/camera") +
       std::to_string(camera_id);
-  int64_t video_duration = 1000000;
+  const int64_t video_duration = 1000000;
 
   EXPECT_CALL(*capture_controller_factory, CreateCaptureController)
       .Times(1)

--- a/packages/camera/camera_windows/windows/test/camera_test.cpp
+++ b/packages/camera/camera_windows/windows/test/camera_test.cpp
@@ -144,7 +144,24 @@ TEST(Camera, CreateCaptureEngineReportsError) {
 
   camera->AddPendingResult(PendingResultType::kCreateCamera, std::move(result));
 
-  camera->OnCreateCaptureEngineFailed(error_text);
+  camera->OnCreateCaptureEngineFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, CreateCaptureEngineReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kCreateCamera, std::move(result));
+
+  camera->OnCreateCaptureEngineFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnStartPreviewSucceededReturnsFrameSize) {
@@ -182,7 +199,24 @@ TEST(Camera, StartPreviewReportsError) {
 
   camera->AddPendingResult(PendingResultType::kInitialize, std::move(result));
 
-  camera->OnStartPreviewFailed(error_text);
+  camera->OnStartPreviewFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, StartPreviewReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kInitialize, std::move(result));
+
+  camera->OnStartPreviewFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnPausePreviewSucceededReturnsSuccess) {
@@ -212,7 +246,24 @@ TEST(Camera, PausePreviewReportsError) {
 
   camera->AddPendingResult(PendingResultType::kPausePreview, std::move(result));
 
-  camera->OnPausePreviewFailed(error_text);
+  camera->OnPausePreviewFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, PausePreviewReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kPausePreview, std::move(result));
+
+  camera->OnPausePreviewFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnResumePreviewSucceededReturnsSuccess) {
@@ -244,7 +295,25 @@ TEST(Camera, ResumePreviewReportsError) {
   camera->AddPendingResult(PendingResultType::kResumePreview,
                            std::move(result));
 
-  camera->OnResumePreviewFailed(error_text);
+  camera->OnResumePreviewFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, OnResumePreviewPermissionFailureReturnsError) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kResumePreview,
+                           std::move(result));
+
+  camera->OnResumePreviewFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnStartRecordSucceededReturnsSuccess) {
@@ -274,7 +343,24 @@ TEST(Camera, StartRecordReportsError) {
 
   camera->AddPendingResult(PendingResultType::kStartRecord, std::move(result));
 
-  camera->OnStartRecordFailed(error_text);
+  camera->OnStartRecordFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, StartRecordReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kStartRecord, std::move(result));
+
+  camera->OnStartRecordFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnStopRecordSucceededReturnsSuccess) {
@@ -306,7 +392,24 @@ TEST(Camera, StopRecordReportsError) {
 
   camera->AddPendingResult(PendingResultType::kStopRecord, std::move(result));
 
-  camera->OnStopRecordFailed(error_text);
+  camera->OnStopRecordFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, StopRecordReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kStopRecord, std::move(result));
+
+  camera->OnStopRecordFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnTakePictureSucceededReturnsSuccess) {
@@ -338,7 +441,24 @@ TEST(Camera, TakePictureReportsError) {
 
   camera->AddPendingResult(PendingResultType::kTakePicture, std::move(result));
 
-  camera->OnTakePictureFailed(error_text);
+  camera->OnTakePictureFailed(CameraResult::kError, error_text);
+}
+
+TEST(Camera, TakePictureReportsAccessDenied) {
+  std::unique_ptr<CameraImpl> camera =
+      std::make_unique<CameraImpl>(MOCK_DEVICE_ID);
+  std::unique_ptr<MockMethodResult> result =
+      std::make_unique<MockMethodResult>();
+
+  std::string error_text = "error_text";
+
+  EXPECT_CALL(*result, SuccessInternal).Times(0);
+  EXPECT_CALL(*result,
+              ErrorInternal(Eq("CameraAccessDenied"), Eq(error_text), _));
+
+  camera->AddPendingResult(PendingResultType::kTakePicture, std::move(result));
+
+  camera->OnTakePictureFailed(CameraResult::kAccessDenied, error_text);
 }
 
 TEST(Camera, OnVideoRecordSucceededInvokesCameraChannelEvent) {

--- a/packages/camera/camera_windows/windows/test/mocks.h
+++ b/packages/camera/camera_windows/windows/test/mocks.h
@@ -134,41 +134,43 @@ class MockCamera : public Camera {
               (override));
   MOCK_METHOD(std::unique_ptr<flutter::MethodResult<>>, GetPendingResultByType,
               (PendingResultType type));
-  MOCK_METHOD(void, OnCreateCaptureEngineFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnCreateCaptureEngineFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnStartPreviewSucceeded, (int32_t width, int32_t height),
               (override));
-  MOCK_METHOD(void, OnStartPreviewFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnStartPreviewFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnResumePreviewSucceeded, (), (override));
-  MOCK_METHOD(void, OnResumePreviewFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnResumePreviewFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnPausePreviewSucceeded, (), (override));
-  MOCK_METHOD(void, OnPausePreviewFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnPausePreviewFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnStartRecordSucceeded, (), (override));
-  MOCK_METHOD(void, OnStartRecordFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnStartRecordFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnStopRecordSucceeded, (const std::string& file_path),
               (override));
-  MOCK_METHOD(void, OnStopRecordFailed, (const std::string& error), (override));
+  MOCK_METHOD(void, OnStopRecordFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnTakePictureSucceeded, (const std::string& file_path),
               (override));
-  MOCK_METHOD(void, OnTakePictureFailed, (const std::string& error),
-              (override));
+  MOCK_METHOD(void, OnTakePictureFailed,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(void, OnVideoRecordSucceeded,
               (const std::string& file_path, int64_t video_duration),
               (override));
-  MOCK_METHOD(void, OnVideoRecordFailed, (const std::string& error),
-              (override));
-  MOCK_METHOD(void, OnCaptureError, (const std::string& error), (override));
+  MOCK_METHOD(void, OnVideoRecordFailed,
+              (CameraResult result, const std::string& error), (override));
+  MOCK_METHOD(void, OnCaptureError,
+              (CameraResult result, const std::string& error), (override));
 
   MOCK_METHOD(bool, HasDeviceId, (std::string & device_id), (const override));
   MOCK_METHOD(bool, HasCameraId, (int64_t camera_id), (const override));


### PR DESCRIPTION
## Background

The camera plugin reports issues to the Flutter app by throwing [`CameraException`](https://pub.dev/documentation/camera_platform_interface/latest/camera_platform_interface/CameraException-class.html)s. As per [this proposal](https://docs.google.com/document/d/1t_5FYzOTlBWC6arHc4_8VuG0BUOtIyP9xWvbDER5Y9I/edit), we would like to standardize the `CameraException`'s `code` value so that common errors can be handled consistently across platforms.

This change makes the Windows camera plugin set the error code to `CameraAccessDenied` when camera permissions were denied. This is a breaking change as previously the error code would've been `camera_error` or `capture_error`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
