### PR TITLE
Uncomments avoid_redundant_argument_values in analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -83,7 +83,7 @@ linter:
     # - avoid_positional_boolean_parameters # would have been nice to enable this but by now there's too many places that break it
     # - avoid_print # LOCAL CHANGE - Needs to be enabled and violations fixed.
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
-    # - avoid_redundant_argument_values # LOCAL CHANGE - Needs to be enabled and violations fixed.
+    - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters

--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.10.0
 
 * **Breaking Change** Bumps default camera_web package version, which updates permission exception code from `cameraPermission` to `CameraAccessDenied`.

--- a/packages/camera/camera/example/lib/main.dart
+++ b/packages/camera/camera/example/lib/main.dart
@@ -159,7 +159,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
                 _cameraTogglesRowWidget(),
                 _thumbnailWidget(),
@@ -271,7 +270,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       children: <Widget>[
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_on),
@@ -325,7 +323,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       child: ClipRect(
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
@@ -397,7 +394,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -435,7 +431,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Text(_minAvailableExposureOffset.toString()),
                   Slider(
@@ -486,7 +481,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -523,7 +517,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         IconButton(
           icon: const Icon(Icons.camera_alt),

--- a/packages/camera/camera/test/camera_preview_test.dart
+++ b/packages/camera/camera/test/camera_preview_test.dart
@@ -201,7 +201,6 @@ void main() {
       controller.value = controller.value.copyWith(
         isInitialized: true,
         deviceOrientation: DeviceOrientation.portraitUp,
-        lockedCaptureOrientation: null,
         recordingOrientation: const Optional<DeviceOrientation>.fromNullable(
             DeviceOrientation.landscapeLeft),
         previewSize: const Size(480, 640),

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -697,7 +697,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -742,7 +741,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -787,7 +785,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -1219,7 +1216,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -1285,7 +1281,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -1339,7 +1334,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 
@@ -1385,7 +1379,6 @@ void main() {
         PlatformException(
           code: 'TEST_ERROR',
           message: 'This is a test error message',
-          details: null,
         ),
       );
 

--- a/packages/camera/camera/test/camera_value_test.dart
+++ b/packages/camera/camera/test/camera_value_test.dart
@@ -18,7 +18,6 @@ void main() {
     test('Can be created', () {
       const CameraValue cameraValue = CameraValue(
         isInitialized: false,
-        errorDescription: null,
         previewSize: Size(10, 10),
         isRecordingPaused: false,
         isRecordingVideo: false,
@@ -32,7 +31,6 @@ void main() {
         lockedCaptureOrientation: DeviceOrientation.portraitUp,
         recordingOrientation: DeviceOrientation.portraitUp,
         focusPointSupported: true,
-        isPreviewPaused: false,
         previewPauseOrientation: DeviceOrientation.portraitUp,
       );
 
@@ -129,7 +127,6 @@ void main() {
     test('toString() works as expected', () {
       const CameraValue cameraValue = CameraValue(
           isInitialized: false,
-          errorDescription: null,
           previewSize: Size(10, 10),
           isRecordingPaused: false,
           isRecordingVideo: false,

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.10.0
 
 * **Breaking Change** Updates Android camera access permission error codes to be consistent with other platforms. If your app still handles the legacy `cameraPermission` exception, please update it to handle the new permission exception codes that are noted in the README.

--- a/packages/camera/camera_android/example/lib/main.dart
+++ b/packages/camera/camera_android/example/lib/main.dart
@@ -161,7 +161,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
                 _cameraTogglesRowWidget(),
                 _thumbnailWidget(),
@@ -274,7 +273,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       children: <Widget>[
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_on),
@@ -328,7 +326,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       child: ClipRect(
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
@@ -400,7 +397,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -439,7 +435,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Text(_minAvailableExposureOffset.toString()),
                   Slider(
@@ -490,7 +485,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -528,7 +522,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         IconButton(
           icon: const Icon(Icons.camera_alt),

--- a/packages/camera/camera_android/test/android_camera_test.dart
+++ b/packages/camera/camera_android/test/android_camera_test.dart
@@ -961,7 +961,6 @@ void main() {
           'setZoomLevel': PlatformException(
             code: 'ZOOM_ERROR',
             message: 'Illegal zoom error',
-            details: null,
           )
         },
       );

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 0.9.8+4
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 0.9.8+3
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 0.9.8+3
 
 * Ignores missing return warnings in preparation for [upcoming analysis changes](https://github.com/flutter/flutter/issues/105750).
 

--- a/packages/camera/camera_avfoundation/example/lib/main.dart
+++ b/packages/camera/camera_avfoundation/example/lib/main.dart
@@ -161,7 +161,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
           Padding(
             padding: const EdgeInsets.all(5.0),
             child: Row(
-              mainAxisAlignment: MainAxisAlignment.start,
               children: <Widget>[
                 _cameraTogglesRowWidget(),
                 _thumbnailWidget(),
@@ -274,7 +273,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       children: <Widget>[
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_on),
@@ -328,7 +326,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
       child: ClipRect(
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
           children: <Widget>[
             IconButton(
               icon: const Icon(Icons.flash_off),
@@ -400,7 +397,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -439,7 +435,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   Text(_minAvailableExposureOffset.toString()),
                   Slider(
@@ -490,7 +485,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
               ),
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
                   TextButton(
                     style: styleAuto,
@@ -528,7 +522,6 @@ class _CameraExampleHomeState extends State<CameraExampleHome>
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         IconButton(
           icon: const Icon(Icons.camera_alt),

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -961,7 +961,6 @@ void main() {
           'setZoomLevel': PlatformException(
             code: 'ZOOM_ERROR',
             message: 'Illegal zoom error',
-            details: null,
           )
         },
       );

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 2.2.2
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 2.2.1
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 2.2.1
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/104231).
 * Ignores missing return warnings in preparation for [upcoming analysis changes](https://github.com/flutter/flutter/issues/105750).

--- a/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
+++ b/packages/camera/camera_platform_interface/test/method_channel/method_channel_camera_test.dart
@@ -954,7 +954,6 @@ void main() {
             'setZoomLevel': PlatformException(
               code: 'ZOOM_ERROR',
               message: 'Illegal zoom error',
-              details: null,
             )
           },
         );

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 0.3.1+1
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 0.3.1
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 0.3.1
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
 

--- a/packages/camera/camera_web/example/integration_test/camera_options_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_options_test.dart
@@ -30,7 +30,7 @@ void main() {
     testWidgets('supports value equality', (WidgetTester tester) async {
       expect(
         CameraOptions(
-          audio: const AudioConstraints(enabled: false),
+          audio: const AudioConstraints(),
           video: VideoConstraints(
             facingMode: FacingModeConstraint(CameraType.environment),
             width:
@@ -42,7 +42,7 @@ void main() {
         ),
         equals(
           CameraOptions(
-            audio: const AudioConstraints(enabled: false),
+            audio: const AudioConstraints(),
             video: VideoConstraints(
               facingMode: FacingModeConstraint(CameraType.environment),
               width: const VideoSizeConstraint(

--- a/packages/camera/camera_web/example/integration_test/camera_service_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_service_test.dart
@@ -102,7 +102,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -124,7 +123,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -146,7 +144,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -168,7 +165,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -190,7 +186,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -212,7 +207,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -234,7 +228,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -256,7 +249,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -278,7 +270,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -300,7 +291,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -322,7 +312,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -344,7 +333,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()
@@ -365,7 +353,6 @@ void main() {
           expect(
             () => cameraService.getMediaStreamForOptions(
               const CameraOptions(),
-              cameraId: cameraId,
             ),
             throwsA(
               isA<CameraWebException>()

--- a/packages/camera/camera_web/example/integration_test/camera_web_test.dart
+++ b/packages/camera/camera_web/example/integration_test/camera_web_test.dart
@@ -593,7 +593,7 @@ void main() {
               (Camera camera) => camera.options,
               'options',
               CameraOptions(
-                audio: const AudioConstraints(enabled: false),
+                audio: const AudioConstraints(),
                 video: VideoConstraints(
                   facingMode: FacingModeConstraint(CameraType.user),
                   width: VideoSizeConstraint(
@@ -2330,7 +2330,6 @@ void main() {
         when(
           () => cameraService.getMediaStreamForOptions(
             any(),
-            cameraId: cameraId,
           ),
         ).thenAnswer((Invocation _) async => videoElement.captureStream());
 

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+6
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.1.0+5
 
 * Fixes bugs in in error handling.

--- a/packages/camera/camera_windows/example/lib/main.dart
+++ b/packages/camera/camera_windows/example/lib/main.dart
@@ -114,7 +114,6 @@ class _MyAppState extends State<MyApp> {
 
       await CameraPlatform.instance.initializeCamera(
         cameraId,
-        imageFormatGroup: ImageFormatGroup.unknown,
       );
 
       final CameraInitializedEvent event = await initialized;
@@ -429,7 +428,6 @@ class _MyAppState extends State<MyApp> {
                   vertical: 10,
                 ),
                 child: Align(
-                  alignment: Alignment.center,
                   child: Container(
                     constraints: const BoxConstraints(
                       maxHeight: 500,

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.9.0
 
 * **BREAKING CHANGE**: Methods that take `XTypeGroup`s now throw an

--- a/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
@@ -21,8 +21,7 @@ void main() {
 
         final MockDomHelper mockDomHelper = MockDomHelper(
             files: <XFile>[mockFile],
-            expectAccept: '.jpg,.jpeg,image/png,image/*',
-            expectMultiple: false);
+            expectAccept: '.jpg,.jpeg,image/png,image/*');
 
         final FileSelectorWeb plugin =
             FileSelectorWeb(domHelper: mockDomHelper);

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.10+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.1.10
 
 * Avoids map shift when scrolling on iOS.

--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -59,7 +59,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        compassEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -97,7 +96,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        mapToolbarEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -215,7 +213,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        zoomGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -277,7 +274,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        liteModeEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           mapIdCompleter.complete(controller.mapId);
         },
@@ -334,7 +330,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        rotateGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -374,7 +369,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        tiltGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -413,7 +407,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        scrollGesturesEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -572,7 +565,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        trafficEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -592,7 +584,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        buildingsEnabled: true,
         onMapCreated: (GoogleMapController controller) {
           mapIdCompleter.complete(controller.mapId);
         },
@@ -617,8 +608,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        myLocationButtonEnabled: true,
-        myLocationEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           mapIdCompleter.complete(controller.mapId);
         },
@@ -638,7 +627,6 @@ void main() {
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
         myLocationButtonEnabled: false,
-        myLocationEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           fail('OnMapCreated should get called only once.');
         },
@@ -661,7 +649,6 @@ void main() {
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
         myLocationButtonEnabled: false,
-        myLocationEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           mapIdCompleter.complete(controller.mapId);
         },
@@ -686,8 +673,6 @@ void main() {
       child: GoogleMap(
         key: key,
         initialCameraPosition: _kInitialCameraPosition,
-        myLocationButtonEnabled: true,
-        myLocationEnabled: false,
         onMapCreated: (GoogleMapController controller) {
           mapIdCompleter.complete(controller.mapId);
         },
@@ -988,9 +973,7 @@ void main() {
         tileOverlayId: const TileOverlayId('tile_overlay_1'),
         tileProvider: _DebugTileProvider(),
         zIndex: 2,
-        visible: true,
         transparency: 0.2,
-        fadeIn: true,
       );
 
       final TileOverlay tileOverlay2 = TileOverlay(
@@ -1047,18 +1030,14 @@ void main() {
         tileOverlayId: const TileOverlayId('tile_overlay_1'),
         tileProvider: _DebugTileProvider(),
         zIndex: 2,
-        visible: true,
         transparency: 0.2,
-        fadeIn: true,
       );
 
       final TileOverlay tileOverlay2 = TileOverlay(
         tileOverlayId: const TileOverlayId('tile_overlay_2'),
         tileProvider: _DebugTileProvider(),
         zIndex: 3,
-        visible: true,
         transparency: 0.5,
-        fadeIn: true,
       );
       await tester.pumpWidget(
         Directionality(
@@ -1127,9 +1106,7 @@ void main() {
         tileOverlayId: const TileOverlayId('tile_overlay_1'),
         tileProvider: _DebugTileProvider(),
         zIndex: 2,
-        visible: true,
         transparency: 0.2,
-        fadeIn: true,
       );
 
       await tester.pumpWidget(
@@ -1201,7 +1178,6 @@ class _DebugTileProvider implements TileProvider {
       textDirection: TextDirection.ltr,
     );
     textPainter.layout(
-      minWidth: 0.0,
       maxWidth: width.toDouble(),
     );
     const Offset offset = Offset(0, 0);

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_click.dart
@@ -90,7 +90,6 @@ class _MapClickBodyState extends State<_MapClickBody> {
       )));
     }
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_ui.dart
@@ -336,7 +336,6 @@ class MapUiBodyState extends State<MapUiBody> {
       );
     }
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/padding.dart
@@ -68,7 +68,6 @@ class MarkerIconsBodyState extends State<MarkerIconsBody> {
     columnChildren.addAll(<Widget>[_paddingInput(), _buttons()]);
 
     return Column(
-      mainAxisAlignment: MainAxisAlignment.start,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: columnChildren,
     );

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/place_marker.dart
@@ -402,7 +402,6 @@ class PlaceMarkerBodyState extends State<PlaceMarkerBody> {
           padding: const EdgeInsets.only(left: 12, right: 12),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceAround,
-            mainAxisSize: MainAxisSize.max,
             children: <Widget>[
               if (markerPosition == null)
                 Container()

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/tile_overlay.dart
@@ -137,7 +137,6 @@ class _DebugTileProvider implements TileProvider {
       textDirection: TextDirection.ltr,
     );
     textPainter.layout(
-      minWidth: 0.0,
       maxWidth: width.toDouble(),
     );
     const Offset offset = Offset(0, 0);

--- a/packages/google_maps_flutter/google_maps_flutter/test/fake_maps_controllers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/fake_maps_controllers.dart
@@ -12,8 +12,7 @@ class FakePlatformGoogleMap {
   FakePlatformGoogleMap(int id, Map<dynamic, dynamic> params)
       : cameraPosition =
             CameraPosition.fromMap(params['initialCameraPosition']),
-        channel = MethodChannel(
-            'plugins.flutter.io/google_maps_$id', const StandardMethodCodec()) {
+        channel = MethodChannel('plugins.flutter.io/google_maps_$id') {
     channel.setMockMethodCallHandler(onMethodCall);
     updateOptions(params['options'] as Map<dynamic, dynamic>);
     updateMarkers(params);

--- a/packages/google_maps_flutter/google_maps_flutter/test/google_map_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/google_map_test.dart
@@ -90,7 +90,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          compassEnabled: true,
         ),
       ),
     );
@@ -119,7 +118,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          mapToolbarEnabled: true,
         ),
       ),
     );
@@ -233,7 +231,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          minMaxZoomPreference: MinMaxZoomPreference.unbounded,
         ),
       ),
     );
@@ -263,7 +260,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          rotateGesturesEnabled: true,
         ),
       ),
     );
@@ -292,7 +288,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          scrollGesturesEnabled: true,
         ),
       ),
     );
@@ -321,7 +316,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          tiltGesturesEnabled: true,
         ),
       ),
     );
@@ -379,7 +373,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          zoomGesturesEnabled: true,
         ),
       ),
     );
@@ -408,7 +401,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          zoomControlsEnabled: true,
         ),
       ),
     );
@@ -422,7 +414,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          myLocationEnabled: false,
         ),
       ),
     );
@@ -452,7 +443,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          myLocationEnabled: false,
         ),
       ),
     );
@@ -537,7 +527,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          trafficEnabled: false,
         ),
       ),
     );
@@ -581,7 +570,6 @@ void main() {
         textDirection: TextDirection.ltr,
         child: GoogleMap(
           initialCameraPosition: CameraPosition(target: LatLng(10.0, 15.0)),
-          buildingsEnabled: true,
         ),
       ),
     );

--- a/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/polyline_updates_test.dart
@@ -200,8 +200,7 @@ void main() {
   });
 
   testWidgets('Update non platform related attr', (WidgetTester tester) async {
-    Polyline p1 =
-        const Polyline(polylineId: PolylineId('polyline_1'), onTap: null);
+    Polyline p1 = const Polyline(polylineId: PolylineId('polyline_1'));
     final Set<Polyline> prev = <Polyline>{p1};
     p1 = Polyline(
         polylineId: const PolylineId('polyline_1'), onTap: () => print(2 + 2));

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.2.1
 
 * Adds a new interface for inspecting the platform map state in tests.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/types/tile_overlay_test.dart
@@ -35,7 +35,6 @@ void main() {
       const TileOverlay tileOverlay = TileOverlay(
           tileOverlayId: TileOverlayId('id'),
           fadeIn: false,
-          tileProvider: null,
           transparency: 0.1,
           zIndex: 1,
           visible: false,
@@ -91,7 +90,6 @@ void main() {
       const TileOverlay tileOverlayDifferentProvider = TileOverlay(
           tileOverlayId: TileOverlayId('id1'),
           fadeIn: false,
-          tileProvider: null,
           transparency: 0.1,
           zIndex: 1,
           visible: false,

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.4.0+1
 
 * Updates `README.md` to describe a hit-testing issue when Flutter widgets are overlaid on top of the Map widget.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
@@ -450,8 +450,6 @@ void main() {
             initialCameraPosition: const CameraPosition(
               target: LatLng(43.308, -5.6910),
               zoom: 12,
-              bearing: 0,
-              tilt: 0,
             ),
           );
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/projection_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/projection_test.dart
@@ -51,7 +51,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
 
@@ -75,7 +74,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
         final GoogleMapController controller = await controllerCompleter.future;
@@ -99,7 +97,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
         final GoogleMapController controller = await controllerCompleter.future;
@@ -124,7 +121,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
 
@@ -149,7 +145,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
         final GoogleMapController controller = await controllerCompleter.future;
@@ -179,7 +174,6 @@ void main() {
         await pumpCenteredMap(
           tester,
           initialCamera: initialCamera,
-          size: size,
           onMapCreated: onMapCreated,
         );
         final GoogleMapController controller = await controllerCompleter.future;

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.4.1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 5.4.0
 
 * Adds support for configuring `serverClientId` through `GoogleSignIn` constructor.

--- a/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
+++ b/packages/google_sign_in/google_sign_in/lib/google_sign_in.dart
@@ -192,10 +192,7 @@ class GoogleSignIn {
     List<String> scopes = const <String>[],
     String? hostedDomain,
   }) {
-    return GoogleSignIn(
-        signInOption: SignInOption.standard,
-        scopes: scopes,
-        hostedDomain: hostedDomain);
+    return GoogleSignIn(scopes: scopes, hostedDomain: hostedDomain);
   }
 
   /// Factory for creating sign in suitable for games. This option is only

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.5+4
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.8.5+3
 
 * Adds argument error assertions to the app-facing package, to ensure

--- a/packages/image_picker/image_picker/test/image_picker_deprecated_test.dart
+++ b/packages/image_picker/image_picker/test/image_picker_deprecated_test.dart
@@ -79,36 +79,15 @@ void main() {
               imageQuality: 70);
 
           verifyInOrder(<Object>[
+            mockPlatform.pickImage(source: ImageSource.camera),
+            mockPlatform.pickImage(source: ImageSource.camera, maxWidth: 10.0),
+            mockPlatform.pickImage(source: ImageSource.camera, maxHeight: 10.0),
             mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: null,
-                imageQuality: null),
+                source: ImageSource.camera, maxWidth: 10.0, maxHeight: 20.0),
             mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: null,
-                imageQuality: null),
+                source: ImageSource.camera, maxWidth: 10.0, imageQuality: 70),
             mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: 10.0,
-                imageQuality: null),
-            mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: 20.0,
-                imageQuality: null),
-            mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: null,
-                imageQuality: 70),
-            mockPlatform.pickImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: 10.0,
-                imageQuality: 70),
+                source: ImageSource.camera, maxHeight: 10.0, imageQuality: 70),
             mockPlatform.pickImage(
                 source: ImageSource.camera,
                 maxWidth: 10.0,
@@ -128,9 +107,7 @@ void main() {
           final ImagePicker picker = ImagePicker();
           await picker.getImage(source: ImageSource.camera);
 
-          verify(mockPlatform.pickImage(
-              source: ImageSource.camera,
-              preferredCameraDevice: CameraDevice.rear));
+          verify(mockPlatform.pickImage(source: ImageSource.camera));
         });
 
         test('camera position can set to front', () async {
@@ -173,13 +150,9 @@ void main() {
               maxDuration: const Duration(seconds: 10));
 
           verifyInOrder(<Object>[
+            mockPlatform.pickVideo(source: ImageSource.camera),
             mockPlatform.pickVideo(
                 source: ImageSource.camera,
-                preferredCameraDevice: CameraDevice.rear,
-                maxDuration: null),
-            mockPlatform.pickVideo(
-                source: ImageSource.camera,
-                preferredCameraDevice: CameraDevice.rear,
                 maxDuration: const Duration(seconds: 10)),
           ]);
         });
@@ -195,9 +168,7 @@ void main() {
           final ImagePicker picker = ImagePicker();
           await picker.getVideo(source: ImageSource.camera);
 
-          verify(mockPlatform.pickVideo(
-              source: ImageSource.camera,
-              preferredCameraDevice: CameraDevice.rear));
+          verify(mockPlatform.pickVideo(source: ImageSource.camera));
         });
 
         test('camera position can set to front', () async {
@@ -277,18 +248,12 @@ void main() {
               maxWidth: 10.0, maxHeight: 20.0, imageQuality: 70);
 
           verifyInOrder(<Object>[
-            mockPlatform.pickMultiImage(
-                maxWidth: null, maxHeight: null, imageQuality: null),
-            mockPlatform.pickMultiImage(
-                maxWidth: 10.0, maxHeight: null, imageQuality: null),
-            mockPlatform.pickMultiImage(
-                maxWidth: null, maxHeight: 10.0, imageQuality: null),
-            mockPlatform.pickMultiImage(
-                maxWidth: 10.0, maxHeight: 20.0, imageQuality: null),
-            mockPlatform.pickMultiImage(
-                maxWidth: 10.0, maxHeight: null, imageQuality: 70),
-            mockPlatform.pickMultiImage(
-                maxWidth: null, maxHeight: 10.0, imageQuality: 70),
+            mockPlatform.pickMultiImage(),
+            mockPlatform.pickMultiImage(maxWidth: 10.0),
+            mockPlatform.pickMultiImage(maxHeight: 10.0),
+            mockPlatform.pickMultiImage(maxWidth: 10.0, maxHeight: 20.0),
+            mockPlatform.pickMultiImage(maxWidth: 10.0, imageQuality: 70),
+            mockPlatform.pickMultiImage(maxHeight: 10.0, imageQuality: 70),
             mockPlatform.pickMultiImage(
                 maxWidth: 10.0, maxHeight: 20.0, imageQuality: 70),
           ]);

--- a/packages/image_picker/image_picker/test/image_picker_test.dart
+++ b/packages/image_picker/image_picker/test/image_picker_test.dart
@@ -76,36 +76,15 @@ void main() {
               imageQuality: 70);
 
           verifyInOrder(<Object>[
+            mockPlatform.getImage(source: ImageSource.camera),
+            mockPlatform.getImage(source: ImageSource.camera, maxWidth: 10.0),
+            mockPlatform.getImage(source: ImageSource.camera, maxHeight: 10.0),
             mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: null,
-                imageQuality: null),
+                source: ImageSource.camera, maxWidth: 10.0, maxHeight: 20.0),
             mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: null,
-                imageQuality: null),
+                source: ImageSource.camera, maxWidth: 10.0, imageQuality: 70),
             mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: 10.0,
-                imageQuality: null),
-            mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: 20.0,
-                imageQuality: null),
-            mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: 10.0,
-                maxHeight: null,
-                imageQuality: 70),
-            mockPlatform.getImage(
-                source: ImageSource.camera,
-                maxWidth: null,
-                maxHeight: 10.0,
-                imageQuality: 70),
+                source: ImageSource.camera, maxHeight: 10.0, imageQuality: 70),
             mockPlatform.getImage(
                 source: ImageSource.camera,
                 maxWidth: 10.0,
@@ -138,9 +117,7 @@ void main() {
           final ImagePicker picker = ImagePicker();
           await picker.pickImage(source: ImageSource.camera);
 
-          verify(mockPlatform.getImage(
-              source: ImageSource.camera,
-              preferredCameraDevice: CameraDevice.rear));
+          verify(mockPlatform.getImage(source: ImageSource.camera));
         });
 
         test('camera position can set to front', () async {
@@ -183,13 +160,9 @@ void main() {
               maxDuration: const Duration(seconds: 10));
 
           verifyInOrder(<Object>[
+            mockPlatform.getVideo(source: ImageSource.camera),
             mockPlatform.getVideo(
                 source: ImageSource.camera,
-                preferredCameraDevice: CameraDevice.rear,
-                maxDuration: null),
-            mockPlatform.getVideo(
-                source: ImageSource.camera,
-                preferredCameraDevice: CameraDevice.rear,
                 maxDuration: const Duration(seconds: 10)),
           ]);
         });
@@ -205,9 +178,7 @@ void main() {
           final ImagePicker picker = ImagePicker();
           await picker.pickVideo(source: ImageSource.camera);
 
-          verify(mockPlatform.getVideo(
-              source: ImageSource.camera,
-              preferredCameraDevice: CameraDevice.rear));
+          verify(mockPlatform.getVideo(source: ImageSource.camera));
         });
 
         test('camera position can set to front', () async {
@@ -312,18 +283,12 @@ void main() {
               maxWidth: 10.0, maxHeight: 20.0, imageQuality: 70);
 
           verifyInOrder(<Object>[
-            mockPlatform.getMultiImage(
-                maxWidth: null, maxHeight: null, imageQuality: null),
-            mockPlatform.getMultiImage(
-                maxWidth: 10.0, maxHeight: null, imageQuality: null),
-            mockPlatform.getMultiImage(
-                maxWidth: null, maxHeight: 10.0, imageQuality: null),
-            mockPlatform.getMultiImage(
-                maxWidth: 10.0, maxHeight: 20.0, imageQuality: null),
-            mockPlatform.getMultiImage(
-                maxWidth: 10.0, maxHeight: null, imageQuality: 70),
-            mockPlatform.getMultiImage(
-                maxWidth: null, maxHeight: 10.0, imageQuality: 70),
+            mockPlatform.getMultiImage(),
+            mockPlatform.getMultiImage(maxWidth: 10.0),
+            mockPlatform.getMultiImage(maxHeight: 10.0),
+            mockPlatform.getMultiImage(maxWidth: 10.0, maxHeight: 20.0),
+            mockPlatform.getMultiImage(maxWidth: 10.0, imageQuality: 70),
+            mockPlatform.getMultiImage(maxHeight: 10.0, imageQuality: 70),
             mockPlatform.getMultiImage(
                 maxWidth: 10.0, maxHeight: 20.0, imageQuality: 70),
           ]);

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.6.1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.6.0
 
 * Deprecates `getMultiImage` in favor of a new method `getMultiImageWithOptions`.

--- a/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
+++ b/packages/image_picker/image_picker_platform_interface/test/new_method_channel_image_picker_test.dart
@@ -1443,9 +1443,7 @@ void main() {
 
       test('Request full metadata argument defaults to true', () async {
         returnValue = <dynamic>['0', '1'];
-        await picker.getMultiImageWithOptions(
-          options: const MultiImagePickerOptions(),
-        );
+        await picker.getMultiImageWithOptions();
 
         expect(
           log,

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.7
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 3.0.6
 
 * Ignores deprecation warnings for upcoming styleFrom button API changes.

--- a/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
@@ -277,7 +277,6 @@ class _MyAppState extends State<_MyApp> {
 
                       purchaseParam = GooglePlayPurchaseParam(
                           productDetails: productDetails,
-                          applicationUserName: null,
                           changeSubscriptionParam: (oldSubscription != null)
                               ? ChangeSubscriptionParam(
                                   oldPurchaseDetails: oldSubscription,
@@ -288,14 +287,12 @@ class _MyAppState extends State<_MyApp> {
                     } else {
                       purchaseParam = PurchaseParam(
                         productDetails: productDetails,
-                        applicationUserName: null,
                       );
                     }
 
                     if (productDetails.id == _kConsumableId) {
                       _inAppPurchase.buyConsumable(
-                          purchaseParam: purchaseParam,
-                          autoConsume: _kAutoConsume || Platform.isIOS);
+                          purchaseParam: purchaseParam);
                     } else {
                       _inAppPurchase.buyNonConsumable(
                           purchaseParam: purchaseParam);
@@ -358,7 +355,6 @@ class _MyAppState extends State<_MyApp> {
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: Row(
-        mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
           TextButton(

--- a/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_test.dart
+++ b/packages/in_app_purchase/in_app_purchase/test/in_app_purchase_test.dart
@@ -184,12 +184,12 @@ class MockInAppPurchasePlatform extends Fake
   @override
   Future<void> completePurchase(PurchaseDetails purchase) {
     log.add(const MethodCall('completePurchase'));
-    return Future<void>.value(null);
+    return Future<void>.value();
   }
 
   @override
   Future<void> restorePurchases({String? applicationUserName}) {
     log.add(const MethodCall('restorePurchases'));
-    return Future<void>.value(null);
+    return Future<void>.value();
   }
 }

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.3+2
+
+* Removes unnecessary imports.
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.2.3+1
 
 * Updates `json_serializable` to fix warnings in generated code.

--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:in_app_purchase_android/billing_client_wrappers.dart';
@@ -282,7 +281,6 @@ class _MyAppState extends State<_MyApp> {
                       final GooglePlayPurchaseParam purchaseParam =
                           GooglePlayPurchaseParam(
                               productDetails: productDetails,
-                              applicationUserName: null,
                               changeSubscriptionParam: oldSubscription != null
                                   ? ChangeSubscriptionParam(
                                       oldPurchaseDetails: oldSubscription,
@@ -291,8 +289,7 @@ class _MyAppState extends State<_MyApp> {
                                   : null);
                       if (productDetails.id == _kConsumableId) {
                         _inAppPurchasePlatform.buyConsumable(
-                            purchaseParam: purchaseParam,
-                            autoConsume: _kAutoConsume || Platform.isIOS);
+                            purchaseParam: purchaseParam);
                       } else {
                         _inAppPurchasePlatform.buyNonConsumable(
                             purchaseParam: purchaseParam);

--- a/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -95,7 +95,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: methodName,
-        value: null,
       );
 
       expect(
@@ -110,7 +109,7 @@ void main() {
   test('endConnection', () async {
     const String endConnectionName = 'BillingClient#endConnection()';
     expect(stubPlatform.countPreviousCalls(endConnectionName), equals(0));
-    stubPlatform.addResponse(name: endConnectionName, value: null);
+    stubPlatform.addResponse(name: endConnectionName);
     await billingClient.endConnection();
     expect(stubPlatform.countPreviousCalls(endConnectionName), equals(1));
   });
@@ -162,7 +161,7 @@ void main() {
     });
 
     test('handles null method channel response', () async {
-      stubPlatform.addResponse(name: queryMethodName, value: null);
+      stubPlatform.addResponse(name: queryMethodName);
 
       final SkuDetailsResponseWrapper response = await billingClient
           .querySkuDetails(
@@ -227,8 +226,7 @@ void main() {
               sku: skuDetails.sku,
               accountId: accountId,
               obfuscatedProfileId: profileId,
-              oldSku: dummyOldPurchase.sku,
-              purchaseToken: null),
+              oldSku: dummyOldPurchase.sku),
           throwsAssertionError);
 
       expect(
@@ -236,7 +234,6 @@ void main() {
               sku: skuDetails.sku,
               accountId: accountId,
               obfuscatedProfileId: profileId,
-              oldSku: null,
               purchaseToken: dummyOldPurchase.purchaseToken),
           throwsAssertionError);
     });
@@ -337,7 +334,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: launchMethodName,
-        value: null,
       );
       const SkuDetailsWrapper skuDetails = dummySkuDetails;
       expect(
@@ -400,7 +396,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: queryPurchasesMethodName,
-        value: null,
       );
       final PurchasesResultWrapper response =
           await billingClient.queryPurchases(SkuType.inapp);
@@ -466,7 +461,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: queryPurchaseHistoryMethodName,
-        value: null,
       );
       final PurchasesHistoryResult response =
           await billingClient.queryPurchaseHistory(SkuType.inapp);
@@ -501,7 +495,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: consumeMethodName,
-        value: null,
       );
       final BillingResultWrapper billingResult =
           await billingClient.consumeAsync('dummy token');
@@ -534,7 +527,6 @@ void main() {
     test('handles method channel returning null', () async {
       stubPlatform.addResponse(
         name: acknowledgeMethodName,
-        value: null,
       );
       final BillingResultWrapper billingResult =
           await billingClient.acknowledgePurchase('dummy token');

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_addition_test.dart
@@ -35,7 +35,7 @@ void main() {
     stubPlatform.addResponse(
         name: startConnectionCall,
         value: buildBillingResultMap(expectedBillingResult));
-    stubPlatform.addResponse(name: endConnectionCall, value: null);
+    stubPlatform.addResponse(name: endConnectionCall);
     iapAndroidPlatformAddition =
         InAppPurchaseAndroidPlatformAddition(BillingClient((_) {}));
   });

--- a/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/in_app_purchase_android_platform_test.dart
@@ -39,7 +39,7 @@ void main() {
     stubPlatform.addResponse(
         name: startConnectionCall,
         value: buildBillingResultMap(expectedBillingResult));
-    stubPlatform.addResponse(name: endConnectionCall, value: null);
+    stubPlatform.addResponse(name: endConnectionCall);
 
     InAppPurchaseAndroidPlatform.registerPlatform();
     iapAndroidPlatform =

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.1+1
+
+* Removes unnecessary imports.
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.3.1
 
 * Adds ability to purchase more than one of a product.

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:in_app_purchase_platform_interface/in_app_purchase_platform_interface.dart';
@@ -21,8 +20,6 @@ void main() {
 
   runApp(_MyApp());
 }
-
-const bool _kAutoConsume = true;
 
 const String _kConsumableId = 'consumable';
 const String _kUpgradeId = 'upgrade';
@@ -268,12 +265,10 @@ class _MyAppState extends State<_MyApp> {
                     onPressed: () {
                       final PurchaseParam purchaseParam = PurchaseParam(
                         productDetails: productDetails,
-                        applicationUserName: null,
                       );
                       if (productDetails.id == _kConsumableId) {
                         _iapStoreKitPlatform.buyConsumable(
-                            purchaseParam: purchaseParam,
-                            autoConsume: _kAutoConsume || Platform.isIOS);
+                            purchaseParam: purchaseParam);
                       } else {
                         _iapStoreKitPlatform.buyNonConsumable(
                             purchaseParam: purchaseParam);
@@ -335,7 +330,6 @@ class _MyAppState extends State<_MyApp> {
     return Padding(
       padding: const EdgeInsets.all(4.0),
       child: Row(
-        mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.end,
         children: <Widget>[
           TextButton(

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -75,8 +75,7 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
             purchaseParam is AppStorePurchaseParam ? purchaseParam.quantity : 1,
         applicationUsername: purchaseParam.applicationUserName,
         simulatesAskToBuyInSandbox: purchaseParam is AppStorePurchaseParam &&
-            purchaseParam.simulatesAskToBuyInSandbox,
-        requestData: null));
+            purchaseParam.simulatesAskToBuyInSandbox));
 
     return true; // There's no error feedback from iOS here to return.
   }

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
@@ -63,8 +63,6 @@ class FakeStoreKitPlatform {
       payment: SKPaymentWrapper(productIdentifier: id, quantity: quantity),
       transactionState: SKPaymentTransactionStateWrapper.purchasing,
       transactionTimeStamp: 123123.121,
-      error: null,
-      originalTransaction: null,
     );
   }
 
@@ -76,9 +74,7 @@ class FakeStoreKitPlatform {
             SKPaymentWrapper(productIdentifier: productId, quantity: quantity),
         transactionState: SKPaymentTransactionStateWrapper.purchased,
         transactionTimeStamp: 123123.121,
-        transactionIdentifier: transactionId,
-        error: null,
-        originalTransaction: null);
+        transactionIdentifier: transactionId);
   }
 
   SKPaymentTransactionWrapper createFailedTransaction(String productId,
@@ -92,8 +88,7 @@ class FakeStoreKitPlatform {
         error: const SKError(
             code: 0,
             domain: 'ios_domain',
-            userInfo: <String, Object>{'message': 'an error message'}),
-        originalTransaction: null);
+            userInfo: <String, Object>{'message': 'an error message'}));
   }
 
   SKPaymentTransactionWrapper createCanceledTransaction(
@@ -108,8 +103,7 @@ class FakeStoreKitPlatform {
         error: SKError(
             code: errorCode,
             domain: 'ios_domain',
-            userInfo: const <String, Object>{'message': 'an error message'}),
-        originalTransaction: null);
+            userInfo: const <String, Object>{'message': 'an error message'}));
   }
 
   SKPaymentTransactionWrapper createRestoredTransaction(
@@ -120,9 +114,7 @@ class FakeStoreKitPlatform {
             SKPaymentWrapper(productIdentifier: productId, quantity: quantity),
         transactionState: SKPaymentTransactionStateWrapper.restored,
         transactionTimeStamp: 123123.121,
-        transactionIdentifier: transactionId,
-        error: null,
-        originalTransaction: null);
+        transactionIdentifier: transactionId);
   }
 
   Future<dynamic> onMethodCall(MethodCall call) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_methodchannel_apis_test.dart
@@ -222,7 +222,7 @@ class FakeStoreKitPlatform {
       case '-[InAppPurchasePlugin startProductRequest:result:]':
         startProductRequestParam = call.arguments as List<dynamic>;
         if (getProductRequestFailTest) {
-          return Future<dynamic>.value(null);
+          return Future<dynamic>.value();
         }
         return Future<Map<String, dynamic>>.value(
             buildProductResponseMap(dummyProductResponseWrapper));
@@ -240,7 +240,7 @@ class FakeStoreKitPlatform {
       // payment queue
       case '-[SKPaymentQueue canMakePayments:]':
         if (testReturnNull) {
-          return Future<dynamic>.value(null);
+          return Future<dynamic>.value();
         }
         return Future<bool>.value(true);
       case '-[SKPaymentQueue transactions]':

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
@@ -19,7 +19,6 @@ final SKPaymentTransactionWrapper dummyOriginalTransaction =
     SKPaymentTransactionWrapper(
   transactionState: SKPaymentTransactionStateWrapper.purchased,
   payment: dummyPayment,
-  originalTransaction: null,
   transactionTimeStamp: 1231231231.00,
   transactionIdentifier: '123123',
   error: dummyError,

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.1.0
 
 * Adds Windows support.

--- a/packages/local_auth/local_auth/example/lib/main.dart
+++ b/packages/local_auth/local_auth/example/lib/main.dart
@@ -83,7 +83,6 @@ class _MyAppState extends State<MyApp> {
       authenticated = await auth.authenticate(
         localizedReason: 'Let OS determine authentication method',
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
         ),
       );
@@ -117,7 +116,6 @@ class _MyAppState extends State<MyApp> {
         localizedReason:
             'Scan your fingerprint (or face or whatever) to authenticate',
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
           biometricOnly: true,
         ),

--- a/packages/local_auth/local_auth/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth/test/local_auth_test.dart
@@ -37,7 +37,6 @@ void main() {
         const AndroidAuthMessages(),
         const WindowsAuthMessages(),
       ],
-      options: const AuthenticationOptions(),
     )).called(1);
   });
 

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.9
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 1.0.8
 
 * Removes usages of `FingerprintManager` and other `BiometricManager` deprecated method usages.

--- a/packages/local_auth/local_auth_android/example/lib/main.dart
+++ b/packages/local_auth/local_auth_android/example/lib/main.dart
@@ -86,7 +86,6 @@ class _MyAppState extends State<MyApp> {
         localizedReason: 'Let OS determine authentication method',
         authMessages: <AuthMessages>[const AndroidAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
         ),
       );
@@ -121,7 +120,6 @@ class _MyAppState extends State<MyApp> {
             'Scan your fingerprint (or face or whatever) to authenticate',
         authMessages: <AuthMessages>[const AndroidAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
           biometricOnly: true,
         ),

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 1.0.7
 
 * Updates references to the obsolete master branch.

--- a/packages/local_auth/local_auth_ios/example/lib/main.dart
+++ b/packages/local_auth/local_auth_ios/example/lib/main.dart
@@ -86,7 +86,6 @@ class _MyAppState extends State<MyApp> {
         localizedReason: 'Let OS determine authentication method',
         authMessages: <AuthMessages>[const IOSAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
         ),
       );
@@ -121,7 +120,6 @@ class _MyAppState extends State<MyApp> {
             'Scan your fingerprint (or face or whatever) to authenticate',
         authMessages: <AuthMessages>[const IOSAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
           biometricOnly: true,
         ),

--- a/packages/local_auth/local_auth_windows/CHANGELOG.md
+++ b/packages/local_auth/local_auth_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 1.0.1
 
 * Updates references to the obsolete master branch.

--- a/packages/local_auth/local_auth_windows/example/lib/main.dart
+++ b/packages/local_auth/local_auth_windows/example/lib/main.dart
@@ -86,7 +86,6 @@ class _MyAppState extends State<MyApp> {
         localizedReason: 'Let OS determine authentication method',
         authMessages: <AuthMessages>[const WindowsAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
         ),
       );
@@ -121,7 +120,6 @@ class _MyAppState extends State<MyApp> {
             'Scan your fingerprint (or face or whatever) to authenticate',
         authMessages: <AuthMessages>[const WindowsAuthMessages()],
         options: const AuthenticationOptions(
-          useErrorDialogs: true,
           stickyAuth: true,
           biometricOnly: true,
         ),

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.12
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.0.11
 
 * Updates references to the obsolete master branch.

--- a/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
+++ b/packages/path_provider/path_provider/example/integration_test/path_provider_test.dart
@@ -73,8 +73,7 @@ void main() {
     testWidgets('getExternalStorageDirectories (type: $type)',
         (WidgetTester tester) async {
       if (Platform.isIOS) {
-        final Future<List<Directory>?> result =
-            getExternalStorageDirectories(type: null);
+        final Future<List<Directory>?> result = getExternalStorageDirectories();
         expect(result, throwsA(isInstanceOf<UnsupportedError>()));
       } else if (Platform.isAndroid) {
         final List<Directory>? directories =

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.1.0
 
 * Upgrades `package:ffi` dependency to 2.0.0.

--- a/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
+++ b/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart
@@ -161,7 +161,7 @@ class PathProviderWindows extends PathProviderPlatform {
         if (hr == E_INVALIDARG || hr == E_FAIL) {
           throw WindowsException(hr);
         }
-        return Future<String?>.value(null);
+        return Future<String?>.value();
       }
 
       final String path = pathPtrPtr.value.toDartString();

--- a/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
+++ b/packages/path_provider/path_provider_windows/test/path_provider_windows_test.dart
@@ -63,7 +63,7 @@ void main() {
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    }, language: languageEn, encoding: encodingCP1252);
+    }, encoding: encodingCP1252);
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {
@@ -77,7 +77,7 @@ void main() {
     pathProvider.versionInfoQuerier = FakeVersionInfoQuerier(<String, String>{
       'CompanyName': 'A Company',
       'ProductName': 'Amazing App',
-    }, language: languageEn, encoding: encodingUnicode);
+    });
     final String? path = await pathProvider.getApplicationSupportPath();
     expect(path, isNotNull);
     if (path != null) {

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.6
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 6.1.5
 
 * Migrates `README.md` examples to the [`code-excerpt` system](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#readme-code).

--- a/packages/url_launcher/url_launcher/test/src/url_launcher_string_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/url_launcher_string_test.dart
@@ -83,8 +83,7 @@ void main() {
           webOnlyWindowName: null,
         )
         ..setResponse(true);
-      expect(await launchUrlString(urlString, mode: LaunchMode.platformDefault),
-          isTrue);
+      expect(await launchUrlString(urlString), isTrue);
     });
 
     test('explicit default launch mode with non-web URL', () async {
@@ -100,8 +99,7 @@ void main() {
           webOnlyWindowName: null,
         )
         ..setResponse(true);
-      expect(await launchUrlString(urlString, mode: LaunchMode.platformDefault),
-          isTrue);
+      expect(await launchUrlString(urlString), isTrue);
     });
 
     test('in-app webview', () async {

--- a/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/url_launcher_uri_test.dart
@@ -88,7 +88,7 @@ void main() {
           webOnlyWindowName: null,
         )
         ..setResponse(true);
-      expect(await launchUrl(url, mode: LaunchMode.platformDefault), isTrue);
+      expect(await launchUrl(url), isTrue);
     });
 
     test('explicit default launch mode with non-web URL', () async {
@@ -104,7 +104,7 @@ void main() {
           webOnlyWindowName: null,
         )
         ..setResponse(true);
-      expect(await launchUrl(url, mode: LaunchMode.platformDefault), isTrue);
+      expect(await launchUrl(url), isTrue);
     });
 
     test('in-app webview', () async {

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.5+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.4.5
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/104231).

--- a/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
+++ b/packages/video_player/video_player/example/integration_test/controller_swap_test.dart
@@ -65,7 +65,7 @@ void main() {
 
       // Expect that `another` played.
       expect(another.value.position,
-          (Duration position) => position > const Duration(seconds: 0));
+          (Duration position) => position > const Duration());
 
       await expectLater(started.future, completes);
       await expectLater(ended.future, completes);
@@ -76,7 +76,6 @@ void main() {
 
 Widget renderVideoWidget(VideoPlayerController controller) {
   return Material(
-    elevation: 0,
     child: Directionality(
       textDirection: TextDirection.ltr,
       child: Center(

--- a/packages/video_player/video_player/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player/example/integration_test/video_player_test.dart
@@ -49,7 +49,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(_controller.value.position, const Duration(seconds: 0));
+      expect(_controller.value.position, const Duration());
       expect(_controller.value.isPlaying, false);
       // The WebM version has a slightly different duration than the MP4.
       expect(_controller.value.duration,
@@ -87,7 +87,7 @@ void main() {
 
         expect(_controller.value.isPlaying, true);
         expect(_controller.value.position,
-            (Duration position) => position > const Duration(seconds: 0));
+            (Duration position) => position > const Duration());
       },
     );
 
@@ -177,7 +177,6 @@ void main() {
       }
 
       await tester.pumpWidget(Material(
-        elevation: 0,
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Center(
@@ -265,7 +264,7 @@ void main() {
 
         expect(_controller.value.isPlaying, false);
         expect(_controller.value.position,
-            (Duration position) => position > const Duration(seconds: 0));
+            (Duration position) => position > const Duration());
 
         await expectLater(started.future, completes);
         await expectLater(ended.future, completes);
@@ -285,7 +284,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(_controller.value.position, const Duration(seconds: 0));
+      expect(_controller.value.position, const Duration());
       expect(_controller.value.isPlaying, false);
       // Due to the duration calculation accurancy between platforms,
       // the milliseconds on Web will be a slightly different from natives.
@@ -308,7 +307,7 @@ void main() {
       expect(_controller.value.isPlaying, true);
       expect(
         _controller.value.position,
-        (Duration position) => position > const Duration(milliseconds: 0),
+        (Duration position) => position > const Duration(),
       );
     });
 

--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -273,7 +273,7 @@ class _ControlsOverlay extends StatelessWidget {
     Duration(seconds: -3),
     Duration(seconds: -1, milliseconds: -500),
     Duration(milliseconds: -250),
-    Duration(milliseconds: 0),
+    Duration(),
     Duration(milliseconds: 250),
     Duration(seconds: 1, milliseconds: 500),
     Duration(seconds: 3),
@@ -419,7 +419,6 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
   @override
   Widget build(BuildContext context) {
     return Material(
-      elevation: 0,
       child: Center(
         child: FutureBuilder<bool>(
           future: started(),

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -1005,7 +1005,6 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
       );
     } else {
       progressIndicator = LinearProgressIndicator(
-        value: null,
         valueColor: AlwaysStoppedAnimation<Color>(colors.playedColor),
         backgroundColor: colors.backgroundColor,
       );

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -175,8 +175,8 @@ void main() {
 
   testWidgets('no transform when rotationCorrection is zero',
       (WidgetTester tester) async {
-    final FakeController controller = FakeController.value(
-        VideoPlayerValue(duration: Duration.zero, rotationCorrection: 0));
+    final FakeController controller =
+        FakeController.value(VideoPlayerValue(duration: Duration.zero));
     controller.textureId = 1;
     await tester.pumpWidget(VideoPlayer(controller));
     expect(find.byType(Transform), findsNothing);
@@ -209,8 +209,7 @@ void main() {
     });
 
     testWidgets('handles null text', (WidgetTester tester) async {
-      await tester
-          .pumpWidget(const MaterialApp(home: ClosedCaption(text: null)));
+      await tester.pumpWidget(const MaterialApp(home: ClosedCaption()));
       expect(find.byType(Text), findsNothing);
     });
 
@@ -373,7 +372,7 @@ void main() {
       );
       expect(
           controller.textureId, VideoPlayerController.kUninitializedTextureId);
-      expect(await controller.position, const Duration(seconds: 0));
+      expect(await controller.position, const Duration());
       await controller.initialize();
 
       await controller.dispose();
@@ -471,7 +470,7 @@ void main() {
           'https://127.0.0.1',
         );
         await controller.initialize();
-        expect(await controller.position, const Duration(seconds: 0));
+        expect(await controller.position, const Duration());
 
         await controller.seekTo(const Duration(milliseconds: 500));
 
@@ -494,13 +493,13 @@ void main() {
           'https://127.0.0.1',
         );
         await controller.initialize();
-        expect(await controller.position, const Duration(seconds: 0));
+        expect(await controller.position, const Duration());
 
         await controller.seekTo(const Duration(seconds: 100));
         expect(await controller.position, const Duration(seconds: 1));
 
         await controller.seekTo(const Duration(seconds: -100));
-        expect(await controller.position, const Duration(seconds: 0));
+        expect(await controller.position, const Duration());
       });
     });
 
@@ -789,7 +788,7 @@ void main() {
         await tester.pumpAndSettle();
         expect(controller.value.isBuffering, isTrue);
 
-        const Duration bufferStart = Duration(seconds: 0);
+        const Duration bufferStart = Duration();
         const Duration bufferEnd = Duration(milliseconds: 500);
         fakeVideoEventStream.add(VideoEvent(
             eventType: VideoEventType.bufferingUpdate,
@@ -884,7 +883,7 @@ void main() {
           text: 'foo', number: 0, start: Duration.zero, end: Duration.zero);
       const Duration captionOffset = Duration(milliseconds: 250);
       final List<DurationRange> buffered = <DurationRange>[
-        DurationRange(const Duration(seconds: 0), const Duration(seconds: 4))
+        DurationRange(const Duration(), const Duration(seconds: 4))
       ];
       const bool isInitialized = true;
       const bool isPlaying = true;
@@ -1035,9 +1034,7 @@ void main() {
     test('false allowBackgroundPlayback pauses playback', () async {
       final VideoPlayerController controller = VideoPlayerController.file(
         File(''),
-        videoPlayerOptions: VideoPlayerOptions(
-          allowBackgroundPlayback: false,
-        ),
+        videoPlayerOptions: VideoPlayerOptions(),
       );
       await controller.initialize();
       await controller.play();
@@ -1121,7 +1118,7 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Future<Duration> getPosition(int textureId) async {
     calls.add('position');
-    return _positions[textureId] ?? const Duration(seconds: 0);
+    return _positions[textureId] ?? const Duration();
   }
 
   @override

--- a/packages/video_player/video_player/test/web_vtt_test.dart
+++ b/packages/video_player/video_player/test/web_vtt_test.dart
@@ -38,8 +38,7 @@ void main() {
 
       expect(parsedFile.captions[0].start,
           const Duration(seconds: 5, milliseconds: 200));
-      expect(parsedFile.captions[0].end,
-          const Duration(seconds: 6, milliseconds: 000));
+      expect(parsedFile.captions[0].end, const Duration(seconds: 6));
       expect(parsedFile.captions[0].text,
           "You know I'm so excited my glasses are falling off here.");
     });
@@ -106,7 +105,7 @@ void main() {
     final Caption firstCaption = parsedFile.captions.single;
     expect(firstCaption.number, 1);
     expect(firstCaption.start, const Duration(seconds: 13));
-    expect(firstCaption.end, const Duration(seconds: 16, milliseconds: 0));
+    expect(firstCaption.end, const Duration(seconds: 16));
     expect(firstCaption.text, 'Valid');
   });
 }

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.9
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.3.8
 
 * Updates ExoPlayer to 2.18.0.

--- a/packages/video_player/video_player_android/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player_android/example/integration_test/video_player_test.dart
@@ -57,7 +57,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(await _controller.position, const Duration(seconds: 0));
+      expect(await _controller.position, const Duration());
       expect(_controller.value.duration,
           const Duration(seconds: 7, milliseconds: 540));
     });
@@ -68,8 +68,7 @@ void main() {
       await _controller.play();
       await tester.pumpAndSettle(_playDuration);
 
-      expect(
-          await _controller.position, greaterThan(const Duration(seconds: 0)));
+      expect(await _controller.position, greaterThan(const Duration()));
     });
 
     testWidgets('can seek', (WidgetTester tester) async {
@@ -117,8 +116,7 @@ void main() {
       await _controller.play();
       await tester.pumpAndSettle(_playDuration);
 
-      expect(
-          await _controller.position, greaterThan(const Duration(seconds: 0)));
+      expect(await _controller.position, greaterThan(const Duration()));
     });
   });
 
@@ -149,8 +147,7 @@ void main() {
       await tester.pumpAndSettle(_playDuration);
       await _controller.pause();
 
-      expect(
-          await _controller.position, greaterThan(const Duration(seconds: 0)));
+      expect(await _controller.position, greaterThan(const Duration()));
 
       await expectLater(started.future, completes);
       await expectLater(ended.future, completes);

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -521,7 +521,6 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
       );
     } else {
       progressIndicator = const LinearProgressIndicator(
-        value: null,
         valueColor: AlwaysStoppedAnimation<Color>(playedColor),
         backgroundColor: backgroundColor,
       );

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -341,7 +341,7 @@ void main() {
                 eventType: VideoEventType.bufferingUpdate,
                 buffered: <DurationRange>[
                   DurationRange(
-                    const Duration(milliseconds: 0),
+                    const Duration(),
                     const Duration(milliseconds: 1234),
                   ),
                   DurationRange(

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 2.3.7
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 2.3.6
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 2.3.6
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
 

--- a/packages/video_player/video_player_avfoundation/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/example/integration_test/video_player_test.dart
@@ -57,7 +57,7 @@ void main() {
       await _controller.initialize();
 
       expect(_controller.value.isInitialized, true);
-      expect(await _controller.position, const Duration(seconds: 0));
+      expect(await _controller.position, const Duration());
       expect(_controller.value.duration,
           const Duration(seconds: 7, milliseconds: 540));
     });
@@ -69,7 +69,7 @@ void main() {
       await tester.pumpAndSettle(_playDuration);
 
       expect(
-          await _controller.position, greaterThan(const Duration(seconds: 0)));
+          await _controller.position, greaterThan(const Duration()));
     });
 
     testWidgets('can seek', (WidgetTester tester) async {
@@ -124,7 +124,7 @@ void main() {
       await tester.pumpAndSettle(_playDuration);
 
       expect(
-          await _controller.position, greaterThan(const Duration(seconds: 0)));
+          await _controller.position, greaterThan(const Duration()));
     });
   });
 
@@ -159,7 +159,7 @@ void main() {
       // fixed on the native side to wait for completion, so this is testing
       // the native code rather than the MiniController position cache.
       expect(
-          _controller.value.position, greaterThan(const Duration(seconds: 0)));
+          _controller.value.position, greaterThan(const Duration()));
 
       await expectLater(started.future, completes);
       await expectLater(ended.future, completes);

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -521,7 +521,6 @@ class _VideoProgressIndicatorState extends State<VideoProgressIndicator> {
       );
     } else {
       progressIndicator = const LinearProgressIndicator(
-        value: null,
         valueColor: AlwaysStoppedAnimation<Color>(playedColor),
         backgroundColor: backgroundColor,
       );

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -320,7 +320,7 @@ void main() {
                 eventType: VideoEventType.bufferingUpdate,
                 buffered: <DurationRange>[
                   DurationRange(
-                    const Duration(milliseconds: 0),
+                    const Duration(),
                     const Duration(milliseconds: 1234),
                   ),
                   DurationRange(

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 5.1.5
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 5.1.4
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 5.1.4
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
 

--- a/packages/video_player/video_player_platform_interface/lib/messages.dart
+++ b/packages/video_player/video_player_platform_interface/lib/messages.dart
@@ -156,7 +156,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -181,7 +180,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -206,7 +204,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -231,7 +228,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -256,7 +252,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -282,7 +277,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -307,7 +301,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -332,7 +325,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -357,7 +349,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -382,7 +373,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =
@@ -408,7 +398,6 @@ class VideoPlayerApi {
       throw PlatformException(
         code: 'channel-error',
         message: 'Unable to establish connection on channel.',
-        details: null,
       );
     } else if (replyMap['error'] != null) {
       final Map<Object?, Object?> error =

--- a/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
+++ b/packages/video_player/video_player_platform_interface/test/method_channel_video_player_test.dart
@@ -345,7 +345,7 @@ void main() {
                 eventType: VideoEventType.bufferingUpdate,
                 buffered: <DurationRange>[
                   DurationRange(
-                    const Duration(milliseconds: 0),
+                    const Duration(),
                     const Duration(milliseconds: 1234),
                   ),
                   DurationRange(

--- a/packages/webview_flutter/webview_flutter/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 3.0.6
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 3.0.5
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 3.0.5
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/104231).
 * Updates references to the obsolete master branch.

--- a/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/example/integration_test/webview_flutter_test.dart
@@ -401,8 +401,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -460,8 +458,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -558,7 +554,6 @@ Future<void> main() async {
               pageLoaded.complete(null);
             },
             initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
-            allowsInlineMediaPlayback: false,
           ),
         ),
       );
@@ -663,8 +658,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -732,8 +725,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );

--- a/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter/test/webview_flutter_test.dart
@@ -85,9 +85,7 @@ void main() {
       JavascriptMode.unrestricted,
     );
 
-    await tester.pumpWidget(const WebView(
-      javascriptMode: JavascriptMode.disabled,
-    ));
+    await tester.pumpWidget(const WebView());
 
     final CreationParams disabledparams = captureBuildArgs(
       mockWebViewPlatform,
@@ -455,7 +453,6 @@ void main() {
     await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
-        javascriptMode: JavascriptMode.disabled,
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
         },
@@ -489,7 +486,6 @@ void main() {
     await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
-        javascriptMode: JavascriptMode.disabled,
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
         },
@@ -527,7 +523,6 @@ void main() {
     await tester.pumpWidget(
       WebView(
         initialUrl: 'https://flutter.io',
-        javascriptMode: JavascriptMode.disabled,
         onWebViewCreated: (WebViewController webViewController) {
           controller = webViewController;
         },
@@ -757,7 +752,6 @@ void main() {
     testWidgets('onPageStarted is null', (WidgetTester tester) async {
       await tester.pumpWidget(const WebView(
         initialUrl: 'https://youtube.com',
-        onPageStarted: null,
       ));
 
       final WebViewPlatformCallbacksHandler handler = captureBuildArgs(
@@ -818,7 +812,6 @@ void main() {
     testWidgets('onPageFinished is null', (WidgetTester tester) async {
       await tester.pumpWidget(const WebView(
         initialUrl: 'https://youtube.com',
-        onPageFinished: null,
       ));
 
       final WebViewPlatformCallbacksHandler handler = captureBuildArgs(
@@ -878,7 +871,6 @@ void main() {
     testWidgets('onLoadingProgress is null', (WidgetTester tester) async {
       await tester.pumpWidget(const WebView(
         initialUrl: 'https://youtube.com',
-        onProgress: null,
       ));
 
       final WebViewPlatformCallbacksHandler handler = captureBuildArgs(
@@ -1033,7 +1025,6 @@ void main() {
 
       await tester.pumpWidget(WebView(
         key: key,
-        debuggingEnabled: false,
       ));
 
       final WebSettings disabledSettings =
@@ -1046,9 +1037,7 @@ void main() {
 
   group('zoomEnabled', () {
     testWidgets('Enable zoom', (WidgetTester tester) async {
-      await tester.pumpWidget(const WebView(
-        zoomEnabled: true,
-      ));
+      await tester.pumpWidget(const WebView());
 
       final CreationParams params = captureBuildArgs(
         mockWebViewPlatform,
@@ -1075,7 +1064,6 @@ void main() {
 
       await tester.pumpWidget(WebView(
         key: key,
-        zoomEnabled: true,
       ));
 
       final WebSettings enabledSettings =

--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.3
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.9.2
 
 * Updates the Java InstanceManager to take a listener for when an object is garbage collected.

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -406,8 +406,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -465,8 +463,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -616,8 +612,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -685,8 +679,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );

--- a/packages/webview_flutter/webview_flutter_android/test/android_webview_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/android_webview_test.dart
@@ -81,7 +81,7 @@ void main() {
       });
 
       test('loadData with null values', () {
-        webView.loadData(data: 'hello', mimeType: null, encoding: null);
+        webView.loadData(data: 'hello');
         verify(mockPlatformHostApi.loadData(
           webViewInstanceId,
           'hello',

--- a/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/webview_android_widget_test.dart
@@ -165,8 +165,6 @@ void main() {
         await buildWidget(
           tester,
           creationParams: CreationParams(
-            autoMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
             webSettings: WebSettings(
               userAgent: const WebSetting<String?>.absent(),
               hasNavigationDelegate: false,

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,4 +1,9 @@
-## NEXT
+## 1.9.3
+
+* Fixes previous version in this CHANGELOG.md from NEXT to 1.9.2
+* Fixes avoid_redundant_argument_values lint warnings.
+
+## 1.9.2
 
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/method_channel/webview_method_channel_test.dart
@@ -40,13 +40,11 @@ void main() {
           if (methodCall.arguments == 'invalid file') {
             throw PlatformException(
                 code: 'loadFile_failed',
-                message: 'Failed loading file.',
-                details: null);
+                message: 'Failed loading file.');
           } else if (methodCall.arguments == 'some error') {
             throw PlatformException(
               code: 'some_error',
               message: 'Some error occurred.',
-              details: null,
             );
           }
           return null;
@@ -55,13 +53,11 @@ void main() {
             throw PlatformException(
               code: 'loadFlutterAsset_invalidKey',
               message: 'Failed loading asset.',
-              details: null,
             );
           } else if (methodCall.arguments == 'some error') {
             throw PlatformException(
               code: 'some_error',
               message: 'Some error occurred.',
-              details: null,
             );
           }
           return null;

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.3
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 2.9.2
 
 * Fixes crash when an Objective-C object in `FWFInstanceManager` is released, but the dealloc

--- a/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/example/integration_test/webview_flutter_test.dart
@@ -411,8 +411,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -470,8 +468,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -567,7 +563,6 @@ Future<void> main() async {
               pageLoaded.complete(null);
             },
             initialMediaPlaybackPolicy: AutoMediaPlaybackPolicy.always_allow,
-            allowsInlineMediaPlayback: false,
           ),
         ),
       );
@@ -672,8 +667,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );
@@ -741,8 +734,6 @@ Future<void> main() async {
             onPageFinished: (String url) {
               pageLoaded.complete(null);
             },
-            initialMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
           ),
         ),
       );

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit_webview_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/src/web_kit_webview_widget_test.dart
@@ -212,8 +212,6 @@ void main() {
         await buildWidget(
           tester,
           creationParams: CreationParams(
-            autoMediaPlaybackPolicy:
-                AutoMediaPlaybackPolicy.require_user_action_for_all_media_types,
             webSettings: WebSettings(
               userAgent: const WebSetting<String?>.absent(),
               hasNavigationDelegate: false,
@@ -737,7 +735,7 @@ void main() {
         await buildWidget(tester);
 
         when(mockWebView.evaluateJavaScript('runJavaScript')).thenAnswer(
-          (_) => Future<String?>.value(null),
+          (_) => Future<String?>.value(),
         );
         expect(
           () => testController.runJavascriptReturningResult('runJavaScript'),
@@ -1217,7 +1215,7 @@ void main() {
 
       testWidgets('progress observer is not removed without being set first',
           (WidgetTester tester) async {
-        await buildWidget(tester, hasProgressTracking: false);
+        await buildWidget(tester);
 
         verifyNever(mockWebView.removeObserver(
           mockWebView,

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/v4/webkit_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/v4/webkit_webview_controller_test.dart
@@ -346,7 +346,7 @@ void main() {
       );
 
       when(mockWebView.evaluateJavaScript('runJavaScript')).thenAnswer(
-        (_) => Future<String?>.value(null),
+        (_) => Future<String?>.value(),
       );
       expect(
         () => controller.runJavaScriptReturningResult('runJavaScript'),

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+* Fixes avoid_redundant_argument_values lint warnings.
+
 ## 0.9.0
 
 * Replaces PR-description-based version/changelog/breaking change check

--- a/script/tool/lib/src/common/plugin_command.dart
+++ b/script/tool/lib/src/common/plugin_command.dart
@@ -44,7 +44,6 @@ abstract class PluginCommand extends Command<void> {
   }) : _gitDir = gitDir {
     argParser.addMultiOption(
       _packagesArg,
-      splitCommas: true,
       help:
           'Specifies which packages the command should run on (before sharding).\n',
       valueHelp: 'package1,package2,...',

--- a/script/tool/lib/src/firebase_test_lab_command.dart
+++ b/script/tool/lib/src/firebase_test_lab_command.dart
@@ -335,7 +335,7 @@ class FirebaseTestLabCommand extends PackageLoopingCommand {
     }
 
     yield* integrationTestDir
-        .listSync(recursive: true, followLinks: true)
+        .listSync(recursive: true)
         .where((FileSystemEntity file) =>
             file is File && file.basename.endsWith('_test.dart'))
         .cast<File>();

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -33,16 +33,13 @@ class PublishCheckCommand extends PackageLoopingCommand {
       help: 'Allows the pre-release SDK warning to pass.\n'
           'When enabled, a pub warning, which asks to publish the package as a pre-release version when '
           'the SDK constraint is a pre-release version, is ignored.',
-      defaultsTo: false,
     );
     argParser.addFlag(_machineFlag,
         help: 'Switch outputs to a machine readable JSON. \n'
             'The JSON contains a "status" field indicating the final status of the command, the possible values are:\n'
             '    $_statusNeedsPublish: There is at least one package need to be published. They also passed all publish checks.\n'
             '    $_statusMessageNoPublish: There are no packages needs to be published. Either no pubspec change detected or all versions have already been published.\n'
-            '    $_statusMessageError: Some error has occurred.',
-        defaultsTo: false,
-        negatable: true);
+            '    $_statusMessageError: Some error has occurred.');
   }
 
   static const String _allowPrereleaseFlag = 'allow-pre-release';

--- a/script/tool/lib/src/publish_plugin_command.dart
+++ b/script/tool/lib/src/publish_plugin_command.dart
@@ -74,7 +74,6 @@ class PublishPluginCommand extends PackageLoopingCommand {
       help:
           'Release all packages that contains pubspec changes at the current commit compares to the base-sha.\n'
           'The --packages option is ignored if this is on.',
-      defaultsTo: false,
     );
     argParser.addFlag(
       _dryRunFlag,
@@ -82,14 +81,10 @@ class PublishPluginCommand extends PackageLoopingCommand {
           'Skips the real `pub publish` and `git tag` commands and assumes both commands are successful.\n'
           'This does not run `pub publish --dry-run`.\n'
           'If you want to run the command with `pub publish --dry-run`, use `pub-publish-flags=--dry-run`',
-      defaultsTo: false,
-      negatable: true,
     );
     argParser.addFlag(_skipConfirmationFlag,
         help: 'Run the command without asking for Y/N inputs.\n'
-            'This command will add a `--force` flag to the `pub publish` command if it is not added with $_pubFlagsOption\n',
-        defaultsTo: false,
-        negatable: true);
+            'This command will add a `--force` flag to the `pub publish` command if it is not added with $_pubFlagsOption\n');
   }
 
   static const String _pubFlagsOption = 'pub-publish-flags';

--- a/script/tool/lib/src/version_check_command.dart
+++ b/script/tool/lib/src/version_check_command.dart
@@ -115,8 +115,6 @@ class VersionCheckCommand extends PackageLoopingCommand {
       help: 'Whether the version check should run against the version on pub.\n'
           'Defaults to false, which means the version check only run against '
           'the previous version in code.',
-      defaultsTo: false,
-      negatable: true,
     );
     argParser.addOption(_changeDescriptionFile,
         help: 'The path to a file containing the description of the change '

--- a/script/tool/test/build_examples_command_test.dart
+++ b/script/tool/test/build_examples_command_test.dart
@@ -504,7 +504,7 @@ void main() {
       });
 
       test('skips non-Flutter examples', () async {
-        createFakePackage('package', packagesDir, isFlutter: false);
+        createFakePackage('package', packagesDir);
 
         final List<String> output = await runCapturingPrint(
             runner, <String>['build-examples', '--ios']);

--- a/script/tool/test/common/file_utils_test.dart
+++ b/script/tool/test/common/file_utils_test.dart
@@ -9,8 +9,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('works on Posix', () async {
-    final FileSystem fileSystem =
-        MemoryFileSystem(style: FileSystemStyle.posix);
+    final FileSystem fileSystem = MemoryFileSystem();
 
     final Directory base = fileSystem.directory('/').childDirectory('base');
     final File file =

--- a/script/tool/test/common/package_looping_command_test.dart
+++ b/script/tool/test/common/package_looping_command_test.dart
@@ -374,10 +374,9 @@ void main() {
     test('skips unsupported Dart versions when requested', () async {
       final RepositoryPackage excluded = createFakePackage(
           'excluded_package', packagesDir,
-          isFlutter: false, dartConstraint: '>=2.17.0 <3.0.0');
-      final RepositoryPackage included = createFakePackage(
-          'a_package', packagesDir,
-          isFlutter: false, dartConstraint: '>=2.14.0 <3.0.0');
+          dartConstraint: '>=2.17.0 <3.0.0');
+      final RepositoryPackage included =
+          createFakePackage('a_package', packagesDir);
 
       final TestPackageLoopingCommand command = createTestCommand(
           packageLoopingType: PackageLoopingType.includeAllSubpackages,
@@ -408,8 +407,7 @@ void main() {
       createFakePlugin('package_a', packagesDir);
       createFakePackage('package_b', packagesDir);
 
-      final TestPackageLoopingCommand command =
-          createTestCommand(hasLongOutput: true);
+      final TestPackageLoopingCommand command = createTestCommand();
       final List<String> output = await runCommand(command);
 
       const String separator =
@@ -442,8 +440,7 @@ void main() {
       createFakePlugin('package_a', packagesDir);
       createFakePackage('package_b', packagesDir);
 
-      final TestPackageLoopingCommand command =
-          createTestCommand(hasLongOutput: true);
+      final TestPackageLoopingCommand command = createTestCommand();
       final List<String> output =
           await runCommand(command, arguments: <String>['--log-timing']);
 
@@ -595,7 +592,7 @@ void main() {
       createFakePackage('package_b', packagesDir);
 
       final TestPackageLoopingCommand command =
-          createTestCommand(hasLongOutput: true, captureOutput: true);
+          createTestCommand(captureOutput: true);
       final List<String> output = await runCommand(command);
 
       expect(output, isEmpty);
@@ -785,8 +782,7 @@ void main() {
 
       createFakePackage('package_f', packagesDir);
 
-      final TestPackageLoopingCommand command =
-          createTestCommand(hasLongOutput: true);
+      final TestPackageLoopingCommand command = createTestCommand();
       final List<String> output = await runCommand(command);
 
       expect(
@@ -811,8 +807,7 @@ void main() {
     test('prints exclusions as skips in long-form run summary', () async {
       createFakePackage('package_a', packagesDir);
 
-      final TestPackageLoopingCommand command =
-          createTestCommand(hasLongOutput: true);
+      final TestPackageLoopingCommand command = createTestCommand();
       final List<String> output =
           await runCommand(command, arguments: <String>['--exclude=package_a']);
 

--- a/script/tool/test/common/plugin_utils_test.dart
+++ b/script/tool/test/common/plugin_utils_test.dart
@@ -223,12 +223,12 @@ void main() {
         'plugin',
         packagesDir,
         platformSupport: <String, PlatformDetails>{
-          platformLinux: const PlatformDetails(PlatformSupport.inline,
-              hasNativeCode: true, hasDartCode: true),
-          platformMacOS: const PlatformDetails(PlatformSupport.inline,
-              hasNativeCode: true, hasDartCode: true),
-          platformWindows: const PlatformDetails(PlatformSupport.inline,
-              hasNativeCode: true, hasDartCode: true),
+          platformLinux:
+              const PlatformDetails(PlatformSupport.inline, hasDartCode: true),
+          platformMacOS:
+              const PlatformDetails(PlatformSupport.inline, hasDartCode: true),
+          platformWindows:
+              const PlatformDetails(PlatformSupport.inline, hasDartCode: true),
         },
       );
 

--- a/script/tool/test/common/repository_package_test.dart
+++ b/script/tool/test/common/repository_package_test.dart
@@ -213,7 +213,7 @@ void main() {
 
     test('returns false for non-Flutter package', () async {
       final RepositoryPackage package =
-          createFakePackage('a_package', packagesDir, isFlutter: false);
+          createFakePackage('a_package', packagesDir);
       expect(package.requiresFlutter(), false);
     });
   });

--- a/script/tool/test/custom_test_command_test.dart
+++ b/script/tool/test/custom_test_command_test.dart
@@ -146,7 +146,7 @@ void main() {
       ]);
 
       processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-        MockProcess(exitCode: 0), // pub get
+        MockProcess(), // pub get
         MockProcess(exitCode: 1), // test script
       ];
 
@@ -306,7 +306,7 @@ void main() {
       ]);
 
       processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-        MockProcess(exitCode: 0), // pub get
+        MockProcess(), // pub get
         MockProcess(exitCode: 1), // test script
       ];
 

--- a/script/tool/test/license_check_command_test.dart
+++ b/script/tool/test/license_check_command_test.dart
@@ -200,7 +200,7 @@ void main() {
     test('handles the comment styles for all supported languages', () async {
       final File fileA = root.childFile('file_a.cc');
       fileA.createSync();
-      _writeLicense(fileA, comment: '// ');
+      _writeLicense(fileA);
       final File fileB = root.childFile('file_b.sh');
       fileB.createSync();
       _writeLicense(fileB, comment: '# ');

--- a/script/tool/test/lint_android_command_test.dart
+++ b/script/tool/test/lint_android_command_test.dart
@@ -24,7 +24,7 @@ void main() {
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem(style: FileSystemStyle.posix);
+      fileSystem = MemoryFileSystem();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
       mockPlatform = MockPlatform();
       processRunner = RecordingProcessRunner();

--- a/script/tool/test/lint_podspecs_command_test.dart
+++ b/script/tool/test/lint_podspecs_command_test.dart
@@ -23,7 +23,7 @@ void main() {
     late RecordingProcessRunner processRunner;
 
     setUp(() {
-      fileSystem = MemoryFileSystem(style: FileSystemStyle.posix);
+      fileSystem = MemoryFileSystem();
       packagesDir = createPackagesDirectory(fileSystem: fileSystem);
 
       mockPlatform = MockPlatform(isMacOS: true);

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -186,7 +186,7 @@ void main() {
         extraFiles: <String>['example/build.excerpt.yaml']);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-      MockProcess(exitCode: 0), // dart pub get
+      MockProcess(), // dart pub get
       MockProcess(exitCode: 1), // dart run build_runner ...
     ];
 
@@ -211,8 +211,8 @@ void main() {
         extraFiles: <String>['example/build.excerpt.yaml']);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
-      MockProcess(exitCode: 0), // dart pub get
-      MockProcess(exitCode: 0), // dart run build_runner ...
+      MockProcess(), // dart pub get
+      MockProcess(), // dart run build_runner ...
       MockProcess(exitCode: 1), // dart run code_excerpt_updater ...
     ];
 

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -117,7 +117,6 @@ RepositoryPackage createFakePlugin(
   createFakePubspec(
     package,
     name: name,
-    isFlutter: true,
     isPlugin: true,
     platformSupport: platformSupport,
     version: version,
@@ -399,10 +398,10 @@ class RecordingProcessRunner extends ProcessRunner {
     final io.Process? process = _getProcessToReturn(executable);
     final List<String>? processStdout =
         await process?.stdout.transform(stdoutEncoding.decoder).toList();
-    final String stdout = processStdout?.join('') ?? '';
+    final String stdout = processStdout?.join() ?? '';
     final List<String>? processStderr =
         await process?.stderr.transform(stderrEncoding.decoder).toList();
-    final String stderr = processStderr?.join('') ?? '';
+    final String stderr = processStderr?.join() ?? '';
 
     final io.ProcessResult result = process == null
         ? io.ProcessResult(1, 0, '', '')


### PR DESCRIPTION
Enables avoid_redundant_argument_values lint and fixes all related violations in all plugins.

Part of https://github.com/flutter/flutter/issues/76229

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use dart format.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated CHANGELOG.md to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.