### PR TITLE
[script] fix script noop interpolated toString()s

### DIFF
--- a/script/tool/lib/src/common/package_looping_command.dart
+++ b/script/tool/lib/src/common/package_looping_command.dart
@@ -357,7 +357,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
       if (flutterConstraint != null &&
           !flutterConstraint.allows(minFlutterVersion)) {
         return PackageResult.skip(
-            'Does not support Flutter ${minFlutterVersion.toString()}');
+            'Does not support Flutter $minFlutterVersion');
       }
     }
 
@@ -365,8 +365,7 @@ abstract class PackageLoopingCommand extends PluginCommand {
       final Pubspec pubspec = package.parsePubspec();
       final VersionConstraint? dartConstraint = pubspec.environment?['sdk'];
       if (dartConstraint != null && !dartConstraint.allows(minDartVersion)) {
-        return PackageResult.skip(
-            'Does not support Dart ${minDartVersion.toString()}');
+        return PackageResult.skip('Does not support Dart $minDartVersion');
       }
     }
 


### PR DESCRIPTION
Fix diagnostics that will get flagged in the next Dart SDK roll.

See breakage:

https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8806899813430732209/+/u/analyze_flutter_plugins/stdout

Source Linter DEP bump: https://dart-review.googlesource.com/c/sdk/+/253501

/cc @a14n @srawlins 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
