### PR TITLE
[path_provider_windows] bump dependency version of package:win32 in path_provider_windows

### DIFF
--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+* Updates dependency version of `package:win32` to 2.1.0.
+
 ## 2.1.0
 
 * Upgrades `package:ffi` dependency to 2.0.0.

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: path_provider_windows
 description: Windows implementation of the path_provider plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/path_provider/path_provider_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+path_provider%22
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
-  win32: ^2.0.0
+  win32: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
-  win32: ^2.0.0
+  win32: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/path_provider/path_provider_windows/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider_platform_interface: ^2.0.0
-  win32: ^2.1.0
+  win32: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The usage https://github.com/flutter/plugins/blob/b0bfab678f83bebd49e9f9d0a83fe9b40774e853/packages/path_provider/path_provider_windows/lib/src/path_provider_windows_real.dart#L195 of the `wsalloc` function stipulates at least v2.1.0 of `package:win32`
- see https://github.com/timsneath/win32/commit/1ef183040381d89ed2cf27daf5d86afe403ee79c#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR35 where `wsalloc` was introduced
- also see https://pub.dev/documentation/win32/2.1.0/win32/wsalloc.html and https://pub.dev/documentation/win32/2.0.5/win32/wsalloc.html (`wsalloc` not present in v2.0.5 of `package:win32`)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy](https://dart.dev/tools/pub/versioning)
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
