### PR TITLE
[ci] Run analyze with minimum resolved packages

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,6 +171,14 @@ task:
         # Only analyze lib/; non-client code doesn't need to work on
         # all supported legacy version.
         - ./script/tool_runner.sh analyze --lib-only --skip-if-not-supporting-flutter-version="$CHANNEL" --custom-analysis=script/configs/custom_analysis.yaml
+    # Does a sanity check that plugins pass analysis with the lowest possible
+    # versions of all dependencies. This is to catch cases where we add use of
+    # new APIs but forget to update minimum versions of dependencies to when
+    # those APIs are introduced.
+    - name: downgraded_analyze
+      depends_on: analyze
+      analyze_script:
+        - ./script/tool_runner.sh analyze --downgrade
     - name: readme_excerpts
       env:
         CIRRUS_CLONE_SUBMODULES: true

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.5+2
+
+* Updates `image_picker_platform_interface` constraint to the correct minimum
+  version.
+
 ## 0.8.5+1
 
 * Switches to an internal method channel implementation.

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.5+1
+version: 0.8.5+2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
-  image_picker_platform_interface: ^2.3.0
+  image_picker_platform_interface: ^2.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.10
+
+* Updates `local_auth_platform_interface` constraint to the correct minimum
+  version.
+
 ## 1.0.9
 
 * Updates  androidx.fragment version to 1.5.1.

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.9
+version: 1.0.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -22,7 +22,7 @@ dependencies:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.1
   intl: ^0.17.0
-  local_auth_platform_interface: ^1.0.0
+  local_auth_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.8
+
+* Updates `local_auth_platform_interface` constraint to the correct minimum
+  version.
+
 ## 1.0.7
 
 * Updates references to the obsolete master branch.

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_ios
 description: iOS implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.7
+version: 1.0.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   intl: ^0.17.0
-  local_auth_platform_interface: ^1.0.0
+  local_auth_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/local_auth/local_auth_windows/CHANGELOG.md
+++ b/packages/local_auth/local_auth_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.2
+
+* Updates `local_auth_platform_interface` constraint to the correct minimum
+  version.
+
 ## 1.0.1
 
 * Updates references to the obsolete master branch.

--- a/packages/local_auth/local_auth_windows/pubspec.yaml
+++ b/packages/local_auth/local_auth_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_windows
 description: Windows implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.1
+version: 1.0.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  local_auth_platform_interface: ^1.0.0
+  local_auth_platform_interface: ^1.0.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.13
+
+* Updates `url_launcher_platform_interface` constraint to the correct minimum
+  version.
+
 ## 2.0.12
 
 * Fixes call to `setState` after dispose on the `Link` widget.

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_web
 description: Web platform implementation of url_launcher
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 2.0.12
+version: 2.0.13
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  url_launcher_platform_interface: ^2.0.0
+  url_launcher_platform_interface: ^2.0.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_wkwebview/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.9.3
+
+* Updates `webview_flutter_platform_interface` constraint to the correct minimum
+  version.
+
 ## 2.9.2
 
 * Fixes crash when an Objective-C object in `FWFInstanceManager` is released, but the dealloc

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_wkwebview
 description: A Flutter plugin that provides a WebView widget based on Apple's WKWebView control.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 2.9.2
+version: 2.9.3
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
-  webview_flutter_platform_interface: ^1.8.0
+  webview_flutter_platform_interface: ^1.9.0
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,10 +1,15 @@
+## 0.9.1
+
+* Adds a `--downgrade` flag to `analyze` for analyzing with the oldest possible
+  versions of packages.
+
 ## 0.9.0
 
 * Replaces PR-description-based version/changelog/breaking change check
   overrides in `version-check` with label-based overrides using a new
   `pr-labels` flag, since we don't actually have reliable access to the
   PR description in checks.
-  
+
 ## 0.8.10
 
 - Adds a new `remove-dev-dependencies` command to remove `dev_dependencies`

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -33,7 +33,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
         help: 'An optional path to a Dart SDK; this is used to override the '
             'SDK used to provide analysis.');
     argParser.addFlag(_downgradeFlag,
-        help: 'Runs "flutter pub downgrade" before analysis, to verify that '
+        help: 'Runs "flutter pub downgrade" before analysis to verify that '
             'the minimum constraints are sufficiently new for APIs used.');
     argParser.addFlag(_libOnlyFlag,
         help: 'Only analyze the lib/ directory of the main package, not the '

--- a/script/tool/lib/src/analyze_command.dart
+++ b/script/tool/lib/src/analyze_command.dart
@@ -32,12 +32,16 @@ class AnalyzeCommand extends PackageLoopingCommand {
         valueHelp: 'dart-sdk',
         help: 'An optional path to a Dart SDK; this is used to override the '
             'SDK used to provide analysis.');
+    argParser.addFlag(_downgradeFlag,
+        help: 'Runs "flutter pub downgrade" before analysis, to verify that '
+            'the minimum constraints are sufficiently new for APIs used.');
     argParser.addFlag(_libOnlyFlag,
         help: 'Only analyze the lib/ directory of the main package, not the '
             'entire package.');
   }
 
   static const String _customAnalysisFlag = 'custom-analysis';
+  static const String _downgradeFlag = 'downgrade';
   static const String _libOnlyFlag = 'lib-only';
   static const String _analysisSdk = 'analysis-sdk';
 
@@ -113,6 +117,12 @@ class AnalyzeCommand extends PackageLoopingCommand {
       return PackageResult.skip('No lib/ directory.');
     }
 
+    if (getBoolArg(_downgradeFlag)) {
+      if (!await _runPubCommand(package, 'downgrade')) {
+        return PackageResult.fail(<String>['Unable to downgrade dependencies']);
+      }
+    }
+
     // Analysis runs over the package and all subpackages (unless only lib/ is
     // being analyzed), so all of them need `flutter pub get` run before
     // analyzing. `example` packages can be skipped since 'flutter packages get'
@@ -127,10 +137,7 @@ class AnalyzeCommand extends PackageLoopingCommand {
           !RepositoryPackage(packageToGet.directory.parent)
               .pubspecFile
               .existsSync()) {
-        final int exitCode = await processRunner.runAndStream(
-            flutterCommand, <String>['pub', 'get'],
-            workingDir: packageToGet.directory);
-        if (exitCode != 0) {
+        if (!await _runPubCommand(packageToGet, 'get')) {
           return PackageResult.fail(<String>['Unable to get dependencies']);
         }
       }
@@ -146,5 +153,12 @@ class AnalyzeCommand extends PackageLoopingCommand {
       return PackageResult.fail();
     }
     return PackageResult.success();
+  }
+
+  Future<bool> _runPubCommand(RepositoryPackage package, String command) async {
+    final int exitCode = await processRunner.runAndStream(
+        flutterCommand, <String>['pub', command],
+        workingDir: package.directory);
+    return exitCode == 0;
   }
 }

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.9.0
+version: 0.9.1
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
Since our CI always runs on clean projects, they always get the latest resolved versions of dependencies, so won't catch the easy-to-make mistake of introducing use of a new dependency API without updating the minimum version of that dependency to the version that introduced that API.

This adds a new `--downgrade` flag to `analyze` to run `flutter pub downgrade` before analyzing, and adds a new CI step to run in that mode. (This won't catch runtime mistakes, but as with the "legacy analyze" runs this catches the most common type of mistake at a fraction of the CI cost of running all tests again.)

Also fixes all the existing violations flagged by the new step.

Fixes https://github.com/flutter/flutter/issues/108992

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
