### PR TITLE
[google_maps_ios] Cache `+[GMSServices sharedServices]` when first map is created

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.11
+
+* Precaches Google Maps services initialization and syncing.
+
 ## 2.1.10
 
 * Splits iOS implementation out of `google_maps_flutter` as a federated

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
@@ -52,6 +52,7 @@
   // Test pointer equality, should be same retained singleton +[GMSServices sharedServices] object.
   // Retaining the opaque object should be enough to avoid multiple internal initializations,
   // but don't test the internals of the GoogleMaps API. Assume that it does what is documented.
+  // https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_services#a436e03c32b1c0be74e072310a7158831
   XCTAssertEqual(factory1.sharedMapServices, factory2.sharedMapServices);
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerTests/GoogleMapsTests.m
@@ -5,9 +5,14 @@
 @import google_maps_flutter_ios;
 @import google_maps_flutter_ios.Test;
 @import XCTest;
+@import GoogleMaps;
 
 #import <OCMock/OCMock.h>
 #import "PartiallyMockedMapView.h"
+
+@interface FLTGoogleMapFactory (Test)
+@property(strong, nonatomic, readonly) id<NSObject> sharedMapServices;
+@end
 
 @interface GoogleMapsTests : XCTestCase
 @end
@@ -37,6 +42,17 @@
 
   mapView.frame = frame;
   XCTAssertEqual(mapView.frameObserverCount, 0);
+}
+
+- (void)testMapsServiceSync {
+  id registrar = OCMProtocolMock(@protocol(FlutterPluginRegistrar));
+  FLTGoogleMapFactory *factory1 = [[FLTGoogleMapFactory alloc] initWithRegistrar:registrar];
+  XCTAssertNotNil(factory1.sharedMapServices);
+  FLTGoogleMapFactory *factory2 = [[FLTGoogleMapFactory alloc] initWithRegistrar:registrar];
+  // Test pointer equality, should be same retained singleton +[GMSServices sharedServices] object.
+  // Retaining the opaque object should be enough to avoid multiple internal initializations,
+  // but don't test the internals of the GoogleMaps API. Assume that it does what is documented.
+  XCTAssertEqual(factory1.sharedMapServices, factory2.sharedMapServices);
 }
 
 @end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -17,14 +17,12 @@
 
 @implementation FLTGoogleMapFactory
 
+@synthesize sharedMapServices = _sharedMapServices;
+
 - (instancetype)initWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   self = [super init];
   if (self) {
     _registrar = registrar;
-    // Calling this prepares GMSServices on a background thread controlled
-    // by the GoogleMaps framework.
-    // Retain the singleton to cache the initialization work across all map views.
-    _sharedMapServices = [GMSServices sharedServices];
   }
   return self;
 }
@@ -36,11 +34,26 @@
 - (NSObject<FlutterPlatformView> *)createWithFrame:(CGRect)frame
                                     viewIdentifier:(int64_t)viewId
                                          arguments:(id _Nullable)args {
+  // Precache shared map services, if needed.
+  // Retain the shared map services singleton, don't use the result for anything.
+  (void)[self sharedMapServices];
+
   return [[FLTGoogleMapController alloc] initWithFrame:frame
                                         viewIdentifier:viewId
                                              arguments:args
                                              registrar:self.registrar];
 }
+
+- (id<NSObject>)sharedMapServices {
+  if (_sharedMapServices == nil) {
+    // Calling this prepares GMSServices on a background thread controlled
+    // by the GoogleMaps framework.
+    // Retain the singleton to cache the initialization work across all map views.
+    _sharedMapServices = [GMSServices sharedServices];
+  }
+  return _sharedMapServices;
+}
+
 @end
 
 @interface FLTGoogleMapController ()

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -11,6 +11,7 @@
 @interface FLTGoogleMapFactory ()
 
 @property(weak, nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
+@property(strong, nonatomic, readonly) id<NSObject> sharedMapServices;
 
 @end
 
@@ -20,6 +21,10 @@
   self = [super init];
   if (self) {
     _registrar = registrar;
+    // Calling this prepares GMSServices on a background thread controlled
+    // by the GoogleMaps framework.
+    // Retain the singleton to cache the initialization work across all map views.
+    _sharedMapServices = [GMSServices sharedServices];
   }
   return self;
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.1.10
+version: 2.1.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Previously, every MapView creation would reinitialize the underlying Google Maps services:
```
21.00 ms   10.1%	0 s	 	                -[GMSMapView initWithFrame:camera:]
21.00 ms   10.1%	0 s	 	                 +[GMSServices sharedServicesSync]
16.00 ms    7.7%	0 s	 	                  -[GMSAsyncInitServices services]
16.00 ms    7.7%	0 s	 	                   CompleteInit(GMSAsyncInitServices*)
16.00 ms    7.7%	0 s	 	                    invocation function for block in CompleteInit(GMSAsyncInitServices*)
15.00 ms    7.2%	0 s	 	                     -[GMSServices initWithDisplayLink:resourceCache:clearcutClient:dataURL:cachesURL:options:]
4.00 ms    1.9%	0 s	 	                      -[GMSClientParameters startWithCompletionHandler:]
4.00 ms    1.9%	0 s	 	                       -[GMSClientParameters performFirstUpdateFromLastSavedTime]
4.00 ms    1.9%	0 s	 	                        -[GMSClientParameters reloadSavedClientParameters]
4.00 ms    1.9%	0 s	 	                         -[GMSClientParameters updateAllParamsGroupsToDefault]
3.00 ms    1.4%	0 s	 	                          -[GMSClientParameters updateParamGroup:]
3.00 ms    1.4%	0 s	 	                           -[GMSAPIClientParameters updateTypedParamGroup:]
3.00 ms    1.4%	0 s	 	                            -[GMSCoreClientParameters updateTypedParamGroup:]
2.00 ms    0.9%	0 s	 	                             GMSx_GPBGetObjectIvarWithField
2.00 ms    0.9%	0 s	 	                              _objc_msgSend_uncached
2.00 ms    0.9%	0 s	 	                               lookUpImpOrForward
2.00 ms    0.9%	0 s	 	                                initializeAndMaybeRelock(objc_class*, objc_object*, locker_mixin<lockdebug::lock_mixin<objc_lock_base_t> >&, bool)

```

Retain opaque object `+[GMSServices sharedServices]` when the first map is created.  This must be called on the main thread, but kicks off background initialization of service syncing.  [Docs say](https://developers.google.com/maps/documentation/ios-sdk/reference/interface_g_m_s_services#a436e03c32b1c0be74e072310a7158831):
> This is an opaque object. If your application often creates and destroys view or service classes provided by the Google Maps SDK for iOS, it may be useful to hold onto this object directly, as otherwise your connection to Google may be restarted on a regular basis. It also may be useful to take this object in advance of the first map creation, to reduce initial map creation performance cost.

Just retaining it is enough to cache for subsequent views, without needing to pass it into the view itself.

See also GM source (internal links)
cs/piper///depot/google3/googlemac/iPhone/Maps/SDK/Maps/GMSServices+Google.h;l=15-20
cs/piper///depot/google3/googlemac/iPhone/Maps/SDK/Maps/GMSServices.mm;l=259-269;bpv=1;bpt=1

Part of https://github.com/flutter/flutter/issues/109057

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
