### PR TITLE
Add missing submodule command to setup for packages repo.

### DIFF
--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -17,6 +17,12 @@ flutter/packages.)
 
 The commands in tools require the Flutter-bundled version of Dart to be the first `dart` loaded in the path.
 
+### Extra Setup
+
+When updating sample code excerpts (`update-excerpts`) for the README.md files,
+there is some [extra setup for
+submodules](#update-readmemd-from-example-sources) that is necessary.
+
 ### From Source (flutter/plugins only)
 
 Set up:


### PR DESCRIPTION
When trying to execute the instructions for the packages repo, it kept failing with:

```
Resolving dependencies...
Because adaptive_scaffold_example depends on code_excerpter from path which doesn't exist (could not find package code_excerpter at "../../../site-shared/packages/code_excerpter"), version solving failed.
```

This was because the submodule wasn't initialized, so the dependencies weren't available.
