### PR TITLE
Prepare for fix to https://github.com/flutter/flutter/issues/109339.

### DIFF
--- a/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
+++ b/packages/camera/camera_platform_interface/test/camera_platform_interface_test.dart
@@ -18,7 +18,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         CameraPlatform.instance = ImplementsCameraPlatform();
-      }, throwsNoSuchMethodError);
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be extended', () {

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/platform_interface/google_maps_flutter_platform_test.dart
@@ -27,7 +27,14 @@ void main() {
       expect(() {
         GoogleMapsFlutterPlatform.instance =
             ImplementsGoogleMapsFlutterPlatform();
-      }, throwsA(isInstanceOf<AssertionError>()));
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be mocked with `implements`', () {

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
@@ -18,7 +18,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         GoogleSignInPlatform.instance = ImplementsGoogleSignInPlatform();
-      }, throwsA(isA<Error>()));
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be extended', () {

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
@@ -133,7 +133,7 @@ void main() {
       InAppPurchasePlatformAddition.instance = null;
     });
 
-    test('Cannot be implemented with `implements`', () {
+    test('Default instance is null', () {
       expect(InAppPurchasePlatformAddition.instance, isNull);
     });
 

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
@@ -14,7 +14,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         InAppPurchasePlatform.instance = ImplementsInAppPurchasePlatform();
-      }, throwsNoSuchMethodError);
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be extended', () {
@@ -128,7 +135,14 @@ void main() {
 
     test('Cannot be implemented with `implements`', () {
       expect(InAppPurchasePlatformAddition.instance, isNull);
-    });
+      // In versions of `package:plugin_platform_interface` prior to fixing
+      // https://github.com/flutter/flutter/issues/109339, an attempt to
+      // implement a platform interface using `implements` would sometimes throw
+      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
+      // the issue is fixed, an `AssertionError` will always be thrown.  For the
+      // purpose of this test, we don't really care what exception is thrown, so
+      // just allow any exception.
+    }, throwsA(anything));
 
     test('Can be implemented.', () {
       InAppPurchasePlatformAddition.instance =

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/test/in_app_purchase_platform_test.dart
@@ -135,14 +135,7 @@ void main() {
 
     test('Cannot be implemented with `implements`', () {
       expect(InAppPurchasePlatformAddition.instance, isNull);
-      // In versions of `package:plugin_platform_interface` prior to fixing
-      // https://github.com/flutter/flutter/issues/109339, an attempt to
-      // implement a platform interface using `implements` would sometimes throw
-      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
-      // the issue is fixed, an `AssertionError` will always be thrown.  For the
-      // purpose of this test, we don't really care what exception is thrown, so
-      // just allow any exception.
-    }, throwsA(anything));
+    });
 
     test('Can be implemented.', () {
       InAppPurchasePlatformAddition.instance =

--- a/packages/quick_actions/quick_actions_platform_interface/test/quick_actions_platform_interface_test.dart
+++ b/packages/quick_actions/quick_actions_platform_interface/test/quick_actions_platform_interface_test.dart
@@ -21,7 +21,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         QuickActionsPlatform.instance = ImplementsQuickActionsPlatform();
-      }, throwsNoSuchMethodError);
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be extended', () {

--- a/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/test/method_channel_url_launcher_test.dart
@@ -24,7 +24,14 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         UrlLauncherPlatform.instance = ImplementsUrlLauncherPlatform();
-      }, throwsA(isInstanceOf<AssertionError>()));
+        // In versions of `package:plugin_platform_interface` prior to fixing
+        // https://github.com/flutter/flutter/issues/109339, an attempt to
+        // implement a platform interface using `implements` would sometimes
+        // throw a `NoSuchMethodError` and other times throw an
+        // `AssertionError`.  After the issue is fixed, an `AssertionError` will
+        // always be thrown.  For the purpose of this test, we don't really care
+        // what exception is thrown, so just allow any exception.
+      }, throwsA(anything));
     });
 
     test('Can be mocked with `implements`', () {

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_navigation_delegate_test.dart
@@ -23,7 +23,14 @@ void main() {
 
     expect(() {
       PlatformNavigationDelegate(params);
-    }, throwsNoSuchMethodError);
+      // In versions of `package:plugin_platform_interface` prior to fixing
+      // https://github.com/flutter/flutter/issues/109339, an attempt to
+      // implement a platform interface using `implements` would sometimes throw
+      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
+      // the issue is fixed, an `AssertionError` will always be thrown.  For the
+      // purpose of this test, we don't really care what exception is thrown, so
+      // just allow any exception.
+    }, throwsA(anything));
   });
 
   test('Can be extended', () {

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_controller_test.dart
@@ -28,7 +28,14 @@ void main() {
     expect(() {
       PlatformWebViewController(
           const PlatformWebViewControllerCreationParams());
-    }, throwsNoSuchMethodError);
+      // In versions of `package:plugin_platform_interface` prior to fixing
+      // https://github.com/flutter/flutter/issues/109339, an attempt to
+      // implement a platform interface using `implements` would sometimes throw
+      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
+      // the issue is fixed, an `AssertionError` will always be thrown.  For the
+      // purpose of this test, we don't really care what exception is thrown, so
+      // just allow any exception.
+    }, throwsA(anything));
   });
 
   test('Can be extended', () {

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_widget_test.dart
@@ -27,7 +27,14 @@ void main() {
 
     expect(() {
       PlatformWebViewWidget(params);
-    }, throwsNoSuchMethodError);
+      // In versions of `package:plugin_platform_interface` prior to fixing
+      // https://github.com/flutter/flutter/issues/109339, an attempt to
+      // implement a platform interface using `implements` would sometimes throw
+      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
+      // the issue is fixed, an `AssertionError` will always be thrown.  For the
+      // purpose of this test, we don't really care what exception is thrown, so
+      // just allow any exception.
+    }, throwsA(anything));
   });
 
   test('Can be extended', () {

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/webview_platform_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/webview_platform_test.dart
@@ -22,7 +22,14 @@ void main() {
   test('Cannot be implemented with `implements`', () {
     expect(() {
       WebViewPlatform.instance = ImplementsWebViewPlatform();
-    }, throwsNoSuchMethodError);
+      // In versions of `package:plugin_platform_interface` prior to fixing
+      // https://github.com/flutter/flutter/issues/109339, an attempt to
+      // implement a platform interface using `implements` would sometimes throw
+      // a `NoSuchMethodError` and other times throw an `AssertionError`.  After
+      // the issue is fixed, an `AssertionError` will always be thrown.  For the
+      // purpose of this test, we don't really care what exception is thrown, so
+      // just allow any exception.
+    }, throwsA(anything));
   });
 
   test('Can be extended', () {


### PR DESCRIPTION
Currently, in some circumstances where a subclasses of
`PlatformInterface` erroneously uses `implements` rather than
`extends`, a `NoSuchMethodError` will be thrown (in spite of the
documentation at
https://pub.dev/documentation/plugin_platform_interface/latest/plugin_platform_interface/PlatformInterface/verify.html
claiming that `AssertionError` will be thrown).

After https://github.com/flutter/flutter/issues/109339 is fixed, the
correct type of exception will be thrown.  To avoid tests breakages
when the fix happens, we need to modify these tests so that they don't
care what kind of exception is thrown.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
