### PR TITLE
[webview_flutter_platform_interface] Adds missing build params for WebViewWidget 

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,7 +1,8 @@
-## NEXT
+## 1.9.2
 
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
+* Adds missing build params for v4 WebViewWidget interface.
 
 ## 1.9.1
 

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:webview_flutter_platform_interface/v4/src/platform_webview_controller.dart';
 
 import 'webview_platform.dart';
 
@@ -33,5 +36,38 @@ abstract class PlatformWebViewWidget extends PlatformInterface {
   /// Builds a new WebView.
   ///
   /// Returns a Widget tree that embeds the created web view.
-  Widget build(BuildContext context);
+  Widget build(BuildParams params);
+}
+
+/// Describes the parameters necessary for displaying the platform WebView.
+@immutable
+class BuildParams {
+  /// Constructs a [BuildParams].
+  const BuildParams(
+    this.context, {
+    required this.controller,
+    this.layoutDirection = TextDirection.ltr,
+    this.gestureRecognizers,
+  });
+
+  /// Describes the part of the user interface represented by the returned
+  /// widget.
+  final BuildContext context;
+
+  /// Controls the embedded WebView for the current platform.
+  final PlatformWebViewController controller;
+
+  /// The layout direction to use for the embedded WebView.
+  final TextDirection layoutDirection;
+
+  /// Specifies which gestures should be consumed by the web view.
+  ///
+  /// It is possible for other gesture recognizers to be competing with the web
+  /// view on pointer events, e.g if the web view is inside a [ListView] the
+  /// [ListView] will want to handle vertical drags. The web view will claim
+  /// gestures that are recognized by any of the recognizers on this list.
+  ///
+  /// When this is empty or null, the web view will only handle pointer events
+  /// for gestures that were not claimed by any other gesture recognizer.
+  final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
@@ -47,7 +47,7 @@ class BuildParams {
     this.context, {
     required this.controller,
     this.layoutDirection = TextDirection.ltr,
-    this.gestureRecognizers,
+    this.gestureRecognizers = const <Factory<OneSequenceGestureRecognizer>>{},
   });
 
   /// Describes the part of the user interface represented by the returned
@@ -69,5 +69,5 @@ class BuildParams {
   ///
   /// When this is empty or null, the web view will only handle pointer events
   /// for gestures that were not claimed by any other gesture recognizer.
-  final Set<Factory<OneSequenceGestureRecognizer>>? gestureRecognizers;
+  final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
@@ -40,6 +40,43 @@ abstract class PlatformWebViewWidget extends PlatformInterface {
 }
 
 /// Describes the parameters necessary for displaying the platform WebView.
+///
+/// Platform specific implementations can add additional fields by extending
+/// this class.
+///
+/// {@tool sample}
+/// This example demonstrates how to extend the [BuildParams] to provide
+/// additional platform specific parameters.
+///
+/// When extending [BuildParams], additional parameters should always accept
+/// `null` or have a default value to prevent breaking changes.
+///
+/// ```dart
+/// @immutable
+/// class WebKitBuildParams extends BuildParams {
+///   WebKitBuildParams(
+///     super.context, {
+///     required super.controller,
+///     super.layoutDirection,
+///     super.gestureRecognizers,
+///     this.platformSpecificFieldExample,
+///   });
+///
+///   WebKitBuildParams.fromBuildParams(
+///     BuildParams params, {
+///     Object? platformSpecificFieldExample,
+///   }) : this(
+///           params.context,
+///           controller: params.controller,
+///           layoutDirection: params.layoutDirection,
+///           gestureRecognizers: params.gestureRecognizers,
+///           platformSpecificFieldExample: platformSpecificFieldExample,
+///         );
+///
+///   final Object? platformSpecificFieldExample;
+/// }
+/// ```
+/// {@end-tool}
 @immutable
 class BuildParams {
   /// Constructs a [BuildParams].

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_webview_widget.dart
@@ -104,7 +104,7 @@ class BuildParams {
   /// [ListView] will want to handle vertical drags. The web view will claim
   /// gestures that are recognized by any of the recognizers on this list.
   ///
-  /// When this is empty or null, the web view will only handle pointer events
-  /// for gestures that were not claimed by any other gesture recognizer.
+  /// When this is empty, the web view will only handle pointer events for
+  /// gestures that were not claimed by any other gesture recognizer.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 }

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutte
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.9.1
+version: 1.9.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_widget_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_widget_test.dart
@@ -75,7 +75,7 @@ class ExtendsWebViewWidgetDelegate extends PlatformWebViewWidget {
       : super.implementation(params);
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildParams params) {
     throw UnimplementedError(
         'build is not implemented for ExtendedWebViewWidgetDelegate.');
   }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/94051

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
