### PR TITLE
[url_launcher] Added draggable property to link info.

### DIFF
--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+* Adds a new `draggable` property to the data controlling the `Link` widget.
+
 ## 2.1.0
 
 * Adds a new `launchUrl` method corresponding to the new app-facing interface.

--- a/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
@@ -72,6 +72,11 @@ abstract class LinkInfo {
 
   /// Whether the link is disabled or not.
   bool get isDisabled;
+
+  /// Whether the link can be dragged e.g. to create a shortcut on the desktop.
+  ///
+  /// Default is true.
+  bool get draggable => true;
 }
 
 typedef _SendMessage = Function(String, ByteData?, void Function(ByteData?));

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/u
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Platform interface part of allowing use of the Link widget in lists with mouse drag enabled.

Platform interface part of [#5430](https://github.com/flutter/plugins/pull/5430)

Issues fixed: [#102735](https://github.com/flutter/flutter/issues/102735)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
