### PR TITLE
[tools] Validate code excerpt configuration

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.2
+
+* Adds checking of `code-excerpt` configuration to `readme-check`, to validate
+  that if the excerpting tags are added to a README they are actually being
+  used.
+
 ## 0.9.1
 
 * Adds a `--downgrade` flag to `analyze` for analyzing with the oldest possible

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.9.1
+version: 0.9.2
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -42,7 +42,7 @@ void main() {
 
   test('runs pub get before running scripts', () async {
     final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
     final Directory example = getExampleDir(package);
 
     await runCapturingPrint(runner, <String>['update-excerpts']);
@@ -69,7 +69,7 @@ void main() {
 
   test('runs when config is present', () async {
     final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
     final Directory example = getExampleDir(package);
 
     final List<String> output =
@@ -128,7 +128,7 @@ void main() {
 
   test('restores pubspec even if running the script fails', () async {
     final RepositoryPackage package = createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
       MockProcess(exitCode: 1), // dart pub get
@@ -159,7 +159,7 @@ void main() {
 
   test('fails if pub get fails', () async {
     createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
       MockProcess(exitCode: 1), // dart pub get
@@ -183,7 +183,7 @@ void main() {
 
   test('fails if extraction fails', () async {
     createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
       MockProcess(), // dart pub get
@@ -208,7 +208,7 @@ void main() {
 
   test('fails if injection fails', () async {
     createFakePlugin('a_package', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
       MockProcess(), // dart pub get
@@ -234,7 +234,7 @@ void main() {
 
   test('fails if files are changed with --fail-on-change', () async {
     createFakePlugin('a_plugin', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
@@ -258,7 +258,7 @@ void main() {
 
   test('fails if git ls-files fails', () async {
     createFakePlugin('a_plugin', packagesDir,
-        extraFiles: <String>['example/build.excerpt.yaml']);
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
 
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
       MockProcess(exitCode: 1)

--- a/script/tool/test/util.dart
+++ b/script/tool/test/util.dart
@@ -23,6 +23,13 @@ import 'mocks.dart';
 
 export 'package:flutter_plugin_tools/src/common/repository_package.dart';
 
+/// The relative path from a package to the file that is used to enable
+/// README excerpting for a package.
+// This is a shared constant to ensure that both readme-check and
+// update-excerpt are looking for the same file, so that readme-check can't
+// get out of sync with what actually drives excerpting.
+const String kReadmeExcerptConfigPath = 'example/build.excerpt.yaml';
+
 const String _defaultDartConstraint = '>=2.14.0 <3.0.0';
 const String _defaultFlutterConstraint = '>=2.5.0';
 


### PR DESCRIPTION
Ensures that if a REAME uses code excerpting, the package is configured
to drive it. This avoids the (so far common) mistake of adding tags when
the block check fails, but not setting up the package so that they
actually work.

Also adds a link to the wiki for the missing excerpt tag error so that
people find the instructions sooner, rather than adding tags via
guess-and-check.

Fixes https://github.com/flutter/flutter/issues/109231

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
