### PR TITLE
[various] Remove stale NNBD opt-out tags

### DIFF
--- a/packages/google_sign_in/google_sign_in/example/integration_test/google_sign_in_test.dart
+++ b/packages/google_sign_in/google_sign_in/example/integration_test/google_sign_in_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in/google_sign_in.dart';
 import 'package:integration_test/integration_test.dart';

--- a/packages/google_sign_in/google_sign_in/example/test_driver/integration_test.dart
+++ b/packages/google_sign_in/google_sign_in/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();

--- a/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
+++ b/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   testWidgets('Can set shortcuts', (WidgetTester tester) async {
     const QuickActions quickActions = QuickActions();
-    await quickActions.initialize(null);
+    await quickActions.initialize((String _) {});
 
     const ShortcutItem shortCutItem = ShortcutItem(
       type: 'action_one',

--- a/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
+++ b/packages/quick_actions/quick_actions/example/integration_test/quick_actions_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:quick_actions/quick_actions.dart';

--- a/packages/quick_actions/quick_actions/example/test_driver/integration_test.dart
+++ b/packages/quick_actions/quick_actions/example/test_driver/integration_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:integration_test/integration_test_driver.dart';
 
 Future<void> main() => integrationDriver();


### PR DESCRIPTION
Some tests still had some tags opting tests out of NNBD. These were mostly scrubbed out of the repository when driver gained NNBD support, but these were missed.

Part of https://github.com/flutter/flutter/issues/110017

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
