### PR TITLE
[camera]revert the weakSelf in FLTThreadSafeEventChannel

### DIFF
--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.8+5
+
+* Fixes a regression introduced in 0.9.8+4 where the stream handler is not set. 
+
 ## 0.9.8+4
 
 * Fixes a crash due to sending orientation change events when the engine is torn down. 

--- a/packages/camera/camera_avfoundation/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
+++ b/packages/camera/camera_avfoundation/example/ios/RunnerTests/ThreadSafeEventChannelTests.m
@@ -63,4 +63,20 @@
   [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
+- (void)testEventChannel_shouldBeKeptAliveWhenDispatchingBackToMainThread {
+  XCTestExpectation *expectation =
+      [self expectationWithDescription:@"Completion should be called."];
+  dispatch_async(dispatch_queue_create("test", NULL), ^{
+    FLTThreadSafeEventChannel *channel = [[FLTThreadSafeEventChannel alloc]
+        initWithEventChannel:OCMClassMock([FlutterEventChannel class])];
+
+    [channel setStreamHandler:OCMOCK_ANY
+                   completion:^{
+                     [expectation fulfill];
+                   }];
+  });
+
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 @end

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeEventChannel.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeEventChannel.m
@@ -21,11 +21,13 @@
 
 - (void)setStreamHandler:(NSObject<FlutterStreamHandler> *)handler
               completion:(void (^)(void))completion {
-  __weak typeof(self) weakSelf = self;
+  // WARNING: Should not use weak self, because FLTThreadSafeEventChannel is a local variable
+  // (retained within call stack, but not in the heap). FLTEnsureToRunOnMainQueue may trigger a
+  // context switch (when calling from background thread), in which case using weak self will always
+  // result in a nil self. Alternative to using strong self, we can also create a local strong
+  // variable to be captured by this block.
   FLTEnsureToRunOnMainQueue(^{
-    typeof(self) strongSelf = weakSelf;
-    if (!strongSelf) return;
-    [strongSelf.channel setStreamHandler:handler];
+    [self.channel setStreamHandler:handler];
     completion();
   });
 }

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.8+4
+version: 0.9.8+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
# Why this bug? 

introduced in https://github.com/flutter/flutter/issues/109910

This is the same reason why we can't use weakSelf in [FLTThreadSafeFlutterResult](https://github.com/flutter/plugins/blob/fbdf7e3e9617748166ede491d96ab41322cd8e6d/packages/camera/camera_avfoundation/ios/Classes/FLTThreadSafeFlutterResult.m#L55-L60) - it's only retained within a call stack, not in the heap. So when dispatched back to main, the wrapper has been gone. 

# Workaround

As a temp workaround, I will simply revert the change in `FLTThreadSafeEventChannel` to fix the bug. An alternative workaround is to make `FLTThreadSafeEventChannel` an ivar and keep it around during streaming. I have verified that both works. 

In this particular example, we don't have to worry about strongSelf making engine API being called after engine is torn down. This is because engine would have to be dispatched to the main thread to be torn down, which must happen after the current block that we just enqueued. 

# Long term solution 

However, I dislike this approach, because all our thread safe wrappers cannot be re-used as general utilitys - they can only be used in this particular context of camera plugin. 

In the long term, I think a more general solution is to always use strong reference to the wrapper itself (where the retain cycle will be broken after the work is done dispatching), but pass in weak reference of the `plugin`, and use the `plugin` reference to tell if the engine is torn down or not (instead of using wrapper reference). This approach will make the wrapper working for both ivar and local variable/argument scenarios, while still avoiding calling engine API after engine is torn down. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/109910

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flxtter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
