### PR TITLE
Adds info about commands requiring Flutter-bundled dart

### DIFF
--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -15,6 +15,8 @@ instead. (It is marked as Discontinued since it is no longer maintained as
 a general-purpose tool, but updates are still published for use in
 flutter/packages.)
 
+The commands in tools require the Flutter-bundled version of Dart to be the first `dart` loaded in the path.
+
 ### From Source (flutter/plugins only)
 
 Set up:
@@ -50,8 +52,6 @@ following shows a number of common commands being run for a specific plugin.
 
 All examples assume running from source; see above for running the
 published version instead.
-
-Some commands require the Flutter-bundled version of Dart to be the first `dart` loaded into path (or the only version of Dart installed).
 
 Most commands take a `--packages` argument to control which package(s) the
 command is targetting. An package name can be any of:

--- a/script/tool/README.md
+++ b/script/tool/README.md
@@ -51,6 +51,8 @@ following shows a number of common commands being run for a specific plugin.
 All examples assume running from source; see above for running the
 published version instead.
 
+Some commands require the Flutter-bundled version of Dart to be the first `dart` loaded into path (or the only version of Dart installed).
+
 Most commands take a `--packages` argument to control which package(s) the
 command is targetting. An package name can be any of:
 - The name of a package (e.g., `path_provider_android`).


### PR DESCRIPTION
Adds info about some commands requiring Flutter-bundled dart.

Fixes https://github.com/flutter/flutter/issues/109824

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
