### PR TITLE
[shared_preferences] Prepare for change in handling of NoSuchMethod.

### DIFF
--- a/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/lib/shared_preferences_platform_interface.dart
@@ -27,7 +27,7 @@ abstract class SharedPreferencesStorePlatform {
     if (!value.isMock) {
       try {
         value._verifyProvidesDefaultImplementations();
-      } on NoSuchMethodError catch (_) {
+      } catch (_) {
         throw AssertionError(
             'Platform interfaces must not be implemented with `implements`');
       }

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -21,7 +21,8 @@ void main() {
     test('disallows implementing interface, unusual exception', () {
       expect(
         () {
-          SharedPreferencesStorePlatform.instance = IllegalImplementationWithUnusualException();
+          SharedPreferencesStorePlatform.instance =
+              IllegalImplementationWithUnusualException();
         },
         throwsAssertionError,
       );

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -17,6 +17,15 @@ void main() {
         throwsAssertionError,
       );
     });
+
+    test('disallows implementing interface, unusual exception', () {
+      expect(
+        () {
+          SharedPreferencesStorePlatform.instance = IllegalImplementationWithUnusualException();
+        },
+        throwsAssertionError,
+      );
+    });
   });
 }
 
@@ -46,3 +55,12 @@ class IllegalImplementation implements SharedPreferencesStorePlatform {
     throw UnimplementedError();
   }
 }
+
+class IllegalImplementationWithUnusualException extends IllegalImplementation {
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    throw _UnusualException();
+  }
+}
+
+class _UnusualException {}


### PR DESCRIPTION
In a future release of Dart, if a class containing private members is
*implemented* (rather than *extendeed*), any attempt to invoke one of
the private members will result in a runtime error (see
https://github.com/dart-lang/sdk/issues/49687).  This is necessary in
order to soundly support field promotion
(https://github.com/dart-lang/language/issues/2020).

The runtime error will most likely be a new exception type, not
`NoSuchMethodError`.  So, to avoid breaking the
`SharedPreferencesStorePlatform.instance` setter, we need to
generalize it to consider any exception thrown by
`_verifyProvidesDefaultImplementations` as an indication that the
`SharedPreferencesStorePlatform` has been illegally implemented.

In the non-error case, `_verifyProvidesDefaultImplementations` does
nothing, so this generalization should be safe.

Fixes https://github.com/flutter/flutter/issues/110364.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
