### PR TITLE
[various] Adopt `plugin_platform_interface`

### DIFF
--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+* Adopts `plugin_platform_interface`.
+  * Deprecates `isMock` in favor of the now-standard
+    `MockPlatformInterfaceMixin`.
+
 ## 2.2.0
 
 * Adds support for the `serverClientId` parameter.

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 2.3.0
 
-* Adopts `plugin_platform_interface`.
-  * Deprecates `isMock` in favor of the now-standard
-    `MockPlatformInterfaceMixin`.
+* Adopts `plugin_platform_interface`. As a result, `isMock` is deprecated in
+  favor of the now-standard `MockPlatformInterfaceMixin`.
 
 ## 2.2.0
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/lib/google_sign_in_platform_interface.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'src/method_channel_google_sign_in.dart';
 import 'src/types.dart';
@@ -20,13 +21,19 @@ export 'src/types.dart';
 /// ensures that the subclass will get the default implementation, while
 /// platform implementations that `implements` this interface will be broken by
 /// newly added [GoogleSignInPlatform] methods.
-abstract class GoogleSignInPlatform {
+abstract class GoogleSignInPlatform extends PlatformInterface {
+  /// Constructs a GoogleSignInPlatform.
+  GoogleSignInPlatform() : super(token: _token);
+
+  static final Object _token = Object();
+
   /// Only mock implementations should set this to `true`.
   ///
   /// Mockito mocks implement this class with `implements` which is forbidden
   /// (see class docs). This property provides a backdoor for mocks to skip the
   /// verification that the class isn't implemented with `implements`.
   @visibleForTesting
+  @Deprecated('Use MockPlatformInterfaceMixin instead')
   bool get isMock => false;
 
   /// The default instance of [GoogleSignInPlatform] to use.
@@ -44,24 +51,10 @@ abstract class GoogleSignInPlatform {
   // https://github.com/flutter/flutter/issues/43368
   static set instance(GoogleSignInPlatform instance) {
     if (!instance.isMock) {
-      try {
-        instance._verifyProvidesDefaultImplementations();
-      } on NoSuchMethodError catch (_) {
-        throw AssertionError(
-            'Platform interfaces must not be implemented with `implements`');
-      }
+      PlatformInterface.verify(instance, _token);
     }
     _instance = instance;
   }
-
-  /// This method ensures that [GoogleSignInPlatform] isn't implemented with `implements`.
-  ///
-  /// See class docs for more details on why using `implements` to implement
-  /// [GoogleSignInPlatform] is forbidden.
-  ///
-  /// This private method is called by the [instance] setter, which should fail
-  /// if the provided instance is a class implemented with `implements`.
-  void _verifyProvidesDefaultImplementations() {}
 
   /// Initializes the plugin. Deprecated: call [initWithParams] instead.
   ///

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,6 +13,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  plugin_platform_interface: ^2.1.0
   quiver: ^3.0.0
 
 dev_dependencies:

--- a/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
+++ b/packages/google_sign_in/google_sign_in_platform_interface/test/google_sign_in_platform_interface_test.dart
@@ -5,6 +5,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:google_sign_in_platform_interface/google_sign_in_platform_interface.dart';
 import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
   // Store the initial instance before any tests change it.
@@ -33,7 +34,11 @@ void main() {
     });
 
     test('Can be mocked with `implements`', () {
-      GoogleSignInPlatform.instance = ImplementsWithIsMock();
+      GoogleSignInPlatform.instance = ModernMockImplementation();
+    });
+
+    test('still supports legacy isMock', () {
+      GoogleSignInPlatform.instance = LegacyIsMockImplementation();
     });
   });
 
@@ -76,9 +81,16 @@ void main() {
   });
 }
 
-class ImplementsWithIsMock extends Mock implements GoogleSignInPlatform {
+class LegacyIsMockImplementation extends Mock implements GoogleSignInPlatform {
   @override
   bool get isMock => true;
+}
+
+class ModernMockImplementation extends Mock
+    with MockPlatformInterfaceMixin
+    implements GoogleSignInPlatform {
+  @override
+  bool get isMock => false;
 }
 
 class ImplementsGoogleSignInPlatform extends Mock

--- a/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 2.1.0
 
-* Adopts `plugin_platform_interface`.
-  * Deprecates `isMock` in favor of the now-standard
-    `MockPlatformInterfaceMixin`.
-* Fixes newly enabled analyzer options.
+* Adopts `plugin_platform_interface`. As a result, `isMock` is deprecated in
+  favor of the now-standard `MockPlatformInterfaceMixin`.
 
 ## 2.0.0
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
@@ -1,5 +1,8 @@
-## NEXT
+## 2.1.0
 
+* Adopts `plugin_platform_interface`.
+  * Deprecates `isMock` in favor of the now-standard
+    `MockPlatformInterfaceMixin`.
 * Fixes newly enabled analyzer options.
 
 ## 2.0.0

--- a/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_platform_interface
 description: A common platform interface for the shared_preferences plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_platform_interface
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.0
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,6 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  plugin_platform_interface: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
@@ -10,12 +11,25 @@ void main() {
 
   group(SharedPreferencesStorePlatform, () {
     test('disallows implementing interface', () {
-      expect(
-        () {
-          SharedPreferencesStorePlatform.instance = IllegalImplementation();
-        },
-        throwsAssertionError,
-      );
+      expect(() {
+        SharedPreferencesStorePlatform.instance = IllegalImplementation();
+      },
+          // In versions of `package:plugin_platform_interface` prior to fixing
+          // https://github.com/flutter/flutter/issues/109339, an attempt to
+          // implement a platform interface using `implements` would sometimes
+          // throw a `NoSuchMethodError` and other times throw an
+          // `AssertionError`. After the issue is fixed, an `AssertionError` will
+          // always be thrown. For the purpose of this test, we don't really care
+          // what exception is thrown, so just allow any exception.
+          throwsA(anything));
+    });
+
+    test('supports MockPlatformInterfaceMixin', () {
+      SharedPreferencesStorePlatform.instance = ModernMockImplementation();
+    });
+
+    test('still supports legacy isMock', () {
+      SharedPreferencesStorePlatform.instance = LegacyIsMockImplementation();
     });
   });
 }
@@ -23,6 +37,58 @@ void main() {
 class IllegalImplementation implements SharedPreferencesStorePlatform {
   // Intentionally declare self as not a mock to trigger the
   // compliance check.
+  @override
+  bool get isMock => false;
+
+  @override
+  Future<bool> clear() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> remove(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) {
+    throw UnimplementedError();
+  }
+}
+
+class LegacyIsMockImplementation implements SharedPreferencesStorePlatform {
+  @override
+  bool get isMock => true;
+
+  @override
+  Future<bool> clear() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Map<String, Object>> getAll() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> remove(String key) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<bool> setValue(String valueType, String key, Object value) {
+    throw UnimplementedError();
+  }
+}
+
+class ModernMockImplementation
+    with MockPlatformInterfaceMixin
+    implements SharedPreferencesStorePlatform {
   @override
   bool get isMock => false;
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
+++ b/packages/shared_preferences/shared_preferences_platform_interface/test/shared_preferences_platform_interface_test.dart
@@ -34,6 +34,7 @@ void main() {
   });
 }
 
+/// An implementation using `implements` that isn't a mock, which isn't allowed.
 class IllegalImplementation implements SharedPreferencesStorePlatform {
   // Intentionally declare self as not a mock to trigger the
   // compliance check.


### PR DESCRIPTION
Switches `google_sign_in` and `shared_preferences` from a legacy custom
system for verifying that implementations use `extends` rather than
`implements` to the now-standard `plugin_platform_interface`,
deprecating the `isMock` approach to overriding it.

Fixes https://github.com/flutter/flutter/issues/98710
Fixes https://github.com/flutter/flutter/issues/98709

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
