### PR TITLE
show AuthMessage On LocalAuth Import

### DIFF
--- a/packages/file_selector/file_selector/example/ios/Flutter/Debug.xcconfig
+++ b/packages/file_selector/file_selector/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/file_selector/file_selector/example/ios/Flutter/Release.xcconfig
+++ b/packages/file_selector/file_selector/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/file_selector/file_selector/example/ios/Podfile
+++ b/packages/file_selector/file_selector/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/packages/local_auth/local_auth/lib/local_auth.dart
+++ b/packages/local_auth/local_auth/lib/local_auth.dart
@@ -3,7 +3,14 @@
 // found in the LICENSE file.
 
 export 'package:local_auth/src/local_auth.dart' show LocalAuthentication;
+export 'package:local_auth_android/types/auth_messages_android.dart'
+    show AndroidAuthMessages;
+export 'package:local_auth_ios/types/auth_messages_ios.dart'
+    show IOSAuthMessages;
+export 'package:local_auth_platform_interface/types/auth_messages.dart';
 export 'package:local_auth_platform_interface/types/auth_options.dart'
     show AuthenticationOptions;
 export 'package:local_auth_platform_interface/types/biometric_type.dart'
     show BiometricType;
+export 'package:local_auth_windows/types/auth_messages_windows.dart'
+    show WindowsAuthMessages;


### PR DESCRIPTION
AuthMessage can not be detected from LocalAuth Import. 
I have updated and export code line so AuthMessage shown ... 

Changes : 
`export 'package:local_auth_windows/types/auth_messages_windows.dart'
    show WindowsAuthMessages;
export 'package:local_auth_android/types/auth_messages_android.dart'
    show AndroidAuthMessages;
export 'package:local_auth_ios/types/auth_messages_ios.dart'
    show IOSAuthMessages;
export 'package:local_auth_platform_interface/types/auth_messages.dart';
`

