### PR TITLE
Revert "[url_launcher]: Bump gradle from 3.4.2 to 7.2.2 in /packages/url_launcher/url_launcher_android/android #6194"

### DIFF
--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,5 +1,10 @@
-## NEXT
+## 6.0.19
 
+* Revert gradle back to 3.4.2.
+
+## 6.0.18
+
+* Updates gradle to 7.2.2.
 * Updates minimum Flutter version to 2.10.
 
 ## 6.0.17

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,6 +1,5 @@
-## 6.0.18
+## NEXT
 
-* Updates gradle to 7.2.2.
 * Updates minimum Flutter version to 2.10.
 
 ## 6.0.17

--- a/packages/url_launcher/url_launcher_android/android/build.gradle
+++ b/packages/url_launcher/url_launcher_android/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:3.4.2'
     }
 }
 

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.18
+version: 6.0.17
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: url_launcher_android
 description: Android implementation of the url_launcher plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/url_launcher/url_launcher_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+url_launcher%22
-version: 6.0.17
+version: 6.0.19
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/111304

Breaks: https://github.com/flutter/flutter/pull/111197/files#diff-9aeff568c87b1d587222c343afb84ef72fc07e0692d50ecb3de670e5606f9505R46