### PR TITLE
Revert "[camera]: Bump robolectric from 4.5 to 4.8.2 in /packages/camera/camera_android/android"

### DIFF
--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -63,5 +63,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.7.0'
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'org.robolectric:robolectric:4.8.2'
+    testImplementation 'org.robolectric:robolectric:4.5'
 }


### PR DESCRIPTION
Reverts flutter/plugins#6329

camera_android unit tests seem to be failing pretty consistently [in](https://github.com/flutter/plugins/runs/8278228414) [main](https://github.com/flutter/plugins/runs/8278229490).

Attempting to restore the tree by reverting the PR above.