### PR TITLE
[plugin_platform_interface] Switch `PlatformInterface._instanceToken` to an expando.

### DIFF
--- a/packages/plugin_platform_interface/CHANGELOG.md
+++ b/packages/plugin_platform_interface/CHANGELOG.md
@@ -1,7 +1,11 @@
-## NEXT
+## 2.1.3
 
 * Minor fixes for new analysis options.
 * Adds additional tests for `PlatformInterface` and `MockPlatformInterfaceMixin`.
+* Modifies `PlatformInterface` to use an expando for detecting if a customer
+  tries to implement PlatformInterface using `implements` rather than `extends`.
+  This ensures that `verify` will continue to work as advertized after
+  https://github.com/dart-lang/language/issues/2020 is implemented.
 
 ## 2.1.2
 

--- a/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
+++ b/packages/plugin_platform_interface/lib/plugin_platform_interface.dart
@@ -49,13 +49,14 @@ abstract class PlatformInterface {
   }
 
   /// Expando mapping instances of PlatformInterface to their associated tokens.
-  /// The reason we don't simply use a private field of type `Object?` is
-  /// because as part of implementing
-  /// https://github.com/dart-lang/language/issues/2020, it will soon become a
-  /// runtime error to invoke a private member that is mocked in another
-  /// library.  By using an expando rather than an instance field, we ensure
-  /// that we will be able to reliably detect implementations using `implements`
-  /// rather than `extends`.
+  /// The reason this is not simply a private field of type `Object?` is because
+  /// as of the implementation of field promotion in Dart
+  /// (https://github.com/dart-lang/language/issues/2020), it is a runtime error
+  /// to invoke a private member that is mocked in another library.  The expando
+  /// approach prevents [_verify] from triggering this runtime exception when
+  /// encountering an implementation that uses `implements` rather than
+  /// `extends`.  This in turn allows [_verify] to throw an [AssertionError] (as
+  /// documented).
   static final Expando<Object> _instanceTokens = Expando<Object>();
 
   /// Ensures that the platform instance was constructed with a non-`const` token

--- a/packages/plugin_platform_interface/pubspec.yaml
+++ b/packages/plugin_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # be done when absolutely necessary and after the ecosystem has already migrated to 2.X.Y version
 # that is forward compatible with 3.0.0 (ideally the ecosystem have migrated to depend on:
 # `plugin_platform_interface: >=2.X.Y <4.0.0`).
-version: 2.1.2
+version: 2.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -21,6 +21,12 @@ class SamplePluginPlatform extends PlatformInterface {
 class ImplementsSamplePluginPlatform extends Mock
     implements SamplePluginPlatform {}
 
+class ImplementsSamplePluginPlatformUsingNoSuchMethod
+    implements SamplePluginPlatform {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class ImplementsSamplePluginPlatformUsingMockPlatformInterfaceMixin extends Mock
     with MockPlatformInterfaceMixin
     implements SamplePluginPlatform {}
@@ -95,6 +101,12 @@ void main() {
     test('prevents implementation with `implements`', () {
       expect(() {
         SamplePluginPlatform.instance = ImplementsSamplePluginPlatform();
+      }, throwsA(isA<AssertionError>()));
+    });
+
+    test('prevents implmentation with `implements` and `noSuchMethod`', () {
+      expect(() {
+        SamplePluginPlatform.instance = ImplementsSamplePluginPlatformUsingNoSuchMethod();
       }, throwsA(isA<AssertionError>()));
     });
 

--- a/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
+++ b/packages/plugin_platform_interface/test/plugin_platform_interface_test.dart
@@ -106,7 +106,8 @@ void main() {
 
     test('prevents implmentation with `implements` and `noSuchMethod`', () {
       expect(() {
-        SamplePluginPlatform.instance = ImplementsSamplePluginPlatformUsingNoSuchMethod();
+        SamplePluginPlatform.instance =
+            ImplementsSamplePluginPlatformUsingNoSuchMethod();
       }, throwsA(isA<AssertionError>()));
     });
 


### PR DESCRIPTION
This change replaces `PlatformInterface._instanceToken` (an instance field that points from a `PlatformInterface` to its corresponding token) with an expando that maps from `PlatformInterface` to `Object`. There is no change to the public API, and no change to the behavior of users' production code.

This change ensures that if a customer tries to implement `PlatformInterface` using `implements` rather than `extends`, the code in `PlatformInterface._verify` won't try to access the private `_instanceToken` field in `PlatformInterface`.  This is important because an upcoming change to the dart language is going to cause such accesses to throw exceptions rather than deferring to `noSuchMethod` (see https://github.com/dart-lang/language/issues/2020 for details).

Fixes https://github.com/flutter/flutter/issues/109339.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
