### PR TITLE
[in_app_purchase] Add immediateAndChargeFullPrice ProrationMode

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.2.3+4
 
 * Updates minimum Flutter version to 2.10.
- Adds IMMEDIATE_AND_CHARGE_FULL_PRICE to the ProrationMode.
+* Adds IMMEDIATE_AND_CHARGE_FULL_PRICE to the `ProrationMode`.
 
 ## 0.2.3+3
 

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.3+4
 
 * Updates minimum Flutter version to 2.10.
+ Adds IMMEDIATE_AND_CHARGE_FULL_PRICE to the ProrationMode.
 
 ## 0.2.3+3
 

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -516,7 +516,7 @@ enum ProrationMode {
   @JsonValue(3)
   immediateWithoutProration,
 
-  /// Replacement takes effect when the old plan expires, and the new price will 
+  /// Replacement takes effect when the old plan expires, and the new price will
   /// be charged at the same time.
   @JsonValue(4)
   deferred,

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.dart
@@ -495,7 +495,8 @@ enum ProrationMode {
   @JsonValue(0)
   unknownSubscriptionUpgradeDowngradePolicy,
 
-  /// Replacement takes effect immediately, and the remaining time will be prorated and credited to the user.
+  /// Replacement takes effect immediately, and the remaining time will be prorated
+  /// and credited to the user.
   ///
   /// This is the current default behavior.
   @JsonValue(1)
@@ -508,15 +509,23 @@ enum ProrationMode {
   @JsonValue(2)
   immediateAndChargeProratedPrice,
 
-  /// Replacement takes effect immediately, and the new price will be charged on next recurrence time.
+  /// Replacement takes effect immediately, and the new price will be charged on next
+  /// recurrence time.
   ///
   /// The billing cycle stays the same.
   @JsonValue(3)
   immediateWithoutProration,
 
-  /// Replacement takes effect when the old plan expires, and the new price will be charged at the same time.
+  /// Replacement takes effect when the old plan expires, and the new price will 
+  /// be charged at the same time.
   @JsonValue(4)
   deferred,
+
+  /// Replacement takes effect immediately, and the user is charged full price
+  /// of new plan and is given a full billing cycle of subscription, plus
+  /// remaining prorated time from the old plan.
+  @JsonValue(5)
+  immediateAndChargeFullPrice,
 }
 
 /// Serializer for [ProrationMode].

--- a/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.g.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/lib/src/billing_client_wrappers/billing_client_wrapper.g.dart
@@ -32,6 +32,7 @@ const _$ProrationModeEnumMap = {
   ProrationMode.immediateAndChargeProratedPrice: 2,
   ProrationMode.immediateWithoutProration: 3,
   ProrationMode.deferred: 4,
+  ProrationMode.immediateAndChargeFullPrice: 5,
 };
 
 const _$BillingClientFeatureEnumMap = {

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.3+3
+version: 0.2.3+4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/test/billing_client_wrappers/billing_client_wrapper_test.dart
@@ -311,6 +311,45 @@ void main() {
           const ProrationModeConverter().toJson(prorationMode));
     });
 
+    test(
+        'serializes and deserializes data when using immediateAndChargeFullPrice',
+        () async {
+      const String debugMessage = 'dummy message';
+      const BillingResponse responseCode = BillingResponse.ok;
+      const BillingResultWrapper expectedBillingResult = BillingResultWrapper(
+          responseCode: responseCode, debugMessage: debugMessage);
+      stubPlatform.addResponse(
+        name: launchMethodName,
+        value: buildBillingResultMap(expectedBillingResult),
+      );
+      const SkuDetailsWrapper skuDetails = dummySkuDetails;
+      const String accountId = 'hashedAccountId';
+      const String profileId = 'hashedProfileId';
+      const ProrationMode prorationMode =
+          ProrationMode.immediateAndChargeFullPrice;
+
+      expect(
+          await billingClient.launchBillingFlow(
+              sku: skuDetails.sku,
+              accountId: accountId,
+              obfuscatedProfileId: profileId,
+              oldSku: dummyOldPurchase.sku,
+              prorationMode: prorationMode,
+              purchaseToken: dummyOldPurchase.purchaseToken),
+          equals(expectedBillingResult));
+      final Map<dynamic, dynamic> arguments = stubPlatform
+          .previousCallMatching(launchMethodName)
+          .arguments as Map<dynamic, dynamic>;
+      expect(arguments['sku'], equals(skuDetails.sku));
+      expect(arguments['accountId'], equals(accountId));
+      expect(arguments['oldSku'], equals(dummyOldPurchase.sku));
+      expect(arguments['obfuscatedProfileId'], equals(profileId));
+      expect(
+          arguments['purchaseToken'], equals(dummyOldPurchase.purchaseToken));
+      expect(arguments['prorationMode'],
+          const ProrationModeConverter().toJson(prorationMode));
+    });
+
     test('handles null accountId', () async {
       const String debugMessage = 'dummy message';
       const BillingResponse responseCode = BillingResponse.ok;


### PR DESCRIPTION
Based off of https://github.com/flutter/plugins/pull/6132 by @tosaka07

> Added [IMMEDIATE_AND_CHARGE_FULL_PRICE](https://developer.android.com/reference/com/android/billingclient/api/BillingFlowParams.ProrationMode#IMMEDIATE_AND_CHARGE_FULL_PRICE) to ProrationMode.
> 
> IMMEDIATE_AND_CHARGE_FULL_PRICE is new in Billing Library v4.
> https://developer.android.com/google/play/billing/release-notes#4-0-0-summary-changes
> 
> This library has already been updated to v5, so there is no problem.
> 
> Fixes https://github.com/flutter/flutter/issues/108164