### PR TITLE
[shared_preferences] [test-exempt] Added functionality for List<List<String>>

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,9 @@
+
+
+## 2.0.20
+
+* Added List<List<String>> functionality.
+
 ## NEXT
 
 * Updates minimum Flutter version to 2.10.

--- a/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
+++ b/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart
@@ -90,15 +90,15 @@ class SharedPreferences {
     return list?.toList() as List<String>?;
   }
 
-  /// Reads a set of string values from persistent storage, throwing an
-  /// exception if it's not a string set.
+  /// Reads a set of List<string> values from persistent storage, throwing an
+  /// exception if it's not a List<string> set.
   List<List<String>>? getStringListList(String key) {
     List<List<dynamic>>? listList = _preferenceCache[key] as List<List<dynamic>>?;
     if (listList != null && listList is! List<List<String>>) {
       listList = listList.cast<List<String>>().toList();
       _preferenceCache[key] = listList;
     }
-    // Make a copy of the list so that later mutations won't propagate
+    // Make a copy of the list<list> so that later mutations won't propagate
     return listList?.toList() as List<List<String>>?;
   }
 

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.15
+version: 2.0.20
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Hello ^^,

This pull request adds `List<List<String>>` elements to shared preferences.
I used `List<String>` as a template for this. I did not make any specific tests; However I successfully used it in my app to store calendar data:
`late List<List<String>> eventData;`
[...]
`eventData = prefs.getStringListList('whole_events')!;`
[...]
`print(eventData[0][1]);`

I still get the following error once, when loading the dart file:

`E/flutter (23975): [ERROR:flutter/lib/ui/ui_dart_state.cc(198)] Unhandled Exception: MissingPluginException(No implementation found for method setStringListList on channel plugins.flutter.io/shared_preferences_android)
E/flutter (23975): #0      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:165:7)
E/flutter (23975): <asynchronous suspension>
E/flutter (23975): #1      SharedPreferencesAndroid.setValue (package:shared_preferences_android/shared_preferences_android.dart:32:13)
E/flutter (23975): <asynchronous suspension>`

The code however works as intended. I only tested it on an android emulator as of yet.

This is the first time I contributed to a project so I hope that I did not forget any major aspect of the guidelines.