### PR TITLE
[image_picker] Allow saving photos picked with PHPicker without permissions

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.8.6+1
+* Fixes issue with crashing the app when picking images with PHPicker without providing `Photo Library Usage` permission.
+
 ## 0.8.6
 
 * Adds `requestFullMetadata` option to `pickImage`, so images on iOS can be picked without `Photo Library Usage` permission.

--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.8.6+1
+
 * Fixes issue with crashing the app when picking images with PHPicker without providing `Photo Library Usage` permission.
 
 ## 0.8.6

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
@@ -87,6 +87,7 @@
                 maxHeight:@100
                  maxWidth:@100
       desiredImageQuality:@100
+             fullMetadata:YES
            savedPathBlock:^(NSString *savedPath) {
              if ([[NSFileManager defaultManager] fileExistsAtPath:savedPath]) {
                [pathExpectation fulfill];

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
@@ -22,7 +22,7 @@
   PHPickerResult *result = [self createPickerResultWithProvider:itemProvider
                                                  withIdentifier:UTTypeWebP.identifier];
 
-  [self verifySavingImageWithPickerResult:result];
+  [self verifySavingImageWithPickerResult:result fullMetadata:YES];
 }
 
 - (void)testSavePNGImage API_AVAILABLE(ios(14)) {
@@ -32,7 +32,7 @@
   PHPickerResult *result = [self createPickerResultWithProvider:itemProvider
                                                  withIdentifier:UTTypeWebP.identifier];
 
-  [self verifySavingImageWithPickerResult:result];
+  [self verifySavingImageWithPickerResult:result fullMetadata:YES];
 }
 
 - (void)testSaveJPGImage API_AVAILABLE(ios(14)) {
@@ -42,7 +42,7 @@
   PHPickerResult *result = [self createPickerResultWithProvider:itemProvider
                                                  withIdentifier:UTTypeWebP.identifier];
 
-  [self verifySavingImageWithPickerResult:result];
+  [self verifySavingImageWithPickerResult:result fullMetadata:YES];
 }
 
 - (void)testSaveGIFImage API_AVAILABLE(ios(14)) {
@@ -52,7 +52,21 @@
   PHPickerResult *result = [self createPickerResultWithProvider:itemProvider
                                                  withIdentifier:UTTypeWebP.identifier];
 
-  [self verifySavingImageWithPickerResult:result];
+  [self verifySavingImageWithPickerResult:result fullMetadata:YES];
+}
+
+- (void)testSavePNGImageWithoutFullMetadata API_AVAILABLE(ios(14)) {
+  id photoAssetUtil = OCMClassMock([PHAsset class]);
+
+  NSURL *imageURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                             withExtension:@"png"];
+  NSItemProvider *itemProvider = [[NSItemProvider alloc] initWithContentsOfURL:imageURL];
+  PHPickerResult *result = [self createPickerResultWithProvider:itemProvider
+                                                 withIdentifier:UTTypeWebP.identifier];
+
+  [self verifySavingImageWithPickerResult:result fullMetadata:NO];
+  OCMVerify(times(0), [photoAssetUtil fetchAssetsWithLocalIdentifiers:[OCMArg any]
+                                                              options:[OCMArg any]]);
 }
 
 /**
@@ -79,7 +93,8 @@
  *
  * @param result the picker result
  */
-- (void)verifySavingImageWithPickerResult:(PHPickerResult *)result API_AVAILABLE(ios(14)) {
+- (void)verifySavingImageWithPickerResult:(PHPickerResult *)result
+                             fullMetadata:(BOOL)fullMetadata API_AVAILABLE(ios(14)) {
   XCTestExpectation *pathExpectation = [self expectationWithDescription:@"Path was created"];
 
   FLTPHPickerSaveImageToPathOperation *operation = [[FLTPHPickerSaveImageToPathOperation alloc]
@@ -87,7 +102,7 @@
                 maxHeight:@100
                  maxWidth:@100
       desiredImageQuality:@100
-             fullMetadata:YES
+             fullMetadata:fullMetadata
            savedPathBlock:^(NSString *savedPath) {
              if ([[NSFileManager defaultManager] fileExistsAtPath:savedPath]) {
                [pathExpectation fulfill];

--- a/packages/image_picker/image_picker_ios/example/lib/main.dart
+++ b/packages/image_picker/image_picker_ios/example/lib/main.dart
@@ -93,10 +93,15 @@ class _MyHomePageState extends State<MyHomePage> {
       await _displayPickImageDialog(context!,
           (double? maxWidth, double? maxHeight, int? quality) async {
         try {
-          final List<XFile>? pickedFileList = await _picker.getMultiImage(
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            imageQuality: quality,
+          final List<XFile> pickedFileList =
+              await _picker.getMultiImageWithOptions(
+            options: MultiImagePickerOptions(
+              imageOptions: ImageOptions(
+                maxWidth: maxWidth,
+                maxHeight: maxHeight,
+                imageQuality: quality,
+              ),
+            ),
           );
           setState(() {
             _imageFileList = pickedFileList;
@@ -111,11 +116,13 @@ class _MyHomePageState extends State<MyHomePage> {
       await _displayPickImageDialog(context!,
           (double? maxWidth, double? maxHeight, int? quality) async {
         try {
-          final XFile? pickedFile = await _picker.getImage(
+          final XFile? pickedFile = await _picker.getImageFromSource(
             source: source,
-            maxWidth: maxWidth,
-            maxHeight: maxHeight,
-            imageQuality: quality,
+            options: ImagePickerOptions(
+              maxWidth: maxWidth,
+              maxHeight: maxHeight,
+              imageQuality: quality,
+            ),
           );
           setState(() {
             _setImageFileListFromFile(pickedFile);

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -495,6 +495,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
                                                             maxHeight:maxHeight
                                                              maxWidth:maxWidth
                                                   desiredImageQuality:desiredImageQuality
+                                                         fullMetadata:self.callContext.requestFullMetadata
                                                        savedPathBlock:^(NSString *savedPath) {
                                                          pathList[i] = savedPath;
                                                        }];

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -490,15 +490,15 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 
     for (int i = 0; i < results.count; i++) {
       PHPickerResult *result = results[i];
-      FLTPHPickerSaveImageToPathOperation *operation =
-          [[FLTPHPickerSaveImageToPathOperation alloc] initWithResult:result
-                                                            maxHeight:maxHeight
-                                                             maxWidth:maxWidth
-                                                  desiredImageQuality:desiredImageQuality
-                                                         fullMetadata:self.callContext.requestFullMetadata
-                                                       savedPathBlock:^(NSString *savedPath) {
-                                                         pathList[i] = savedPath;
-                                                       }];
+      FLTPHPickerSaveImageToPathOperation *operation = [[FLTPHPickerSaveImageToPathOperation alloc]
+               initWithResult:result
+                    maxHeight:maxHeight
+                     maxWidth:maxWidth
+          desiredImageQuality:desiredImageQuality
+                 fullMetadata:self.callContext.requestFullMetadata
+               savedPathBlock:^(NSString *savedPath) {
+                 pathList[i] = savedPath;
+               }];
       [operationQueue addOperation:operation];
     }
     [operationQueue waitUntilAllOperationsAreFinished];

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
@@ -26,7 +26,7 @@
                      maxHeight:(NSNumber *)maxHeight
                       maxWidth:(NSNumber *)maxWidth
            desiredImageQuality:(NSNumber *)desiredImageQuality
-           fullMetadata:(BOOL)fullMetadata
+                  fullMetadata:(BOOL)fullMetadata
                 savedPathBlock:(void (^)(NSString *))savedPathBlock API_AVAILABLE(ios(14));
 
 @end

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
@@ -26,6 +26,7 @@
                      maxHeight:(NSNumber *)maxHeight
                       maxWidth:(NSNumber *)maxWidth
            desiredImageQuality:(NSNumber *)desiredImageQuality
+           fullMetadata:(BOOL)fullMetadata
                 savedPathBlock:(void (^)(NSString *))savedPathBlock API_AVAILABLE(ios(14));
 
 @end

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -13,6 +13,7 @@ API_AVAILABLE(ios(14))
 @property(assign, nonatomic) NSNumber *maxHeight;
 @property(assign, nonatomic) NSNumber *maxWidth;
 @property(assign, nonatomic) NSNumber *desiredImageQuality;
+@property(assign, nonatomic) BOOL requestFullMetadata;
 
 @end
 
@@ -28,6 +29,7 @@ typedef void (^GetSavedPath)(NSString *);
                      maxHeight:(NSNumber *)maxHeight
                       maxWidth:(NSNumber *)maxWidth
            desiredImageQuality:(NSNumber *)desiredImageQuality
+           fullMetadata:(BOOL)fullMetadata
                 savedPathBlock:(GetSavedPath)savedPathBlock API_AVAILABLE(ios(14)) {
   if (self = [super init]) {
     if (result) {
@@ -35,6 +37,7 @@ typedef void (^GetSavedPath)(NSString *);
       self.maxHeight = maxHeight;
       self.maxWidth = maxWidth;
       self.desiredImageQuality = desiredImageQuality;
+        self.requestFullMetadata = fullMetadata;
       getSavedPath = savedPathBlock;
       executing = NO;
       finished = NO;
@@ -113,7 +116,10 @@ typedef void (^GetSavedPath)(NSString *);
  * Processes the image.
  */
 - (void)processImage:(UIImage *)localImage API_AVAILABLE(ios(14)) {
-  PHAsset *originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
+    PHAsset *originalAsset;
+    if (self.requestFullMetadata) {
+        originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
+    }
 
   if (self.maxWidth != nil || self.maxHeight != nil) {
     localImage = [FLTImagePickerImageUtil scaledImage:localImage

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -29,7 +29,7 @@ typedef void (^GetSavedPath)(NSString *);
                      maxHeight:(NSNumber *)maxHeight
                       maxWidth:(NSNumber *)maxWidth
            desiredImageQuality:(NSNumber *)desiredImageQuality
-           fullMetadata:(BOOL)fullMetadata
+                  fullMetadata:(BOOL)fullMetadata
                 savedPathBlock:(GetSavedPath)savedPathBlock API_AVAILABLE(ios(14)) {
   if (self = [super init]) {
     if (result) {
@@ -37,7 +37,7 @@ typedef void (^GetSavedPath)(NSString *);
       self.maxHeight = maxHeight;
       self.maxWidth = maxWidth;
       self.desiredImageQuality = desiredImageQuality;
-        self.requestFullMetadata = fullMetadata;
+      self.requestFullMetadata = fullMetadata;
       getSavedPath = savedPathBlock;
       executing = NO;
       finished = NO;
@@ -116,10 +116,10 @@ typedef void (^GetSavedPath)(NSString *);
  * Processes the image.
  */
 - (void)processImage:(UIImage *)localImage API_AVAILABLE(ios(14)) {
-    PHAsset *originalAsset;
-    if (self.requestFullMetadata) {
-        originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
-    }
+  PHAsset *originalAsset;
+  if (self.requestFullMetadata) {
+    originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
+  }
 
   if (self.maxWidth != nil || self.maxHeight != nil) {
     localImage = [FLTImagePickerImageUtil scaledImage:localImage

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -117,7 +117,8 @@ typedef void (^GetSavedPath)(NSString *);
  */
 - (void)processImage:(UIImage *)localImage API_AVAILABLE(ios(14)) {
   PHAsset *originalAsset;
-  // Only if requested, fetch the full "PHAsset" metadata, which requires  "Photo Library Usage" permissions.
+  // Only if requested, fetch the full "PHAsset" metadata, which requires  "Photo Library Usage"
+  // permissions.
   if (self.requestFullMetadata) {
     originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
   }

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -117,6 +117,7 @@ typedef void (^GetSavedPath)(NSString *);
  */
 - (void)processImage:(UIImage *)localImage API_AVAILABLE(ios(14)) {
   PHAsset *originalAsset;
+  // Only if requested, fetch the full "PHAsset" metadata, which requires  "Photo Library Usage" permissions.
   if (self.requestFullMetadata) {
     originalAsset = [FLTImagePickerPhotoAssetUtil getAssetFromPHPickerResult:self.result];
   }

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.6
+version: 0.8.6+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
## Description
Bugfix for picking (multi) images with PHPicker without gallery permissions.

While the current version allows accessing the gallery without permissions, it was still requiring them for returning picked images as a result. 

## Related issues
flutter/flutter#65995
Bug reported in comment under #5915 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/master/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
