### PR TITLE
[file_selector] Update file_selector_platform_interface by adding a new property 'uniformTypeIdentifiers' to the XTypeGroup.

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+* Adds required iOS `macUTIs` parameter for the `_openTextFile`, `_openImageFile` and `_openImageFile`(for multiple images) methods on the `file_selector` project's main example.
+
+## 0.9.3
+
 * Updates minimum Flutter version to 2.10.
 
 ## 0.9.2

--- a/packages/file_selector/file_selector/README.md
+++ b/packages/file_selector/file_selector/README.md
@@ -83,12 +83,13 @@ Different platforms support different type group filter options. To avoid
 filters that cover all platforms you are targeting, or that you conditionally
 pass different `XTypeGroup`s based on `Platform`.
 
-|                | Linux | macOS  | Web | Windows     |
-|----------------|-------|--------|-----|-------------|
-| `extensions`   | ✔️     | ✔️      | ✔️   | ✔️           |
-| `mimeTypes`    | ✔️     | ✔️†     | ✔️   |             |
-| `macUTIs`      |       | ✔️      |     |             |
-| `webWildCards` |       |        | ✔️   |             |
+|                | Linux | macOS  | Web | Windows     | iOS |
+|----------------|-------|--------|-----|-------------|-----|
+| `extensions`   | ✔️     | ✔️      | ✔️   | ✔️           |     |
+| `mimeTypes`    | ✔️     | ✔️†     | ✔️   |             |     |
+| `macUTIs`      |       | ✔️      |     |             |     |
+| `webWildCards` |       |        | ✔️   |             |     |
+| `uniformTypeIdentifiers` |       | ✔️      |     |             | ✔️   |
 
 † `mimeTypes` are not supported on version of macOS earlier than 11 (Big Sur).
 

--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -18,6 +18,7 @@ class OpenImagePage extends StatelessWidget {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
       extensions: <String>['jpg', 'png'],
+      macUTIs: <String>['public.image'],
     );
     final XFile? file =
         await openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -18,10 +18,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: <String>['jpg', 'jpeg'],
+      macUTIs: <String>['public.jpeg'],
     );
     final XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: <String>['png'],
+      macUTIs: <String>['public.png'],
     );
     final List<XFile> files = await openFiles(acceptedTypeGroups: <XTypeGroup>[
       jpgsTypeGroup,

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -15,6 +15,7 @@ class OpenTextPage extends StatelessWidget {
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
       extensions: <String>['txt', 'json'],
+      macUTIs: <String>['public.text'],
     );
     // This demonstrates using an initial directory for the prompt, which should
     // only be done in cases where the application can likely predict where the

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for opening and saving files, or selecting
   directories, using native file selection UI.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.2
+version: 0.9.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_ios/CHANGELOG.md
+++ b/packages/file_selector/file_selector_ios/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+* Removes the unnecessary `label` and `extensions` parameters for the `_openTextFile`, `_openImageFile` and `_openImageFile`(for multiple images) mehtods.
+
+## 0.5.0+2
+
 * Updates minimum Flutter version to 2.10.
 
 ## 0.5.0+1

--- a/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
@@ -16,8 +16,6 @@ class OpenImagePage extends StatelessWidget {
 
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
-      label: 'images',
-      extensions: <String>['jpg', 'png'],
       macUTIs: <String>['public.image'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
@@ -16,13 +16,9 @@ class OpenMultipleImagesPage extends StatelessWidget {
 
   Future<void> _openImageFile(BuildContext context) async {
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
-      label: 'JPEGs',
-      extensions: <String>['jpg', 'jpeg'],
       macUTIs: <String>['public.jpeg'],
     );
     final XTypeGroup pngTypeGroup = XTypeGroup(
-      label: 'PNGs',
-      extensions: <String>['png'],
       macUTIs: <String>['public.png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
@@ -13,8 +13,6 @@ class OpenTextPage extends StatelessWidget {
 
   Future<void> _openTextFile(BuildContext context) async {
     final XTypeGroup typeGroup = XTypeGroup(
-      label: 'text',
-      extensions: <String>['txt', 'json'],
       macUTIs: <String>['public.text'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
+++ b/packages/file_selector/file_selector_ios/lib/file_selector_ios.dart
@@ -53,10 +53,12 @@ class FileSelectorIOS extends FileSelectorPlatform {
       if (typeGroup.allowsAny) {
         return <String>[];
       }
+
       if (typeGroup.macUTIs?.isEmpty ?? true) {
         throw ArgumentError('The provided type group $typeGroup should either '
             'allow all files, or have a non-empty "macUTIs"');
       }
+
       allowedUTIs.addAll(typeGroup.macUTIs!);
     }
     return allowedUTIs;

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_ios
 description: iOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.5.0+1
+version: 0.5.0+2
 
 environment:
   sdk: ">=2.14.4 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+* Adds the `uniformTypeIdentifiers` property to the `XTypeGroup` that relies on `macUTIs`. The last will be deprecated for future releases.
+
+## 2.1.1
+
 * Updates minimum Flutter version to 2.10.
 
 ## 2.1.0

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -26,7 +26,7 @@ class XTypeGroup {
   final List<String>? mimeTypes;
 
   /// The UTIs for this group
-  final List<String>? macUTIs;
+  List<String>? macUTIs;
 
   /// The web wild cards for this group (ex: image/*, video/*)
   final List<String>? webWildCards;
@@ -48,6 +48,14 @@ class XTypeGroup {
         (mimeTypes?.isEmpty ?? true) &&
         (macUTIs?.isEmpty ?? true) &&
         (webWildCards?.isEmpty ?? true);
+  }
+
+  /// Returns the list of Uniform Type Identifiers for this group.
+  List<String>? get uniformTypeIdentifiers => macUTIs;
+
+  /// Returns the list of Uniform Type Identifiers for this group.
+  set uniformTypeIdentifiers(List<String>? value) {
+    macUTIs = value;
   }
 
   static List<String>? _removeLeadingDots(List<String>? exts) => exts

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.0
+version: 2.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -7,12 +7,13 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('XTypeGroup', () {
+    final List<String> extensions = <String>['txt', 'jpg'];
+    final List<String> mimeTypes = <String>['text/plain'];
+    final List<String> macUTIs = <String>['public.plain-text'];
+    final List<String> webWildCards = <String>['image/*'];
+
     test('toJSON() creates correct map', () {
       const String label = 'test group';
-      final List<String> extensions = <String>['txt', 'jpg'];
-      final List<String> mimeTypes = <String>['text/plain'];
-      final List<String> macUTIs = <String>['public.plain-text'];
-      final List<String> webWildCards = <String>['image/*'];
 
       final XTypeGroup group = XTypeGroup(
         label: label,
@@ -69,6 +70,24 @@ void main() {
       expect(mimeOnly.allowsAny, false);
       expect(utiOnly.allowsAny, false);
       expect(webOnly.allowsAny, false);
+    });
+
+    test('setUniformTypeIdentifiers overrides macUTIs', () {
+      final XTypeGroup group = XTypeGroup(
+        label: 'Any',
+      );
+
+      group.uniformTypeIdentifiers = macUTIs;
+
+      expect(group.uniformTypeIdentifiers, macUTIs);
+    });
+
+    test('getUniformTypeIdentifiers returns macUTIs', () {
+      final XTypeGroup group = XTypeGroup(
+        macUTIs: macUTIs,
+      );
+
+      expect(group.uniformTypeIdentifiers, macUTIs);
     });
 
     test('Leading dots are removed from extensions', () {


### PR DESCRIPTION
## Update file_selector_platform_interface by adding the new property 'uniformTypeIdentifiers' to the XTypeGroup.

- Update the main Readme file indicating when to use macUTIs or uniformTypeIdentifiers.
- Update the main example to use the proper properties for all the platforms.
- Update file_selector_platform_interface by adding the new property 'uniformTypeIdentifiers'.

*List which issues are fixed by this PR. You must list at least one issue.*
- [Rename XTypeGroup's macUTIs #103743](https://github.com/flutter/flutter/issues/103743)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
