### PR TITLE
[file_selector] Update file_selector_platform_interface by adding the new property 'uniformTypeIdentifiers' to the XTypeGroup.

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Adds the `uniformTypeIdentifiers` property to the `XTypeGroup` that relies on `macUTIs`. The last will be deprecated for future releases.
+
 ## 2.2.0
 
 * Makes `XTypeGroup`'s constructor constant.

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 
-* Adds the `uniformTypeIdentifiers` property to the `XTypeGroup` that relies on `macUTIs`. The last will be deprecated for future releases.
+* Replaces `macUTIs` with `uniformTypeIdentifiers`. `macUTIs` is available as an alias, but will be deprecated in a future release.
 
 ## 2.2.0
 

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -14,9 +14,13 @@ class XTypeGroup {
     this.label,
     List<String>? extensions,
     this.mimeTypes,
-    this.macUTIs,
+    List<String>? macUTIs,
+    List<String>? uniformTypeIdentifiers,
     this.webWildCards,
-  }) : _extensions = extensions;
+  })  : _extensions = extensions,
+        assert(uniformTypeIdentifiers == null || macUTIs == null,
+            'It is only allowed to specify either macUTIs or uniformTypeIdentifiers'),
+        uniformTypeIdentifiers = uniformTypeIdentifiers ?? macUTIs;
 
   /// The 'name' or reference to this group of types.
   final String? label;
@@ -24,8 +28,8 @@ class XTypeGroup {
   /// The MIME types for this group.
   final List<String>? mimeTypes;
 
-  /// The UTIs for this group.
-  final List<String>? macUTIs;
+  /// The uniform type identifiers for this group
+  final List<String>? uniformTypeIdentifiers;
 
   /// The web wild cards for this group (ex: image/*, video/*).
   final List<String>? webWildCards;
@@ -55,6 +59,9 @@ class XTypeGroup {
         (macUTIs?.isEmpty ?? true) &&
         (webWildCards?.isEmpty ?? true);
   }
+
+  /// Returns the list of uniform type identifiers for this group
+  List<String>? get macUTIs => uniformTypeIdentifiers;
 
   static List<String>? _removeLeadingDots(List<String>? exts) => exts
       ?.map((String ext) => ext.startsWith('.') ? ext.substring(1) : ext)

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -19,7 +19,7 @@ class XTypeGroup {
     this.webWildCards,
   })  : _extensions = extensions,
         assert(uniformTypeIdentifiers == null || macUTIs == null,
-            'It is only allowed to specify either macUTIs or uniformTypeIdentifiers'),
+            'Only one of uniformTypeIdentifiers or macUTIs can be non-null'),
         uniformTypeIdentifiers = uniformTypeIdentifiers ?? macUTIs;
 
   /// The 'name' or reference to this group of types.

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -8,12 +8,11 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('XTypeGroup', () {
     test('toJSON() creates correct map', () {
-      const String label = 'test group';
       const List<String> extensions = <String>['txt', 'jpg'];
       const List<String> mimeTypes = <String>['text/plain'];
       const List<String> macUTIs = <String>['public.plain-text'];
       const List<String> webWildCards = <String>['image/*'];
-
+      const String label = 'test group';
       const XTypeGroup group = XTypeGroup(
         label: label,
         extensions: extensions,
@@ -30,7 +29,7 @@ void main() {
       expect(jsonMap['webWildCards'], webWildCards);
     });
 
-    test('A wildcard group can be created', () {
+    test('a wildcard group can be created', () {
       const XTypeGroup group = XTypeGroup(
         label: 'Any',
       );
@@ -71,7 +70,68 @@ void main() {
       expect(webOnly.allowsAny, false);
     });
 
-    test('Leading dots are removed from extensions', () {
+    test('passing only macUTIs should fill uniformTypeIdentifiers', () {
+      const List<String> macUTIs = <String>['public.plain-text'];
+      const XTypeGroup group = XTypeGroup(
+        macUTIs: macUTIs,
+      );
+
+      expect(group.uniformTypeIdentifiers, macUTIs);
+    });
+
+    test('passing only macUTIs should fill macUTIs', () {
+      const List<String> macUTIs = <String>['public.plain-text'];
+      const XTypeGroup group = XTypeGroup(
+        macUTIs: macUTIs,
+      );
+
+      expect(group.macUTIs, macUTIs);
+    });
+
+    test(
+        'passing only uniformTypeIdentifiers should fill uniformTypeIdentifiers',
+        () {
+      const List<String> uniformTypeIdentifiers = <String>['public.plain-text'];
+      const XTypeGroup group = XTypeGroup(
+        uniformTypeIdentifiers: uniformTypeIdentifiers,
+      );
+
+      expect(group.uniformTypeIdentifiers, uniformTypeIdentifiers);
+    });
+
+    test('passing only uniformTypeIdentifiers should fill macUTIs', () {
+      const List<String> uniformTypeIdentifiers = <String>['public.plain-text'];
+      const XTypeGroup group = XTypeGroup(
+        uniformTypeIdentifiers: uniformTypeIdentifiers,
+      );
+
+      expect(group.macUTIs, uniformTypeIdentifiers);
+    });
+
+    test('passing uniformTypeIdentifiers and macUTIs should throw', () {
+      const List<String> macUTIs = <String>['public.plain-text'];
+      const List<String> uniformTypeIndentifiers = <String>[
+        'public.plain-images'
+      ];
+      expect(
+          () => XTypeGroup(
+              macUTIs: macUTIs,
+              uniformTypeIdentifiers: uniformTypeIndentifiers),
+          throwsA(predicate((Object? e) =>
+              e is AssertionError &&
+              e.message ==
+                  'It is only allowed to specify either macUTIs or uniformTypeIdentifiers')));
+    });
+
+    test(
+        'having uniformTypeIdentifiers and macUTIs as null should leave uniformTypeIdentifiers as null',
+        () {
+      const XTypeGroup group = XTypeGroup();
+
+      expect(group.uniformTypeIdentifiers, null);
+    });
+
+    test('leading dots are removed from extensions', () {
       const List<String> extensions = <String>['.txt', '.jpg'];
       const XTypeGroup group = XTypeGroup(extensions: extensions);
 

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -79,15 +79,6 @@ void main() {
       expect(group.uniformTypeIdentifiers, macUTIs);
     });
 
-    test('passing only macUTIs should fill macUTIs', () {
-      const List<String> macUTIs = <String>['public.plain-text'];
-      const XTypeGroup group = XTypeGroup(
-        macUTIs: macUTIs,
-      );
-
-      expect(group.macUTIs, macUTIs);
-    });
-
     test(
         'passing only uniformTypeIdentifiers should fill uniformTypeIdentifiers',
         () {
@@ -99,7 +90,16 @@ void main() {
       expect(group.uniformTypeIdentifiers, uniformTypeIdentifiers);
     });
 
-    test('passing only uniformTypeIdentifiers should fill macUTIs', () {
+    test('macUTIs getter return macUTIs value passed in constructor', () {
+      const List<String> macUTIs = <String>['public.plain-text'];
+      const XTypeGroup group = XTypeGroup(
+        macUTIs: macUTIs,
+      );
+
+      expect(group.macUTIs, macUTIs);
+    });
+
+    test('macUTIs getter returns uniformTypeIdentifiers value passed in constructor', () {
       const List<String> uniformTypeIdentifiers = <String>['public.plain-text'];
       const XTypeGroup group = XTypeGroup(
         uniformTypeIdentifiers: uniformTypeIdentifiers,
@@ -108,7 +108,7 @@ void main() {
       expect(group.macUTIs, uniformTypeIdentifiers);
     });
 
-    test('passing uniformTypeIdentifiers and macUTIs should throw', () {
+    test('passing both uniformTypeIdentifiers and macUTIs should throw', () {
       const List<String> macUTIs = <String>['public.plain-text'];
       const List<String> uniformTypeIndentifiers = <String>[
         'public.plain-images'

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -99,7 +99,9 @@ void main() {
       expect(group.macUTIs, macUTIs);
     });
 
-    test('macUTIs getter returns uniformTypeIdentifiers value passed in constructor', () {
+    test(
+        'macUTIs getter returns uniformTypeIdentifiers value passed in constructor',
+        () {
       const List<String> uniformTypeIdentifiers = <String>['public.plain-text'];
       const XTypeGroup group = XTypeGroup(
         uniformTypeIdentifiers: uniformTypeIdentifiers,
@@ -120,7 +122,7 @@ void main() {
           throwsA(predicate((Object? e) =>
               e is AssertionError &&
               e.message ==
-                  'It is only allowed to specify either macUTIs or uniformTypeIdentifiers')));
+                  'Only one of uniformTypeIdentifiers or macUTIs can be non-null')));
     });
 
     test(


### PR DESCRIPTION
## Update file_selector_platform_interface by adding the new property 'uniformTypeIdentifiers' to the XTypeGroup.

- Update file_selector_platform_interface by adding the new property 'uniformTypeIdentifiers'.

*List which issues are fixed by this PR. You must list at least one issue.*
- [Rename XTypeGroup's macUTIs #103743](https://github.com/flutter/flutter/issues/103743)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
