### PR TITLE
[ci] Switch iOS platform tests to ARM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -336,7 +336,7 @@ task:
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       create_simulator_script:
         - xcrun simctl list
-        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-15-0 | xargs xcrun simctl boot
+        - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.iOS-16-0 | xargs xcrun simctl boot
       build_script:
         - ./script/tool_runner.sh build-examples --ios
       xcode_analyze_script:
@@ -385,7 +385,7 @@ task:
       script:
         - ./script/tool_runner.sh podspecs
     ### iOS tasks ###
-    # ios-platform_tests builds all the plugins on M1, so this build is run
+    # ios-platform_tests builds all the plugins on ARM, so this build is run
     # on Intel to give us build coverage of both host types.
     - name: ios-build_all_plugins
       env:
@@ -395,7 +395,7 @@ task:
           CHANNEL: "stable"
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
     ### macOS desktop tasks ###
-    # macos-platform_tests builds all the plugins on M1, so this build is run
+    # macos-platform_tests builds all the plugins on ARM, so this build is run
     # on Intel to give us build coverage of both host types.
     - name: macos-build_all_plugins
       env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -195,7 +195,6 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       setup_script:
-        - flutter config --enable-linux-desktop
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
     - name: linux-platform_tests
       # Don't run full platform tests on both channels in pre-submit.
@@ -205,7 +204,6 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       build_script:
-        - flutter config --enable-linux-desktop
         - ./script/tool_runner.sh build-examples --linux
       native_test_script:
         - xvfb-run ./script/tool_runner.sh native-test --linux --no-integration
@@ -322,51 +320,6 @@ task:
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
     ### iOS tasks ###
-    - name: ios-build_all_plugins
-      env:
-        BUILD_ALL_ARGS: "ios --no-codesign"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
-    ### macOS desktop tasks ###
-    - name: macos-platform_tests
-      # Don't run full platform tests on both channels in pre-submit.
-      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
-      env:
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-        PATH: $PATH:/usr/local/bin
-      build_script:
-        - flutter config --enable-macos-desktop
-        - ./script/tool_runner.sh build-examples --macos
-      xcode_analyze_script:
-        - ./script/tool_runner.sh xcode-analyze --macos
-      xcode_analyze_deprecation_script:
-        # Ensure we don't accidentally introduce deprecated code.
-        - ./script/tool_runner.sh xcode-analyze --macos --macos-min-version=12.3
-      native_test_script:
-        - ./script/tool_runner.sh native-test --macos
-      drive_script:
-        - ./script/tool_runner.sh drive-examples --macos --exclude=script/configs/exclude_integration_macos.yaml
-
-# Intel macOS tasks.
-task:
-  << : *MACOS_INTEL_TEMPLATE
-  << : *FLUTTER_UPGRADE_TEMPLATE
-  matrix:
-    ### iOS+macOS tasks ***
-    # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
-    # support. `pod lint` makes a synthetic target that doesn't respect the
-    # pod's arch exclusions, so fails to build.
-    - name: darwin-lint_podspecs
-      script:
-        - ./script/tool_runner.sh podspecs
-    ### iOS tasks ###
-    # TODO(stuartmorgan): Swap this and ios-build_all_plugins once simulator
-    # tests are reliable on the ARM infrastructure. See discussion at
-    # https://github.com/flutter/plugins/pull/5693#issuecomment-1126011089
     - name: ios-platform_tests
       # Don't run full platform tests on both channels in pre-submit.
       skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
@@ -399,6 +352,49 @@ task:
         # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
         - ./script/tool_runner.sh drive-examples --ios --exclude=script/configs/exclude_integration_ios.yaml
     ### macOS desktop tasks ###
+    - name: macos-platform_tests
+      # Don't run full platform tests on both channels in pre-submit.
+      skip: $CIRRUS_PR != '' && $CHANNEL == 'stable'
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+        PATH: $PATH:/usr/local/bin
+      build_script:
+        - ./script/tool_runner.sh build-examples --macos
+      xcode_analyze_script:
+        - ./script/tool_runner.sh xcode-analyze --macos
+      xcode_analyze_deprecation_script:
+        # Ensure we don't accidentally introduce deprecated code.
+        - ./script/tool_runner.sh xcode-analyze --macos --macos-min-version=12.3
+      native_test_script:
+        - ./script/tool_runner.sh native-test --macos
+      drive_script:
+        - ./script/tool_runner.sh drive-examples --macos --exclude=script/configs/exclude_integration_macos.yaml
+
+# Intel macOS tasks.
+task:
+  << : *MACOS_INTEL_TEMPLATE
+  << : *FLUTTER_UPGRADE_TEMPLATE
+  matrix:
+    ### iOS+macOS tasks ***
+    # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
+    # support. `pod lint` makes a synthetic target that doesn't respect the
+    # pod's arch exclusions, so fails to build.
+    - name: darwin-lint_podspecs
+      script:
+        - ./script/tool_runner.sh podspecs
+    ### iOS tasks ###
+    # ios-platform_tests builds all the plugins on M1, so this build is run
+    # on Intel to give us build coverage of both host types.
+    - name: ios-build_all_plugins
+      env:
+        BUILD_ALL_ARGS: "ios --no-codesign"
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      << : *BUILD_ALL_PLUGINS_APP_TEMPLATE
+    ### macOS desktop tasks ###
     # macos-platform_tests builds all the plugins on M1, so this build is run
     # on Intel to give us build coverage of both host types.
     - name: macos-build_all_plugins
@@ -408,5 +404,4 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       setup_script:
-        - flutter config --enable-macos-desktop
       << : *BUILD_ALL_PLUGINS_APP_TEMPLATE


### PR DESCRIPTION
Now that the image is using Ventura, the simulator hang issue that prevented switching these tests previously should be resolved. Updates to iOS 16 simulators, since the ARM image apparently doesn't have iOS 15.

Also does some minor opportunistic cleanup, removing `--enable-*-desktop` flags that are no longer necessary since all desktop platform are enabled by default on stable now.