### PR TITLE
[video_player]fix ios 16 bug where encrypted video stream is not showing

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.3.6
 
+* Fixes a bug in iOS 16 where videos from protected live streams are not shown. 
 * Updates minimum Flutter version to 2.10.
 * Fixes violations of new analysis option use_named_constants.
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -92,10 +92,9 @@
 
     UIImage *image = screenshot.image;
     [frames addObject:UIImagePNGRepresentation(image)];
-    // Take random interval between [1, 2) seconds, since the video length could be the same as a
-    // fixed interval, which would always result in the same frame.
-    NSTimeInterval sampleInterval = 1 + ((double)arc4random() / UINT32_MAX);
-    [NSThread sleepForTimeInterval:sampleInterval];
+    // The sample interval must NOT be the same as video length.
+    // Otherwise it would always result in the same frame.
+    [NSThread sleepForTimeInterval:1];
   }
 
   // At least 1 loading and 2 distinct frames (3 in total) to validate that the video is playing.

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -85,7 +85,10 @@
   for (int i = 0; i < numberOfFrames; i++) {
     UIImage *image = self.app.screenshot.image;
     [frames addObject:UIImagePNGRepresentation(image)];
-    [NSThread sleepForTimeInterval:1];
+    // Take random interval between [1, 2) seconds, since the video length could be the same as a
+    // fixed interval, which would always result in the same frame.
+    NSTimeInterval sampleInterval = 1 + ((double)arc4random() / UINT32_MAX);
+    [NSThread sleepForTimeInterval:sampleInterval];
   }
 
   // At least 1 loading and 2 distinct frames (3 in total) to validate that the video is playing.

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -77,10 +77,12 @@
   XCTAssertTrue([selectedTab waitForExistenceWithTimeout:30.0]);
   XCTAssertTrue(selectedTab.isSelected);
 
+  // Wait until the video is loaded.
+  [NSThread sleepForTimeInterval:60];
+
   NSMutableSet *frames = [NSMutableSet set];
   int numberOfFrames = 5;
   for (int i = 0; i < numberOfFrames; i++) {
-    NSLog(@"Snapshotting frame %d", i);
     UIImage *image = self.app.screenshot.image;
     [frames addObject:UIImagePNGRepresentation(image)];
     [NSThread sleepForTimeInterval:1];

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -81,7 +81,7 @@
   [NSThread sleepForTimeInterval:60];
 
   NSMutableSet *frames = [NSMutableSet set];
-  int numberOfFrames = 5;
+  int numberOfFrames = 60;
   for (int i = 0; i < numberOfFrames; i++) {
     UIImage *image = self.app.screenshot.image;
     [frames addObject:UIImagePNGRepresentation(image)];

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -46,7 +46,7 @@
   XCTAssertTrue(foundPlaybackSpeed5x);
 
   // Cycle through tabs.
-  for (NSString *tabName in @[ @"Asset", @"Remote" ]) {
+  for (NSString *tabName in @[ @"Asset mp4", @"Remote mp4" ]) {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH %@", tabName];
     XCUIElement *unselectedTab = [app.staticTexts elementMatchingPredicate:predicate];
     XCTAssertTrue([unselectedTab waitForExistenceWithTimeout:30.0]);
@@ -58,6 +58,36 @@
     XCTAssertTrue([selectedTab waitForExistenceWithTimeout:30.0]);
     XCTAssertTrue(selectedTab.isSelected);
   }
+}
+
+- (void)testEncryptedVideoStream {
+  // This is to fix a bug (https://github.com/flutter/flutter/issues/111457) in iOS 16 with blank
+  // video for encrypted video streams.
+
+  NSString *tabName = @"Remote enc m3u8";
+
+  NSPredicate *predicate = [NSPredicate predicateWithFormat:@"label BEGINSWITH %@", tabName];
+  XCUIElement *unselectedTab = [self.app.staticTexts elementMatchingPredicate:predicate];
+  XCTAssertTrue([unselectedTab waitForExistenceWithTimeout:30.0]);
+  XCTAssertFalse(unselectedTab.isSelected);
+  [unselectedTab tap];
+
+  XCUIElement *selectedTab = [self.app.otherElements
+      elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label BEGINSWITH %@", tabName]];
+  XCTAssertTrue([selectedTab waitForExistenceWithTimeout:30.0]);
+  XCTAssertTrue(selectedTab.isSelected);
+
+  NSMutableSet *frames = [NSMutableSet set];
+  int numberOfFrames = 5;
+  for (int i = 0; i < numberOfFrames; i++) {
+    NSLog(@"Snapshotting frame %d", i);
+    UIImage *image = self.app.screenshot.image;
+    [frames addObject:UIImagePNGRepresentation(image)];
+    [NSThread sleepForTimeInterval:1];
+  }
+
+  // At least 1 loading and 2 distinct frames (3 in total) to validate that the video is playing.
+  XCTAssert(frames.count >= 3, @"Must have at least 3 distinct frames.");
 }
 
 @end

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerUITests/VideoPlayerUITests.m
@@ -83,7 +83,14 @@
   NSMutableSet *frames = [NSMutableSet set];
   int numberOfFrames = 60;
   for (int i = 0; i < numberOfFrames; i++) {
-    UIImage *image = self.app.screenshot.image;
+    XCUIScreenshot *screenshot = self.app.screenshot;
+
+    // Attach the screenshots for debugging if the test fails.
+    XCTAttachment *attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
+    attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:attachment];
+
+    UIImage *image = screenshot.image;
     [frames addObject:UIImagePNGRepresentation(image)];
     // Take random interval between [1, 2) seconds, since the video length could be the same as a
     // fixed interval, which would always result in the same frame.

--- a/packages/video_player/video_player_avfoundation/example/lib/main.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/main.dart
@@ -206,9 +206,7 @@ class _BumbleBeeEncryptedLiveStreamState
                     aspectRatio: _controller.value.aspectRatio,
                     child: VideoPlayer(_controller),
                   )
-                : Container(
-                    child: const Text('loading...'),
-                  ),
+                : const Text('loading...'),
           ),
         ],
       ),

--- a/packages/video_player/video_player_avfoundation/example/lib/main.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/main.dart
@@ -20,7 +20,7 @@ class _App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         key: const ValueKey<String>('home_page'),
         appBar: AppBar(
@@ -30,15 +30,20 @@ class _App extends StatelessWidget {
             tabs: <Widget>[
               Tab(
                 icon: Icon(Icons.cloud),
-                text: 'Remote',
+                text: 'Remote mp4',
               ),
-              Tab(icon: Icon(Icons.insert_drive_file), text: 'Asset'),
+              Tab(
+                icon: Icon(Icons.favorite),
+                text: 'Remote enc m3u8',
+              ),
+              Tab(icon: Icon(Icons.insert_drive_file), text: 'Asset mp4'),
             ],
           ),
         ),
         body: TabBarView(
           children: <Widget>[
             _BumbleBeeRemoteVideo(),
+            _BumbleBeeEncryptedLiveStream(),
             _ButterFlyAssetVideo(),
           ],
         ),
@@ -149,6 +154,61 @@ class _BumbleBeeRemoteVideoState extends State<_BumbleBeeRemoteVideo> {
                 ],
               ),
             ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _BumbleBeeEncryptedLiveStream extends StatefulWidget {
+  @override
+  _BumbleBeeEncryptedLiveStreamState createState() =>
+      _BumbleBeeEncryptedLiveStreamState();
+}
+
+class _BumbleBeeEncryptedLiveStreamState
+    extends State<_BumbleBeeEncryptedLiveStream> {
+  late MiniController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = MiniController.network(
+      'https://flutter.github.io/assets-for-api-docs/assets/videos/hls/encrypted_bee.m3u8',
+    );
+
+    _controller.addListener(() {
+      setState(() {});
+    });
+    _controller.initialize();
+
+    _controller.play();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          Container(padding: const EdgeInsets.only(top: 20.0)),
+          const Text('With remote encrypted m3u8'),
+          Container(
+            padding: const EdgeInsets.all(20),
+            child: _controller.value.isInitialized
+                ? AspectRatio(
+                    aspectRatio: _controller.value.aspectRatio,
+                    child: VideoPlayer(_controller),
+                  )
+                : Container(
+                    child: const Text('loading...'),
+                  ),
           ),
         ],
       ),

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.5
+version: 2.3.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
## The issue

`copyPixelBufferForItemTime` always return nil (`hasNewPixelBufferForItemTime` returning false) on iOS 16 for encrypted video stream. 

## Research

There aren't too much info online. It seems to be **by design that only Apple's `AVPlayerLayer` can access those encrypted video stream** on iOS 16. 

For example, [this unresolved issue](https://stackoverflow.com/questions/42839831/fairplay-streaming-calling-copypixelbufferforitemtime-on-avplayeritemvideooutpu) (5 years ago, but could be the same issue under different format): 

> the only way to display your protected video content is by using an AVPlayerLayer

Another hint is that iOS 16 introduced a new API [`AVPlayerLayer::copyDisplayedPixelBuffer`](https://developer.apple.com/documentation/avfoundation/avplayerlayer/4042647-copydisplayedpixelbuffer?language=objc) with a note: 

> It also returns nil when displaying protected content

## Reverse engineering

I almost concluded that there's no way to solve it. But i was wondering "how did Apple solve it in `AVPlayerLayer`"? It must have accessed some private APIs. Something like this: 

```
    if player.videoStream.someMetaData.isProtected {
      player.videoStream._unlockProtectedContent() // a hypothetical private API
    }
```

If I *were* to design AVFoundation, I would probably make it a layered structure, so that the "unlocked" pixel buffers can be piped downstream. This mean that "unlocking" probably happens towards the upstream, hence all outputs (including ours!) can be granted the access. Something like this:  

```mermaid
graph TD;
  A[upstream input]-->B[...];
  B-->C[_unlock, hypothetical private API used by AVPlayerLayer];
  C-->D[...];
  D-->E[...]
  E-->F[output 1];
  E-->G[output 2];
  E-->H[output used by AVPlayerLayer];
  E-->I[output used by us];
```

To verify this hypothesis, I created a dummy `AVPlayerLayer` (without adding it to screen), hoping that the hypothetical unlocking happens in the constructor. The result is that **only first video frame is displayed, and all other frames are still not accessible**. 

This tells 3 things: 
1. The above layered structure is likely what Apple is doing 
2. The hypothetical unlocking did happen in the constructor, but only for the first frame. 
3. The "unlocking" process is likely for each specific frame, and not the whole stream

Now based on all the above info, this is what I *guess* Apple's implementation of AVPlayerLayer is: 

```
class AVPlayerLayer { 
  // `init` only unlocks the first frame 
  init(player: AVPlayer) {
    player.videoStream.firstFrame()._unlockFrame() // hypothetical private API
  }

  // each subsequent frame is unlocked separately
  func renderNextFrame() { 
    player.videoStream.frameAtCurrentTime()._unlockFrame() // hypothetical private API

    // now these pixel buffers become accessible
    let pixelBuffer = ... 
    paintOnCanvas(pixelBuffer)
  }
}
```

So in conclusion, **all we need to do is to have a dummy AVPlayerLayer to concurrently play the video**, which should invoke this hypothetical `renderNextFrame()` function, and eventually unlock every single frame for us. 

And it worked :)

## Future

It is pretty obvious that Apple's intention is to only allow `AVPlayerLayer` to access those pixel buffers from iOS 16 onwards. 

To follow this spirit, we should probably rely on platform views with `AVPlayerLayer` attached. This would be a huge change from the current implementation though (CC: @stuartmorgan)

## Other notes

### Can we only enable this workaround only for encrypted files

It is hard to tell if a video stream is encrypted or not. For example, [the second answer in this question](https://stackoverflow.com/questions/42839831/fairplay-streaming-calling-copypixelbufferforitemtime-on-avplayeritemvideooutpu). 

### Can we only enable this for m3u8 files? 

File extensions may not be reliable, and it is not realistic to dig into the m3u8 specs and inspect the metadata. 

### Performance impact? 

Very minimal impact since the layer is not rendered on screen. [Screenshots here](https://github.com/flutter/flutter/issues/111457#issuecomment-1249868173). 

### About tests

The current unit test isn't the best since it validates implementation instead of behavior. A better unit test is to validate that `copyPixelBuffer` actually returns the frames. But this requires setting up the video player properly with encrypted video file and then play the video. Unfortunately I am not too familiar with how this plugin works and how apple's API works yet. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes https://github.com/flutter/flutter/issues/111457


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
