### PR TITLE
[webview_flutter] Adds type definitions for common callback signatures in the navigation delegate

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.4
+
+* Exposes type definitions for commonly used function signatures in the `PlatformNavigationDelegate` class.
+
 ## 1.9.3
 
 * Updates minimum Flutter version to 2.10.

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.9.4
-
-* Exposes type definitions for commonly used function signatures in the `PlatformNavigationDelegate` class.
-
 ## 1.9.3
 
 * Updates minimum Flutter version to 2.10.

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/platform_navigation_delegate.dart
@@ -9,6 +9,19 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'webview_platform.dart';
 
+/// Signature for callbacks that report a pending navigation request.
+typedef NavigationRequestCallback = FutureOr<NavigationDecision> Function(
+    NavigationRequest navigationRequest);
+
+/// Signature for callbacks that report page events triggered by the native web view.
+typedef PageEventCallback = void Function(String url);
+
+/// Signature for callbacks that report loading progress of a page.
+typedef ProgressCallback = void Function(int progress);
+
+/// Signature for callbacks that report a resource loading error.
+typedef WebResourceErrorCallback = void Function(WebResourceError error);
+
 /// An interface defining navigation events that occur on the native platform.
 ///
 /// The [PlatformWebViewController] is notifying this delegate on events that
@@ -40,8 +53,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnNavigationRequest(
-    FutureOr<bool> Function({required String url, required bool isForMainFrame})
-        onNavigationRequest,
+    NavigationRequestCallback onNavigationRequest,
   ) {
     throw UnimplementedError(
         'setOnNavigationRequest is not implemented on the current platform.');
@@ -51,7 +63,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnPageStarted(
-    void Function(String url) onPageStarted,
+    PageEventCallback onPageStarted,
   ) {
     throw UnimplementedError(
         'setOnPageStarted is not implemented on the current platform.');
@@ -61,7 +73,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnPageFinished(
-    void Function(String url) onPageFinished,
+    PageEventCallback onPageFinished,
   ) {
     throw UnimplementedError(
         'setOnPageFinished is not implemented on the current platform.');
@@ -71,7 +83,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnProgress(
-    void Function(int progress) onProgress,
+    ProgressCallback onProgress,
   ) {
     throw UnimplementedError(
         'setOnProgress is not implemented on the current platform.');
@@ -81,7 +93,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   ///
   /// See [PlatformWebViewController.setPlatformNavigationDelegate].
   Future<void> setOnWebResourceError(
-    void Function(WebResourceError error) onWebResourceError,
+    WebResourceErrorCallback onWebResourceError,
   ) {
     throw UnimplementedError(
         'setOnWebResourceError is not implemented on the current platform.');

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/navigation_decision.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/navigation_decision.dart
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// A decision on how to handle a navigation request.
+enum NavigationDecision {
+  /// Prevent the navigation from taking place.
+  prevent,
+
+  /// Allow the navigation to take place.
+  navigate,
+}

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/navigation_request.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/navigation_request.dart
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Defines the parameters of the pending navigation callback.
+class NavigationRequest {
+  /// Creates a [NavigationRequest].
+  const NavigationRequest({
+    required this.url,
+    required this.isMainFrame,
+  });
+
+  /// The URL of the pending navigation request.
+  final String url;
+
+  /// Indicates whether the request was made in the web site's main frame or a subframe.
+  final bool isMainFrame;
+}

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/types.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/v4/src/types/types.dart
@@ -5,6 +5,8 @@
 export 'javascript_message.dart';
 export 'javascript_mode.dart';
 export 'load_request_params.dart';
+export 'navigation_decision.dart';
+export 'navigation_request.dart';
 export 'platform_navigation_delegate_creation_params.dart';
 export 'platform_webview_controller_creation_params.dart';
 export 'platform_webview_cookie_manager_creation_params.dart';

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutte
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.9.3
+version: 1.9.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutte
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.9.4
+version: 1.9.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -5,6 +5,7 @@ issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 version: 1.9.3
+publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_navigation_delegate_test.dart
@@ -61,7 +61,7 @@ void main() {
 
     expect(
       () => callbackDelegate.setOnNavigationRequest(
-          ({required bool isForMainFrame, required String url}) => true),
+          (NavigationRequest navigationRequest) => NavigationDecision.navigate),
       throwsUnimplementedError,
     );
   });

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/src/v4/platform_webview_controller_test.mocks.dart
@@ -38,31 +38,30 @@ class MockPlatformNavigationDelegate extends _i1.Mock
           as _i2.PlatformNavigationDelegateCreationParams);
   @override
   _i4.Future<void> setOnNavigationRequest(
-          _i4.FutureOr<bool> Function({bool isForMainFrame, String url})?
-              onNavigationRequest) =>
+          _i3.NavigationRequestCallback? onNavigationRequest) =>
       (super.noSuchMethod(
           Invocation.method(#setOnNavigationRequest, [onNavigationRequest]),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> setOnPageStarted(void Function(String)? onPageStarted) =>
+  _i4.Future<void> setOnPageStarted(_i3.PageEventCallback? onPageStarted) =>
       (super.noSuchMethod(Invocation.method(#setOnPageStarted, [onPageStarted]),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> setOnPageFinished(void Function(String)? onPageFinished) =>
+  _i4.Future<void> setOnPageFinished(_i3.PageEventCallback? onPageFinished) =>
       (super.noSuchMethod(
           Invocation.method(#setOnPageFinished, [onPageFinished]),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
-  _i4.Future<void> setOnProgress(void Function(int)? onProgress) =>
+  _i4.Future<void> setOnProgress(_i3.ProgressCallback? onProgress) =>
       (super.noSuchMethod(Invocation.method(#setOnProgress, [onProgress]),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
   _i4.Future<void> setOnWebResourceError(
-          void Function(_i2.WebResourceError)? onWebResourceError) =>
+          _i3.WebResourceErrorCallback? onWebResourceError) =>
       (super.noSuchMethod(
           Invocation.method(#setOnWebResourceError, [onWebResourceError]),
           returnValue: Future<void>.value(),

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -3,6 +3,7 @@ description: A Flutter plugin that provides a WebView widget based on Apple's WK
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_wkwebview
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
 version: 2.9.4
+publish_to: none
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
@@ -19,12 +20,8 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
-  # TODO: Remove. Do not merge.
   webview_flutter_platform_interface:
-    git:
-      url: git@github.com:Baseflow/plugins.git
-      ref: issue/94051_navigation_delegate_typedefs
-      path: packages/webview_flutter/webview_flutter_platform_interface
+    path: ../webview_flutter_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_wkwebview/pubspec.yaml
@@ -19,7 +19,12 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
-  webview_flutter_platform_interface: ^1.9.3
+  # TODO: Remove. Do not merge.
+  webview_flutter_platform_interface:
+    git:
+      url: git@github.com:Baseflow/plugins.git
+      ref: issue/94051_navigation_delegate_typedefs
+      path: packages/webview_flutter/webview_flutter_platform_interface
 
 dev_dependencies:
   build_runner: ^2.1.5

--- a/packages/webview_flutter/webview_flutter_wkwebview/test/v4/webkit_navigation_delegate_test.dart
+++ b/packages/webview_flutter/webview_flutter_wkwebview/test/v4/webkit_navigation_delegate_test.dart
@@ -159,15 +159,11 @@ void main() {
         ),
       );
 
-      late final String callbackUrl;
-      late final bool callbackIsMainFrame;
-      FutureOr<bool> onNavigationRequest({
-        required String url,
-        required bool isForMainFrame,
-      }) {
-        callbackUrl = url;
-        callbackIsMainFrame = isForMainFrame;
-        return true;
+      late final NavigationRequest callbackRequest;
+      FutureOr<NavigationDecision> onNavigationRequest(
+          NavigationRequest request) {
+        callbackRequest = request;
+        return NavigationDecision.navigate;
       }
 
       webKitDelgate.setOnNavigationRequest(onNavigationRequest);
@@ -184,8 +180,8 @@ void main() {
         completion(WKNavigationActionPolicy.allow),
       );
 
-      expect(callbackUrl, 'https://www.google.com');
-      expect(callbackIsMainFrame, isFalse);
+      expect(callbackRequest.url, 'https://www.google.com');
+      expect(callbackRequest.isMainFrame, isFalse);
     });
   });
 }


### PR DESCRIPTION
Replacement of https://github.com/flutter/plugins/pull/6430 and https://github.com/flutter/plugins/pull/6441.

From https://github.com/flutter/plugins/pull/6430: 
> While working on the Android implementation of the v4 webview_flutter platform interface I had to duplicate the function signatures used in the [PlatformNavigationDelegate] several times. I realized that if I had to duplicate them, it is likely developers consuming the interface probably also had to manually duplicate these method  signatures.  

> To reduce code duplication and make the API easier for consumers to use I decided to create and expose these type definitions.

Part of https://github.com/flutter/flutter/issues/94051

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
