### PR TITLE
[file_selector] Annotate all creation of XTypeGroup with // ignore: prefer_const_constructor

### DIFF
--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.9.0+1
 
+* Add `// ignore: prefer_const_constructors` to avoid future errors when converting the `XTypeGroup`s constructor to const.
 * Updates minimum Flutter version to 2.10.
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.
 

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_web
 description: Web platform implementation of file_selector
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0
+version: 0.9.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_web/test/utils_test.dart
+++ b/packages/file_selector/file_selector_web/test/utils_test.dart
@@ -11,8 +11,11 @@ void main() {
     group('acceptedTypesToString', () {
       test('works', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'images', webWildCards: <String>['images/*']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'jpgs', extensions: <String>['jpg', 'jpeg']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
@@ -27,7 +30,9 @@ void main() {
 
       test('works with extensions', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'jpgs', extensions: <String>['jpeg', 'jpg']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'pngs', extensions: <String>['png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
@@ -36,8 +41,10 @@ void main() {
 
       test('works with mime types', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
+          // ignore: prefer_const_constructors
           XTypeGroup(
               label: 'jpgs', mimeTypes: <String>['image/jpeg', 'image/jpg']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
@@ -46,8 +53,11 @@ void main() {
 
       test('works with web wild cards', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'images', webWildCards: <String>['image/*']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'audios', webWildCards: <String>['audio/*']),
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'videos', webWildCards: <String>['video/*']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
@@ -56,6 +66,7 @@ void main() {
 
       test('throws for a type group that does not support web', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
+          // ignore: prefer_const_constructors
           XTypeGroup(label: 'text', macUTIs: <String>['public.text']),
         ];
         expect(() => acceptedTypesToString(acceptedTypes), throwsArgumentError);


### PR DESCRIPTION
Annotate all creation of XTypeGroup with // ignore: prefer_const_constructor to prepare this implementation for the const constructor of XTypeGroup.

[#111906 [file_selector] `XTypeGroup` should be immutable](https://github.com/flutter/flutter/issues/111906)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
