### PR TITLE
[file_selector] Convert XTypeGroup to const

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.1.1
+## 2.2.0
 
 * Updates imports for `prefer_relative_imports`.
 * Updates minimum Flutter version to 2.10.

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 2.2.0
 
-* Updates imports for `prefer_relative_imports`.
+* Makes `XTypeGroup`'s constructor constant.
+
+## 2.1.1
+
+* Updates imports for prefer_relative_imports.
 * Updates minimum Flutter version to 2.10.
 
 ## 2.1.0

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.1.1
 
-* Updates imports for prefer_relative_imports.
+* Updates imports for `prefer_relative_imports`.
 * Updates minimum Flutter version to 2.10.
 
 ## 2.1.0

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -1,9 +1,9 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart' show immutable;
 
-/// A set of allowed XTypes
+/// A set of allowed XTypes.
 @immutable
 class XTypeGroup {
   /// Creates a new group with the given label and file extensions.
@@ -18,26 +18,26 @@ class XTypeGroup {
     this.webWildCards,
   }) : _extensions = extensions;
 
-  /// The 'name' or reference to this group of types
+  /// The 'name' or reference to this group of types.
   final String? label;
 
-  /// The MIME types for this group
+  /// The MIME types for this group.
   final List<String>? mimeTypes;
 
-  /// The UTIs for this group
+  /// The UTIs for this group.
   final List<String>? macUTIs;
 
-  /// The web wild cards for this group (ex: image/*, video/*)
+  /// The web wild cards for this group (ex: image/*, video/*).
   final List<String>? webWildCards;
 
   final List<String>? _extensions;
 
-  /// The extensions for this group
+  /// The extensions for this group.
   List<String>? get extensions {
     return _removeLeadingDots(_extensions);
   }
 
-  /// Converts this object into a JSON formatted object
+  /// Converts this object into a JSON formatted object.
   Map<String, dynamic> toJSON() {
     return <String, dynamic>{
       'label': label,

--- a/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/types/x_type_group/x_type_group.dart
@@ -1,26 +1,25 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:meta/meta.dart';
 
 /// A set of allowed XTypes
+@immutable
 class XTypeGroup {
   /// Creates a new group with the given label and file extensions.
   ///
   /// A group with none of the type options provided indicates that any type is
   /// allowed.
-  XTypeGroup({
+  const XTypeGroup({
     this.label,
     List<String>? extensions,
     this.mimeTypes,
     this.macUTIs,
     this.webWildCards,
-  }) : extensions = _removeLeadingDots(extensions);
+  }) : _extensions = extensions;
 
   /// The 'name' or reference to this group of types
   final String? label;
-
-  /// The extensions for this group
-  final List<String>? extensions;
 
   /// The MIME types for this group
   final List<String>? mimeTypes;
@@ -30,6 +29,13 @@ class XTypeGroup {
 
   /// The web wild cards for this group (ex: image/*, video/*)
   final List<String>? webWildCards;
+
+  final List<String>? _extensions;
+
+  /// The extensions for this group
+  List<String>? get extensions {
+    return _removeLeadingDots(_extensions);
+  }
 
   /// Converts this object into a JSON formatted object
   Map<String, dynamic> toJSON() {

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.1.1
+version: 2.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -26,14 +26,14 @@ void main() {
 
     group('#openFile', () {
       test('passes the accepted type groups correctly', () async {
-        final XTypeGroup group = XTypeGroup(
+        const XTypeGroup group = XTypeGroup(
           label: 'text',
           extensions: <String>['txt'],
           mimeTypes: <String>['text/plain'],
           macUTIs: <String>['public.text'],
         );
 
-        final XTypeGroup groupTwo = XTypeGroup(
+        const XTypeGroup groupTwo = XTypeGroup(
             label: 'image',
             extensions: <String>['jpg'],
             mimeTypes: <String>['image/jpg'],
@@ -91,14 +91,14 @@ void main() {
     });
     group('#openFiles', () {
       test('passes the accepted type groups correctly', () async {
-        final XTypeGroup group = XTypeGroup(
+        const XTypeGroup group = XTypeGroup(
           label: 'text',
           extensions: <String>['txt'],
           mimeTypes: <String>['text/plain'],
           macUTIs: <String>['public.text'],
         );
 
-        final XTypeGroup groupTwo = XTypeGroup(
+        const XTypeGroup groupTwo = XTypeGroup(
             label: 'image',
             extensions: <String>['jpg'],
             mimeTypes: <String>['image/jpg'],
@@ -157,14 +157,14 @@ void main() {
 
     group('#getSavePath', () {
       test('passes the accepted type groups correctly', () async {
-        final XTypeGroup group = XTypeGroup(
+        const XTypeGroup group = XTypeGroup(
           label: 'text',
           extensions: <String>['txt'],
           mimeTypes: <String>['text/plain'],
           macUTIs: <String>['public.text'],
         );
 
-        final XTypeGroup groupTwo = XTypeGroup(
+        const XTypeGroup groupTwo = XTypeGroup(
             label: 'image',
             extensions: <String>['jpg'],
             mimeTypes: <String>['image/jpg'],

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -31,7 +31,7 @@ void main() {
     });
 
     test('A wildcard group can be created', () {
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'Any',
       );
 
@@ -44,7 +44,7 @@ void main() {
     });
 
     test('allowsAny treats empty arrays the same as null', () {
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'Any',
         extensions: <String>[],
         mimeTypes: <String>[],
@@ -56,13 +56,13 @@ void main() {
     });
 
     test('allowsAny returns false if anything is set', () {
-      final XTypeGroup extensionOnly =
+      const XTypeGroup extensionOnly =
           XTypeGroup(label: 'extensions', extensions: <String>['txt']);
-      final XTypeGroup mimeOnly =
+      const XTypeGroup mimeOnly =
           XTypeGroup(label: 'mime', mimeTypes: <String>['text/plain']);
-      final XTypeGroup utiOnly =
+      const XTypeGroup utiOnly =
           XTypeGroup(label: 'utis', macUTIs: <String>['public.text']);
-      final XTypeGroup webOnly =
+      const XTypeGroup webOnly =
           XTypeGroup(label: 'web', webWildCards: <String>['.txt']);
 
       expect(extensionOnly.allowsAny, false);


### PR DESCRIPTION
Within the file_selector_platform_interface, XTypeGroup constructor was converted to `const`, meaning that from now on, this object needs to be constructed using `const`.

Issue:
[#111906 [file_selector] `XTypeGroup` should be immutable](https://github.com/flutter/flutter/issues/111906)

Related PR:
[#6463 Annotate all creation of XTypeGroup with // ignore: prefer_const_contructor](https://github.com/flutter/plugins/pull/6463)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
