### PR TITLE
[file_selector] Annotate all parameters of XTypeGroup with // ignore: prefer_const_literals_to_create_immutables

### DIFF
--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_constructors
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
 
 import 'dart:io';
 

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_constructors
+// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
 
 import 'dart:io';
 

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -16,6 +16,8 @@ class OpenTextPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     // This demonstrates using an initial directory for the prompt, which should

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector/file_selector.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
@@ -19,7 +19,11 @@ class OpenImagePage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       macUTIs: <String>['public.image'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'dart:io';
 
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';

--- a/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
@@ -16,7 +16,11 @@ class OpenTextPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       macUTIs: <String>['public.text'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
+++ b/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector_ios/file_selector_ios.dart';
 import 'package:file_selector_ios/src/messages.g.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';

--- a/packages/file_selector/file_selector_linux/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_image_page.dart
@@ -19,6 +19,8 @@ class OpenImagePage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
@@ -19,12 +19,16 @@ class OpenMultipleImagesPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
     // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
     // ignore: prefer_const_constructors
     final XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_text_page.dart
@@ -16,6 +16,8 @@ class OpenTextPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector_linux/file_selector_linux.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/services.dart';

--- a/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
@@ -19,6 +19,8 @@ class OpenImagePage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
@@ -19,12 +19,16 @@ class OpenMultipleImagesPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
     // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
     // ignore: prefer_const_constructors
     final XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
@@ -16,6 +16,8 @@ class OpenTextPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector_macos/file_selector_macos.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/services.dart';

--- a/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'dart:html';
 import 'dart:typed_data';
 

--- a/packages/file_selector/file_selector_web/test/utils_test.dart
+++ b/packages/file_selector/file_selector_web/test/utils_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_web/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
@@ -19,6 +19,8 @@ class OpenImagePage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
@@ -19,12 +19,16 @@ class OpenMultipleImagesPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
     // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
     // ignore: prefer_const_constructors
     final XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
@@ -16,6 +16,8 @@ class OpenTextPage extends StatelessWidget {
     // ignore: prefer_const_constructors
     final XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
+// ignore_for_file: prefer_const_literals_to_create_immutables
+
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_windows/file_selector_windows.dart';
 import 'package:file_selector_windows/src/messages.g.dart';


### PR DESCRIPTION
Annotate all parameters of XTypeGroup with // ignore: prefer_const_literals_to_create_immutables to prepare this implementation for the const constructor of XTypeGroup. On files that have more than two occurrences, an ignore_for_file was added at the top of the file.

Issue:
[#111906 [file_selector] `XTypeGroup` should be immutable](https://github.com/flutter/flutter/issues/111906)

Related PR:
[[file_selector] Convert XTypeGroup to const](https://github.com/flutter/plugins/pull/6476#issuecomment-1259562629)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
