### PR TITLE
[video_player] Fixes a bug where the aspect ratio of some HLS videos are incorrectly inverted

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.3.7
 
+* Fixes a bug where the aspect ratio of some HLS videos are incorrectly inverted.
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.
 
 ## 2.3.6

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
@@ -11,11 +11,6 @@
 
 @interface FLTVideoPlayer : NSObject <FlutterStreamHandler>
 @property(readonly, nonatomic) AVPlayer *player;
-// This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
-// (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some video
-// streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116).
-// An invisible AVPlayerLayer is used to overwrite the protection of pixel buffers in those streams
-// for issue #1, and restore the correct width and height for issue #2.
 @property(readonly, nonatomic) AVPlayerLayer *playerLayer;
 @end
 
@@ -67,7 +62,7 @@
 
 @implementation VideoPlayerTests
 
-- (void)testIOS16BugWithEncryptedVideoStream {
+- (void)testBlankVideoBugWithEncryptedVideoStreamAndInvertedAspectRatioBugForSomeVideoStream {
   // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
   // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
   // video streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116). An

--- a/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
+++ b/packages/video_player/video_player_avfoundation/example/ios/RunnerTests/VideoPlayerTests.m
@@ -11,9 +11,11 @@
 
 @interface FLTVideoPlayer : NSObject <FlutterStreamHandler>
 @property(readonly, nonatomic) AVPlayer *player;
-// This is to fix a bug (https://github.com/flutter/flutter/issues/111457) in iOS 16 with blank
-// video for encrypted video streams. An invisible AVPlayerLayer is used to overwrite the
-// protection of pixel buffers in those streams.
+// This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
+// (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some video
+// streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116).
+// An invisible AVPlayerLayer is used to overwrite the protection of pixel buffers in those streams
+// for issue #1, and restore the correct width and height for issue #2.
 @property(readonly, nonatomic) AVPlayerLayer *playerLayer;
 @end
 
@@ -66,12 +68,11 @@
 @implementation VideoPlayerTests
 
 - (void)testIOS16BugWithEncryptedVideoStream {
-  // This is to fix a bug (https://github.com/flutter/flutter/issues/111457) in iOS 16 with blank
-  // video for encrypted video streams. An invisible AVPlayerLayer is used to overwrite the
-  // protection of pixel buffers in those streams.
-  // Note that a better unit test is to validate that `copyPixelBuffer` API returns the pixel
-  // buffers as expected, which requires setting up the video player properly with a protected video
-  // stream (.m3u8 file).
+  // This is to fix 2 bugs: 1. blank video for encrypted video streams on iOS 16
+  // (https://github.com/flutter/flutter/issues/111457) and 2. swapped width and height for some
+  // video streams (not just iOS 16).  (https://github.com/flutter/flutter/issues/109116). An
+  // invisible AVPlayerLayer is used to overwrite the protection of pixel buffers in those streams
+  // for issue #1, and restore the correct width and height for issue #2.
   NSObject<FlutterPluginRegistry> *registry =
       (NSObject<FlutterPluginRegistry> *)[[UIApplication sharedApplication] delegate];
   NSObject<FlutterPluginRegistrar> *registrar =
@@ -95,13 +96,8 @@
   FLTVideoPlayer *player = videoPlayerPlugin.playersByTextureId[textureMessage.textureId];
   XCTAssertNotNil(player);
 
-  if (@available(iOS 16.0, *)) {
-    XCTAssertNotNil(player.playerLayer, @"AVPlayerLayer should be present for iOS 16.");
-    XCTAssertNotNil(player.playerLayer.superlayer,
-                    @"AVPlayerLayer should be added on screen for iOS 16.");
-  } else {
-    XCTAssertNil(player.playerLayer, @"AVPlayerLayer should not be present before iOS 16.");
-  }
+  XCTAssertNotNil(player.playerLayer, @"AVPlayerLayer should be present.");
+  XCTAssertNotNil(player.playerLayer.superlayer, @"AVPlayerLayer should be added on screen.");
 }
 
 - (void)testSeekToInvokesTextureFrameAvailableOnTextureRegistry {

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.6
+version: 2.3.7
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
# Research

The issue is that `item.presentationSize` returns the swapped width and height for some video streams (likely due to transform). 

I did lots of research and wasn't able to find any workaround online. Then I thought that each segment of the HLS may have different resolution (e.g. different internet speed), so AVFoundation must be adjusting the `presentationSize` continuously. Fixing aspect ratio could also be part of that adjustment. So I used the same trick as the [previous PR](https://github.com/flutter/plugins/pull/6442) to leverage AVPlayerLayer to do the heavy lifting work for us. 

# Reverse Engineering

Apple's video player (i.e. `AVPlayerLayer`) displays the aspect ratio correctly. This makes me think that Apple likely went through the process to fix the aspect ratio based on the transform. 

As discussed in [this PR](https://github.com/flutter/plugins/pull/6442), Apple likely uses a "layered structure" in AVFoundation, where the result of previous operation is piped into the next operation. It is very likely Apple fixes the aspect ratio in the upstream so that all downstream operations can get the correct `presentationSize`. 


```mermaid
graph TD;
  A[upstream input]-->B[...];
  B-->C[_invertAspectRatio, hypothetical private API used by AVPlayerLayer];
  C-->D[...];
  D-->E[...]
  E-->F[presentationSize, used by AVPlayerLayer so it needs to be fixed];
  E-->G[presentationSize, used by us];
```



Also, this operation likely happens to each segment of the stream, since they can have different resolution. Something like: 

```
class AVPlayerLayer {
  func playNextFrame() {
    if needsToLoadNextSegment {
      // A hypothetical private API
      nextSegment._invertAspectRatio() 
    }

    // now `presentationSize` should be fixed at this point. 
    drawOnCanvas(item.presentationSize, ...) 
  }
}
```

So in conclusion, just like the [previous PR](https://github.com/flutter/plugins/pull/6442), **we can also leverage AVPlayerLayer to do the heavy lifting work for us**. 

And it worked :)

(If it weren't for the previous iOS 16 bug, I probably wouldn't be able to come up with this solution). 

## Other solutions

Unlike the [previous PR](https://github.com/flutter/plugins/pull/6442), it's possible that there exists a solution that does not rely on reverse engineering, since the aspect ratio is not sensitive or worth protecting. However I did quite a lot of research and wasn't able to find any relevant public APIs to deal with this (let me know if you found anything). 

## About Integration Tests
Only unit tests for now. 

I need to think more about the integration test. Currently I am thinking about a naive solution to deal with pixels directly, but better ideas are welcome. 

The integration test in the previous PR was deleted. So also need to fix that. 

## About the deprecated `keyWindow.rootViewController`
I simply copied the code from another plugin. Fixing it is not the scope of this PR (tho I'm happy to help if needed). 

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/109116

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
