### PR TITLE
[tool] Adds a `fix` command

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.11.1
+
+* Adds a `fix` command to run `dart fix --apply` in target packages.
+
 ## 0.11
 
 * Renames `publish-plugin` to `publish`.

--- a/script/tool/lib/src/fix_command.dart
+++ b/script/tool/lib/src/fix_command.dart
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:file/file.dart';
+import 'package:platform/platform.dart';
+
+import 'common/core.dart';
+import 'common/package_looping_command.dart';
+import 'common/process_runner.dart';
+import 'common/repository_package.dart';
+
+/// A command to run Dart's "fix" command on packages.
+class FixCommand extends PackageLoopingCommand {
+  /// Creates a fix command instance.
+  FixCommand(
+    Directory packagesDir, {
+    ProcessRunner processRunner = const ProcessRunner(),
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform);
+
+  @override
+  final String name = 'fix';
+
+  @override
+  final String description = 'Fixes packages using dart fix.\n\n'
+      'This command requires "dart" and "flutter" to be in your path, and '
+      'assumes that dependencies have already been fetched (e.g., by running '
+      'the analyze command first).';
+
+  @override
+  final bool hasLongOutput = false;
+
+  @override
+  PackageLoopingType get packageLoopingType =>
+      PackageLoopingType.includeAllSubpackages;
+
+  @override
+  Future<PackageResult> runForPackage(RepositoryPackage package) async {
+    final int exitCode = await processRunner.runAndStream(
+        'dart', <String>['fix', '--apply'],
+        workingDir: package.directory);
+    if (exitCode != 0) {
+      printError('Unable to automatically fix package.');
+      return PackageResult.fail();
+    }
+    return PackageResult.success();
+  }
+}

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -17,6 +17,7 @@ import 'dependabot_check_command.dart';
 import 'drive_examples_command.dart';
 import 'federation_safety_check_command.dart';
 import 'firebase_test_lab_command.dart';
+import 'fix_command.dart';
 import 'format_command.dart';
 import 'license_check_command.dart';
 import 'lint_android_command.dart';
@@ -61,6 +62,7 @@ void main(List<String> args) {
     ..addCommand(DriveExamplesCommand(packagesDir))
     ..addCommand(FederationSafetyCheckCommand(packagesDir))
     ..addCommand(FirebaseTestLabCommand(packagesDir))
+    ..addCommand(FixCommand(packagesDir))
     ..addCommand(FormatCommand(packagesDir))
     ..addCommand(LicenseCheckCommand(packagesDir))
     ..addCommand(LintAndroidCommand(packagesDir))

--- a/script/tool/test/fix_command_test.dart
+++ b/script/tool/test/fix_command_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:args/command_runner.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_plugin_tools/src/common/core.dart';
+import 'package:flutter_plugin_tools/src/fix_command.dart';
+import 'package:test/test.dart';
+
+import 'mocks.dart';
+import 'util.dart';
+
+void main() {
+  late FileSystem fileSystem;
+  late MockPlatform mockPlatform;
+  late Directory packagesDir;
+  late RecordingProcessRunner processRunner;
+  late CommandRunner<void> runner;
+
+  setUp(() {
+    fileSystem = MemoryFileSystem();
+    mockPlatform = MockPlatform();
+    packagesDir = createPackagesDirectory(fileSystem: fileSystem);
+    processRunner = RecordingProcessRunner();
+    final FixCommand command = FixCommand(
+      packagesDir,
+      processRunner: processRunner,
+      platform: mockPlatform,
+    );
+
+    runner = CommandRunner<void>('fix_command', 'Test for fix_command');
+    runner.addCommand(command);
+  });
+
+  test('runs fix in top-level packages and subpackages', () async {
+    final RepositoryPackage package = createFakePackage('a', packagesDir);
+    final RepositoryPackage plugin = createFakePlugin('b', packagesDir);
+
+    await runCapturingPrint(runner, <String>['fix']);
+
+    expect(
+        processRunner.recordedCalls,
+        orderedEquals(<ProcessCall>[
+          ProcessCall('dart', const <String>['fix', '--apply'], package.path),
+          ProcessCall('dart', const <String>['fix', '--apply'],
+              package.getExamples().first.path),
+          ProcessCall('dart', const <String>['fix', '--apply'], plugin.path),
+          ProcessCall('dart', const <String>['fix', '--apply'],
+              plugin.getExamples().first.path),
+        ]));
+  });
+
+  test('fails if "dart fix" fails', () async {
+    createFakePlugin('foo', packagesDir);
+
+    processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
+      MockProcess(exitCode: 1),
+    ];
+
+    Error? commandError;
+    final List<String> output = await runCapturingPrint(runner, <String>['fix'],
+        errorHandler: (Error e) {
+      commandError = e;
+    });
+
+    expect(commandError, isA<ToolExit>());
+    expect(
+      output,
+      containsAllInOrder(<Matcher>[
+        contains('Unable to automatically fix package.'),
+      ]),
+    );
+  });
+}


### PR DESCRIPTION
Adds a new command to run `dart fix --apply` in target packages. Like `update-release-info`, this is not intended for CI use, but for local development. It's useful when enabling new lint options.

This is the first time a command has been so simple that it is literally just running a single command in all packages without any additional logic. We may at some point want to replace this with a generic "run a provided command string" command instead of having to make commands like this, but since this is the first time it's come up and it's not clear that we'll have other uses for that, this is just adding the specific command and we can re-evaluate if we ever find that we are adding a second command like this.

(We may well also end up adding more complexity here, such as summarizing the number of fixes applied to each package at the end of the output, which is another argument for having a new specific command.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
