### PR TITLE
[tool] Improve changed-package run mode logging

### DIFF
--- a/script/tool/lib/src/common/package_command.dart
+++ b/script/tool/lib/src/common/package_command.dart
@@ -338,11 +338,14 @@ abstract class PackageCommand extends Command<void> {
 
     if (changedFileFinder != null) {
       final String baseSha = await changedFileFinder.getBaseSha();
-      print(
-          'Running for all packages that have diffs relative to "$baseSha"\n');
       final List<String> changedFiles =
           await changedFileFinder.getChangedFiles();
-      if (!_changesRequireFullTest(changedFiles)) {
+      if (_changesRequireFullTest(changedFiles)) {
+        print('Running for all packages, since a file has changed that could '
+            'affect the entire repository.');
+      } else {
+        print(
+            'Running for all packages that have diffs relative to "$baseSha"\n');
         packages = _getChangedPackageNames(changedFiles);
       }
     } else if (getBoolArg(_runOnDirtyPackagesArg)) {

--- a/script/tool/test/common/package_command_test.dart
+++ b/script/tool/test/common/package_command_test.dart
@@ -408,11 +408,18 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
       test('all plugins should be tested if .ci.yaml changes', () async {
@@ -426,11 +433,17 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
       test('all plugins should be tested if anything in .ci/ changes',
@@ -445,14 +458,20 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
-      test('all plugins should be tested if anything in script changes.',
+      test('all plugins should be tested if anything in script/ changes.',
           () async {
         processRunner.mockProcessesForExecutable['git-diff'] = <Process>[
           MockProcess(stdout: '''
@@ -464,11 +483,17 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
       test('all plugins should be tested if the root analysis options change.',
@@ -483,11 +508,17 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
       test('all plugins should be tested if formatting options change.',
@@ -502,11 +533,17 @@ packages/plugin1/CHANGELOG
             createFakePlugin('plugin1', packagesDir);
         final RepositoryPackage plugin2 =
             createFakePlugin('plugin2', packagesDir);
-        await runCapturingPrint(runner,
+        final List<String> output = await runCapturingPrint(runner,
             <String>['sample', '--base-sha=main', '--run-on-changed-packages']);
 
         expect(command.plugins,
             unorderedEquals(<String>[plugin1.path, plugin2.path]));
+        expect(
+            output,
+            containsAllInOrder(<Matcher>[
+              contains('Running for all packages, since a file has changed '
+                  'that could affect the entire repository.')
+            ]));
       });
 
       test('Only changed plugin should be tested.', () async {


### PR DESCRIPTION
Improves the initial output when running in a mode that filters by packages that need to be tested so that it clearly indicated when it's using "re-run everything due to a core file change", rather than misleadingly logging that it's only testing changed packages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
