### PR TITLE
♻️ #66795 Remove ignore comment from all places where XTypeGroup is being used and change to const.

### DIFF
--- a/packages/file_selector/file_selector/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_image_page.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
-
 import 'dart:io';
 
 import 'package:file_selector/file_selector.dart';
@@ -18,7 +15,7 @@ class OpenImagePage extends StatelessWidget {
 
   Future<void> _openImageFile(BuildContext context) async {
     // #docregion SingleOpen
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
       extensions: <String>['jpg', 'png'],
     );

--- a/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_multiple_images_page.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables
-
 import 'dart:io';
 
 import 'package:file_selector/file_selector.dart';
@@ -18,11 +15,11 @@ class OpenMultipleImagesPage extends StatelessWidget {
 
   Future<void> _openImageFile(BuildContext context) async {
     // #docregion MultiOpen
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: <String>['jpg', 'jpeg'],
     );
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: <String>['png'],
     );

--- a/packages/file_selector/file_selector/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector/example/lib/open_text_page.dart
@@ -12,12 +12,8 @@ class OpenTextPage extends StatelessWidget {
   const OpenTextPage({Key? key}) : super(key: key);
 
   Future<void> _openTextFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     // This demonstrates using an initial directory for the prompt, which should

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   file_selector_ios: ^0.5.0
   file_selector_linux: ^0.9.0
   file_selector_macos: ^0.9.0
-  file_selector_platform_interface: ^2.0.0
+  file_selector_platform_interface: ^2.2.0
   file_selector_web: ^0.9.0
   file_selector_windows: ^0.9.0
   flutter:

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector/file_selector.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -15,15 +12,11 @@ void main() {
   const String initialDirectory = '/home/flutteruser';
   const String confirmButtonText = 'Use this profile picture';
   const String suggestedName = 'suggested_name';
-  final List<XTypeGroup> acceptedTypeGroups = <XTypeGroup>[
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
+  const List<XTypeGroup> acceptedTypeGroups = <XTypeGroup>[
     XTypeGroup(label: 'documents', mimeTypes: <String>[
       'application/msword',
       'application/vnd.openxmlformats-officedocument.wordprocessing',
     ]),
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
     XTypeGroup(label: 'images', extensions: <String>[
       'jpg',
       'png',

--- a/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_image_page.dart
@@ -15,15 +15,9 @@ class OpenImagePage extends StatelessWidget {
   const OpenImagePage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       macUTIs: <String>['public.image'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_multiple_images_page.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'dart:io';
 
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
@@ -18,16 +15,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
   const OpenMultipleImagesPage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
       extensions: <String>['jpg', 'jpeg'],
       macUTIs: <String>['public.jpeg'],
     );
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
       extensions: <String>['png'],
       macUTIs: <String>['public.png'],

--- a/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_ios/example/lib/open_text_page.dart
@@ -12,15 +12,9 @@ class OpenTextPage extends StatelessWidget {
   const OpenTextPage({Key? key}) : super(key: key);
 
   Future<void> _openTextFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       macUTIs: <String>['public.text'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_ios/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.0.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         pluginClass: FFSFileSelectorPlugin
 
 dependencies:
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
+++ b/packages/file_selector/file_selector_ios/test/file_selector_ios_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector_ios/file_selector_ios.dart';
 import 'package:file_selector_ios/src/messages.g.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
@@ -39,18 +36,14 @@ void main() {
     });
 
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -69,9 +62,7 @@ void main() {
       expect(config.allowMultiSelection, isFalse);
     });
     test('throws for a type group that does not support iOS', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -82,9 +73,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -99,18 +88,14 @@ void main() {
     });
 
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -129,9 +114,7 @@ void main() {
       expect(config.allowMultiSelection, isTrue);
     });
     test('throws for a type group that does not support iOS', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -142,9 +125,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 

--- a/packages/file_selector/file_selector_linux/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_image_page.dart
@@ -15,12 +15,8 @@ class OpenImagePage extends StatelessWidget {
   const OpenImagePage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_multiple_images_page.dart
@@ -15,20 +15,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
   const OpenMultipleImagesPage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_linux/example/lib/open_text_page.dart
@@ -12,12 +12,8 @@ class OpenTextPage extends StatelessWidget {
   const OpenTextPage({Key? key}) : super(key: key);
 
   Future<void> _openTextFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_linux/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   file_selector_linux:
     path: ../
-  file_selector_platform_interface: ^2.0.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
+++ b/packages/file_selector/file_selector_linux/test/file_selector_linux_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector_linux/file_selector_linux.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -32,18 +29,14 @@ void main() {
 
   group('#openFile', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
@@ -108,9 +101,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Linux', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -121,9 +112,7 @@ void main() {
     });
 
     test('passes a wildcard group correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'any',
       );
 
@@ -150,18 +139,14 @@ void main() {
 
   group('#openFiles', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
@@ -226,9 +211,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Linux', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -239,9 +222,7 @@ void main() {
     });
 
     test('passes a wildcard group correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'any',
       );
 
@@ -268,18 +249,14 @@ void main() {
 
   group('#getSavePath', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
@@ -345,9 +322,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Linux', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -358,9 +333,7 @@ void main() {
     });
 
     test('passes a wildcard group correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'any',
       );
 

--- a/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_image_page.dart
@@ -15,12 +15,8 @@ class OpenImagePage extends StatelessWidget {
   const OpenImagePage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_multiple_images_page.dart
@@ -15,20 +15,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
   const OpenMultipleImagesPage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/open_text_page.dart
@@ -12,12 +12,8 @@ class OpenTextPage extends StatelessWidget {
   const OpenTextPage({Key? key}) : super(key: key);
 
   Future<void> _openTextFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.0.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector_macos/file_selector_macos.dart';
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -33,18 +30,14 @@ void main() {
 
   group('openFile', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -103,9 +96,7 @@ void main() {
     });
 
     test('throws for a type group that does not support macOS', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -116,9 +107,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -129,18 +118,14 @@ void main() {
 
   group('openFiles', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -199,9 +184,7 @@ void main() {
     });
 
     test('throws for a type group that does not support macOS', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -212,9 +195,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -225,18 +206,14 @@ void main() {
 
   group('getSavePath', () {
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -296,9 +273,7 @@ void main() {
     });
 
     test('throws for a type group that does not support macOS', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'images',
         webWildCards: <String>['images/*'],
       );
@@ -309,9 +284,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -353,25 +326,19 @@ void main() {
 
   test('ignores all type groups if any of them is a wildcard', () async {
     await plugin.getSavePath(acceptedTypeGroups: <XTypeGroup>[
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      XTypeGroup(
+      const XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       ),
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      XTypeGroup(
+      const XTypeGroup(
         label: 'image',
         extensions: <String>['jpg'],
         mimeTypes: <String>['image/jpg'],
         macUTIs: <String>['public.image'],
       ),
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      XTypeGroup(
+      const XTypeGroup(
         label: 'any',
       ),
     ]);

--- a/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/x_type_group_test.dart
@@ -9,12 +9,12 @@ void main() {
   group('XTypeGroup', () {
     test('toJSON() creates correct map', () {
       const String label = 'test group';
-      final List<String> extensions = <String>['txt', 'jpg'];
-      final List<String> mimeTypes = <String>['text/plain'];
-      final List<String> macUTIs = <String>['public.plain-text'];
-      final List<String> webWildCards = <String>['image/*'];
+      const List<String> extensions = <String>['txt', 'jpg'];
+      const List<String> mimeTypes = <String>['text/plain'];
+      const List<String> macUTIs = <String>['public.plain-text'];
+      const List<String> webWildCards = <String>['image/*'];
 
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: label,
         extensions: extensions,
         mimeTypes: mimeTypes,
@@ -72,8 +72,8 @@ void main() {
     });
 
     test('Leading dots are removed from extensions', () {
-      final List<String> extensions = <String>['.txt', '.jpg'];
-      final XTypeGroup group = XTypeGroup(extensions: extensions);
+      const List<String> extensions = <String>['.txt', '.jpg'];
+      const XTypeGroup group = XTypeGroup(extensions: extensions);
 
       expect(group.extensions, <String>['txt', 'jpg']);
     });

--- a/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
+++ b/packages/file_selector/file_selector_web/example/integration_test/file_selector_web_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'dart:html';
 import 'dart:typed_data';
 
@@ -29,9 +26,7 @@ void main() {
         final FileSelectorWeb plugin =
             FileSelectorWeb(domHelper: mockDomHelper);
 
-        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-        // ignore: prefer_const_constructors
-        final XTypeGroup typeGroup = XTypeGroup(
+        const XTypeGroup typeGroup = XTypeGroup(
           label: 'images',
           extensions: <String>['jpg', 'jpeg'],
           mimeTypes: <String>['image/png'],
@@ -61,9 +56,7 @@ void main() {
         final FileSelectorWeb plugin =
             FileSelectorWeb(domHelper: mockDomHelper);
 
-        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-        // ignore: prefer_const_constructors
-        final XTypeGroup typeGroup = XTypeGroup(
+        const XTypeGroup typeGroup = XTypeGroup(
           label: 'files',
           extensions: <String>['.txt'],
         );

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   flutter: ">=2.10.0"
 
 dependencies:
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   file_selector_web:
     path: ../
   flutter:

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         fileName: file_selector_web.dart
 
 dependencies:
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/file_selector/file_selector_web/test/utils_test.dart
+++ b/packages/file_selector/file_selector_web/test/utils_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_web/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,15 +11,9 @@ void main() {
     group('acceptedTypesToString', () {
       test('works', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'images', webWildCards: <String>['images/*']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'jpgs', extensions: <String>['jpg', 'jpeg']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
+          const XTypeGroup(label: 'images', webWildCards: <String>['images/*']),
+          const XTypeGroup(label: 'jpgs', extensions: <String>['jpg', 'jpeg']),
+          const XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
         expect(accepts, 'images/*,.jpg,.jpeg,image/png');
@@ -36,12 +27,8 @@ void main() {
 
       test('works with extensions', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'jpgs', extensions: <String>['jpeg', 'jpg']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'pngs', extensions: <String>['png']),
+          const XTypeGroup(label: 'jpgs', extensions: <String>['jpeg', 'jpg']),
+          const XTypeGroup(label: 'pngs', extensions: <String>['png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
         expect(accepts, '.jpeg,.jpg,.png');
@@ -49,13 +36,9 @@ void main() {
 
       test('works with mime types', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(
+          const XTypeGroup(
               label: 'jpgs', mimeTypes: <String>['image/jpeg', 'image/jpg']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
+          const XTypeGroup(label: 'pngs', mimeTypes: <String>['image/png']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
         expect(accepts, 'image/jpeg,image/jpg,image/png');
@@ -63,15 +46,9 @@ void main() {
 
       test('works with web wild cards', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'images', webWildCards: <String>['image/*']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'audios', webWildCards: <String>['audio/*']),
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'videos', webWildCards: <String>['video/*']),
+          const XTypeGroup(label: 'images', webWildCards: <String>['image/*']),
+          const XTypeGroup(label: 'audios', webWildCards: <String>['audio/*']),
+          const XTypeGroup(label: 'videos', webWildCards: <String>['video/*']),
         ];
         final String accepts = acceptedTypesToString(acceptedTypes);
         expect(accepts, 'image/*,audio/*,video/*');
@@ -79,9 +56,7 @@ void main() {
 
       test('throws for a type group that does not support web', () {
         final List<XTypeGroup> acceptedTypes = <XTypeGroup>[
-          // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-          // ignore: prefer_const_constructors
-          XTypeGroup(label: 'text', macUTIs: <String>['public.text']),
+          const XTypeGroup(label: 'text', macUTIs: <String>['public.text']),
         ];
         expect(() => acceptedTypesToString(acceptedTypes), throwsArgumentError);
       });

--- a/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_image_page.dart
@@ -15,12 +15,8 @@ class OpenImagePage extends StatelessWidget {
   const OpenImagePage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'images',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'png'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_multiple_images_page.dart
@@ -15,20 +15,12 @@ class OpenMultipleImagesPage extends StatelessWidget {
   const OpenMultipleImagesPage({Key? key}) : super(key: key);
 
   Future<void> _openImageFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup jpgsTypeGroup = XTypeGroup(
+    const XTypeGroup jpgsTypeGroup = XTypeGroup(
       label: 'JPEGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['jpg', 'jpeg'],
     );
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup pngTypeGroup = XTypeGroup(
+    const XTypeGroup pngTypeGroup = XTypeGroup(
       label: 'PNGs',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['png'],
     );
     final List<XFile> files = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
+++ b/packages/file_selector/file_selector_windows/example/lib/open_text_page.dart
@@ -12,12 +12,8 @@ class OpenTextPage extends StatelessWidget {
   const OpenTextPage({Key? key}) : super(key: key);
 
   Future<void> _openTextFile(BuildContext context) async {
-    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-    // ignore: prefer_const_constructors
-    final XTypeGroup typeGroup = XTypeGroup(
+    const XTypeGroup typeGroup = XTypeGroup(
       label: 'text',
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_literals_to_create_immutables
       extensions: <String>['txt', 'json'],
     );
     final XFile? file = await FileSelectorPlatform.instance

--- a/packages/file_selector/file_selector_windows/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=2.10.0"
 
 dependencies:
-  file_selector_platform_interface: ^2.0.0
+  file_selector_platform_interface: ^2.2.0
   file_selector_windows:
     # When depending on this package from a real application you should use:
     #   file_selector_windows: ^x.y.z

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.1.0
+  file_selector_platform_interface: ^2.2.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
+++ b/packages/file_selector/file_selector_windows/test/file_selector_windows_test.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-// ignore_for_file: prefer_const_literals_to_create_immutables
-
 import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
 import 'package:file_selector_windows/file_selector_windows.dart';
 import 'package:file_selector_windows/src/messages.g.dart';
@@ -50,18 +47,14 @@ void main() {
     });
 
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -93,9 +86,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Windows', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         mimeTypes: <String>['text/plain'],
       );
@@ -106,9 +97,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -136,18 +125,14 @@ void main() {
     });
 
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -179,9 +164,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Windows', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         mimeTypes: <String>['text/plain'],
       );
@@ -192,9 +175,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 
@@ -250,18 +231,14 @@ void main() {
     });
 
     test('passes the accepted type groups correctly', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         extensions: <String>['txt'],
         mimeTypes: <String>['text/plain'],
         macUTIs: <String>['public.text'],
       );
 
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup groupTwo = XTypeGroup(
+      const XTypeGroup groupTwo = XTypeGroup(
           label: 'image',
           extensions: <String>['jpg'],
           mimeTypes: <String>['image/jpg'],
@@ -300,9 +277,7 @@ void main() {
     });
 
     test('throws for a type group that does not support Windows', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
         mimeTypes: <String>['text/plain'],
       );
@@ -313,9 +288,7 @@ void main() {
     });
 
     test('allows a wildcard group', () async {
-      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-      // ignore: prefer_const_constructors
-      final XTypeGroup group = XTypeGroup(
+      const XTypeGroup group = XTypeGroup(
         label: 'text',
       );
 


### PR DESCRIPTION
Things I've done:

- Removi todos los ignores que habiamos agregado previamente para que no explote el pipeline.
- Cambie las declaraciones de XTypeGroup de `final` a `const` (esto hace que no necesitemos mas el ignore).
- El pump de version en todos los pubspec que usaban file_selector_platform_interface a la version 2.2.0.

Si pueden checkoutearse a esta rama y tirar `dart pub global run flutter_plugin_tools analyze --packages file_selector` parados desde `/plugins`, me harian un gran favor, a mi me falla siempre el de file_selector_windows y no se si hay algo roto ahi o solo es el problema de siempre.


_This PR was created to be reviewed by the team._

