### PR TITLE
[in_app_purchase][iOS] fix iOS promotional offers (SKPaymentDiscountWrapper was not used properly)

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.3.3
 
-* Fixes `SKProductDiscountWrapper` with being sent trough the method channel as the expected parameter.
+* Supports adding discount information to AppStorePurchaseParam. 
+* Fixes iOS Promotional Offers bug which prevents them from working.
 
 ## 0.3.2+2
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+* Fixes `SKProductDiscountWrapper` with being sent trough the method channel as the expected parameter.
+
 ## 0.3.2+2
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
@@ -404,6 +404,12 @@
         [FIAObjectTranslator getSKPaymentDiscountFromMap:discountMap withError:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(paymentDiscount);
+    XCTAssertEqual(paymentDiscount.identifier, discountMap[@"identifier"]);
+    XCTAssertEqual(paymentDiscount.keyIdentifier, discountMap[@"keyIdentifier"]);
+    XCTAssertEqualObjects(paymentDiscount.nonce,
+                          [[NSUUID alloc] initWithUUIDString:discountMap[@"nonce"]]);
+    XCTAssertEqual(paymentDiscount.signature, discountMap[@"signature"]);
+    XCTAssertEqual(paymentDiscount.timestamp, discountMap[@"timestamp"]);
   }
 }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
@@ -390,4 +390,20 @@
   }
 }
 
+- (void)testSKPaymentDiscountFromMapOverflowingTimestamp {
+  if (@available(iOS 12.2, *)) {
+    NSDictionary *discountMap = @{
+      @"identifier" : @"payment_discount_identifier",
+      @"keyIdentifier" : @"payment_discount_key_identifier",
+      @"nonce" : @"d18981e0-9003-4365-98a2-4b90e3b62c52",
+      @"signature" : @"this is a encrypted signature",
+      @"timestamp" : @1665044583595, // timestamp 2022 Oct
+    };
+    NSString *error = nil;
+    SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:discountMap withError:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(paymentDiscount);
+  }
+}
+
 @end

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/ios/RunnerTests/TranslatorTests.m
@@ -397,10 +397,11 @@
       @"keyIdentifier" : @"payment_discount_key_identifier",
       @"nonce" : @"d18981e0-9003-4365-98a2-4b90e3b62c52",
       @"signature" : @"this is a encrypted signature",
-      @"timestamp" : @1665044583595, // timestamp 2022 Oct
+      @"timestamp" : @1665044583595,  // timestamp 2022 Oct
     };
     NSString *error = nil;
-    SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator getSKPaymentDiscountFromMap:discountMap withError:&error];
+    SKPaymentDiscount *paymentDiscount =
+        [FIAObjectTranslator getSKPaymentDiscountFromMap:discountMap withError:&error];
     XCTAssertNil(error);
     XCTAssertNotNil(paymentDiscount);
   }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -277,7 +277,7 @@
     return nil;
   }
 
-  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || timestamp <= 0) {
+  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || [timestamp longLongValue] <= 0) {
     if (error) {
       *error = @"When specifying a payment discount the 'timestamp' field is mandatory.";
     }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -237,7 +237,7 @@
 
 + (SKPaymentDiscount *)getSKPaymentDiscountFromMap:(NSDictionary *)map
                                          withError:(NSString **)error {
-  if (!map || [map isKindOfClass:[NSNull class]] || map.count <= 0) {
+  if (!map || map.count <= 0) {
     return nil;
   }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/FIAObjectTranslator.m
@@ -237,7 +237,7 @@
 
 + (SKPaymentDiscount *)getSKPaymentDiscountFromMap:(NSDictionary *)map
                                          withError:(NSString **)error {
-  if (!map || map.count <= 0) {
+  if (!map || [map isKindOfClass:[NSNull class]] || map.count <= 0) {
     return nil;
   }
 
@@ -277,7 +277,7 @@
     return nil;
   }
 
-  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || [timestamp intValue] <= 0) {
+  if (!timestamp || ![timestamp isKindOfClass:NSNumber.class] || timestamp <= 0) {
     if (error) {
       *error = @"When specifying a payment discount the 'timestamp' field is mandatory.";
     }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
@@ -201,21 +201,22 @@
 
   if (@available(iOS 12.2, *)) {
     NSDictionary *paymentDiscountMap = [paymentMap objectForKey:@"paymentDiscount"];
-    if(![paymentDiscountMap isKindOfClass:[NSNull class]]) {
+    if (![paymentDiscountMap isKindOfClass:[NSNull class]]) {
       NSString *error = nil;
-      SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator
-          getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
-      
+      SKPaymentDiscount *paymentDiscount =
+          [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
+
       if (error) {
         result([FlutterError
             errorWithCode:@"storekit_invalid_payment_discount_object"
-                  message:[NSString stringWithFormat:@"You have requested a payment and specified a "
-                                                     @"payment discount with invalid properties. %@",
-                                                     error]
+                  message:[NSString
+                              stringWithFormat:@"You have requested a payment and specified a "
+                                               @"payment discount with invalid properties. %@",
+                                               error]
                   details:call.arguments]);
         return;
       }
-      
+
       payment.paymentDiscount = paymentDiscount;
     }
   }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
@@ -200,25 +200,23 @@
                                            : [simulatesAskToBuyInSandbox boolValue];
 
   if (@available(iOS 12.2, *)) {
-    NSDictionary *paymentDiscountMap = [paymentMap objectForKey:@"paymentDiscount"];
-    if (![paymentDiscountMap isKindOfClass:[NSNull class]]) {
-      NSString *error = nil;
-      SKPaymentDiscount *paymentDiscount =
-          [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
+    NSDictionary *paymentDiscountMap = [self getNonNullValueFromDictionary:paymentMap forKey:@"paymentDiscount"];
+    NSString *error = nil;
+    SKPaymentDiscount *paymentDiscount =
+        [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
 
-      if (error) {
-        result([FlutterError
-            errorWithCode:@"storekit_invalid_payment_discount_object"
-                  message:[NSString
-                              stringWithFormat:@"You have requested a payment and specified a "
-                                               @"payment discount with invalid properties. %@",
-                                               error]
-                  details:call.arguments]);
-        return;
-      }
-
-      payment.paymentDiscount = paymentDiscount;
+    if (error) {
+      result([FlutterError
+          errorWithCode:@"storekit_invalid_payment_discount_object"
+                message:[NSString
+                            stringWithFormat:@"You have requested a payment and specified a "
+                                             @"payment discount with invalid properties. %@",
+                                             error]
+                details:call.arguments]);
+      return;
     }
+
+    payment.paymentDiscount = paymentDiscount;
   }
 
   if (![self.paymentQueueHandler addPayment:payment]) {
@@ -368,6 +366,12 @@
     [_paymentQueueHandler showPriceConsentIfNeeded];
   }
   result(nil);
+}
+
+- (id)getNonNullValueFromDictionary:(NSDictionary *)dictionary
+                             forKey:(NSString *)key {
+  id value = dictionary[key];
+  return [value isKindOfClass:[NSNull class]] ? nil : value;
 }
 
 #pragma mark - transaction observer:

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
@@ -200,7 +200,8 @@
                                            : [simulatesAskToBuyInSandbox boolValue];
 
   if (@available(iOS 12.2, *)) {
-    NSDictionary *paymentDiscountMap = [self getNonNullValueFromDictionary:paymentMap forKey:@"paymentDiscount"];
+    NSDictionary *paymentDiscountMap = [self getNonNullValueFromDictionary:paymentMap
+                                                                    forKey:@"paymentDiscount"];
     NSString *error = nil;
     SKPaymentDiscount *paymentDiscount =
         [FIAObjectTranslator getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
@@ -208,10 +209,9 @@
     if (error) {
       result([FlutterError
           errorWithCode:@"storekit_invalid_payment_discount_object"
-                message:[NSString
-                            stringWithFormat:@"You have requested a payment and specified a "
-                                             @"payment discount with invalid properties. %@",
-                                             error]
+                message:[NSString stringWithFormat:@"You have requested a payment and specified a "
+                                                   @"payment discount with invalid properties. %@",
+                                                   error]
                 details:call.arguments]);
       return;
     }
@@ -368,8 +368,7 @@
   result(nil);
 }
 
-- (id)getNonNullValueFromDictionary:(NSDictionary *)dictionary
-                             forKey:(NSString *)key {
+- (id)getNonNullValueFromDictionary:(NSDictionary *)dictionary forKey:(NSString *)key {
   id value = dictionary[key];
   return [value isKindOfClass:[NSNull class]] ? nil : value;
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/ios/Classes/InAppPurchasePlugin.m
@@ -200,22 +200,24 @@
                                            : [simulatesAskToBuyInSandbox boolValue];
 
   if (@available(iOS 12.2, *)) {
-    NSString *error = nil;
-    SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator
-        getSKPaymentDiscountFromMap:[paymentMap objectForKey:@"paymentDiscount"]
-                          withError:&error];
-
-    if (error) {
-      result([FlutterError
-          errorWithCode:@"storekit_invalid_payment_discount_object"
-                message:[NSString stringWithFormat:@"You have requested a payment and specified a "
-                                                   @"payment discount with invalid properties. %@",
-                                                   error]
-                details:call.arguments]);
-      return;
+    NSDictionary *paymentDiscountMap = [paymentMap objectForKey:@"paymentDiscount"];
+    if(![paymentDiscountMap isKindOfClass:[NSNull class]]) {
+      NSString *error = nil;
+      SKPaymentDiscount *paymentDiscount = [FIAObjectTranslator
+          getSKPaymentDiscountFromMap:paymentDiscountMap withError:&error];
+      
+      if (error) {
+        result([FlutterError
+            errorWithCode:@"storekit_invalid_payment_discount_object"
+                  message:[NSString stringWithFormat:@"You have requested a payment and specified a "
+                                                     @"payment discount with invalid properties. %@",
+                                                     error]
+                  details:call.arguments]);
+        return;
+      }
+      
+      payment.paymentDiscount = paymentDiscount;
     }
-
-    payment.paymentDiscount = paymentDiscount;
   }
 
   if (![self.paymentQueueHandler addPayment:payment]) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/in_app_purchase_storekit_platform.dart
@@ -75,7 +75,10 @@ class InAppPurchaseStoreKitPlatform extends InAppPurchasePlatform {
             purchaseParam is AppStorePurchaseParam ? purchaseParam.quantity : 1,
         applicationUsername: purchaseParam.applicationUserName,
         simulatesAskToBuyInSandbox: purchaseParam is AppStorePurchaseParam &&
-            purchaseParam.simulatesAskToBuyInSandbox));
+            purchaseParam.simulatesAskToBuyInSandbox,
+        paymentDiscount: purchaseParam is AppStorePurchaseParam
+            ? purchaseParam.discount
+            : null));
 
     return true; // There's no error feedback from iOS here to return.
   }

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/store_kit_wrappers/sk_payment_queue_wrapper.dart
@@ -405,7 +405,8 @@ class SKPaymentWrapper {
       'applicationUsername': applicationUsername,
       'requestData': requestData,
       'quantity': quantity,
-      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox
+      'simulatesAskToBuyInSandbox': simulatesAskToBuyInSandbox,
+      'paymentDiscount': paymentDiscount?.toMap(),
     };
   }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/app_store_purchase_param.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/app_store_purchase_param.dart
@@ -14,6 +14,7 @@ class AppStorePurchaseParam extends PurchaseParam {
     String? applicationUserName,
     this.quantity = 1,
     this.simulatesAskToBuyInSandbox = false,
+    this.discount,
   }) : super(
           productDetails: productDetails,
           applicationUserName: applicationUserName,
@@ -32,4 +33,7 @@ class AppStorePurchaseParam extends PurchaseParam {
 
   /// Quantity of the product user requested to buy.
   final int quantity;
+
+  /// Discount applied to the product (optional).
+  final SKPaymentDiscountWrapper? discount;
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/app_store_purchase_param.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/lib/src/types/app_store_purchase_param.dart
@@ -34,6 +34,6 @@ class AppStorePurchaseParam extends PurchaseParam {
   /// Quantity of the product user requested to buy.
   final int quantity;
 
-  /// Discount applied to the product (optional).
+  /// Discount applied to the product. The value is `null` when the product does not have a discount.
   final SKPaymentDiscountWrapper? discount;
 }

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS platform of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.2+2
+version: 0.3.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
@@ -30,7 +30,7 @@ class FakeStoreKitPlatform {
   PlatformException? restoreException;
   SKError? testRestoredError;
   bool queueIsActive = false;
-  Map<String, dynamic>? discountReceived;
+  Map<String, dynamic> discountReceived = <String, dynamic>{};
 
   void reset() {
     transactions = <SKPaymentTransactionWrapper>[];
@@ -55,7 +55,7 @@ class FakeStoreKitPlatform {
     restoreException = null;
     testRestoredError = null;
     queueIsActive = false;
-    discountReceived = null;
+    discountReceived = <String, dynamic>{};
   }
 
   SKPaymentTransactionWrapper createPendingTransaction(String id,
@@ -172,21 +172,14 @@ class FakeStoreKitPlatform {
         final String id = call.arguments['productIdentifier'] as String;
         final int quantity = call.arguments['quantity'] as int;
 
-        // in case of testing paymentDiscount
+        // Keep the received paymentDiscount parameter when testing payment with discount.
         if (call.arguments['applicationUsername'] == 'userWithDiscount') {
           if (call.arguments['paymentDiscount'] != null) {
             final Map<dynamic, dynamic> discountArgument =
                 call.arguments['paymentDiscount'];
-            discountReceived = <String, dynamic>{};
-            // can't cast directly the argument to Map<String,dynamic>, will receive:
-            // PlatformException(error, type '_InternalLinkedHashMap<Object?, Object?>' is not a subtype of type 'Map<String?, dynamic>' in type cast, null, null)
-            for (final dynamic key in discountArgument.keys) {
-              if (key is String) {
-                discountReceived![key] = discountArgument[key];
-              }
-            }
+            discountReceived = discountArgument.cast<String, dynamic>();
           } else {
-            discountReceived = null;
+            discountReceived = <String, dynamic>{};
           }
         }
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/fakes/fake_storekit_platform.dart
@@ -177,7 +177,7 @@ class FakeStoreKitPlatform {
           if (call.arguments['paymentDiscount'] != null) {
             final Map<dynamic, dynamic> discountArgument =
                 call.arguments['paymentDiscount'];
-            discountReceived = {};
+            discountReceived = <String, dynamic>{};
             // can't cast directly the argument to Map<String,dynamic>, will receive:
             // PlatformException(error, type '_InternalLinkedHashMap<Object?, Object?>' is not a subtype of type 'Map<String?, dynamic>' in type cast, null, null)
             for (final dynamic key in discountArgument.keys) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
@@ -489,6 +489,36 @@ void main() {
       expect(
           fakeStoreKitPlatform.finishedTransactions.first.payment.quantity, 5);
     });
+
+    test(
+        'buying non consumable with discount, should get purchase objects in the purchase update callback',
+        () async {
+      final List<PurchaseDetails> details = <PurchaseDetails>[];
+      final Completer<List<PurchaseDetails>> completer =
+          Completer<List<PurchaseDetails>>();
+      final Stream<List<PurchaseDetails>> stream =
+          iapStoreKitPlatform.purchaseStream;
+
+      late StreamSubscription<List<PurchaseDetails>> subscription;
+      subscription = stream.listen((List<PurchaseDetails> purchaseDetailsList) {
+        details.addAll(purchaseDetailsList);
+        if (purchaseDetailsList.first.status == PurchaseStatus.purchased) {
+          completer.complete(details);
+          subscription.cancel();
+        }
+      });
+      final AppStorePurchaseParam purchaseParam = AppStorePurchaseParam(
+        productDetails:
+            AppStoreProductDetails.fromSKProduct(dummyProductWrapper),
+        applicationUserName: 'appName',
+        discount: dummyPaymentDiscountWrapper,
+      );
+      await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
+
+      final List<PurchaseDetails> result = await completer.future;
+      expect(result.length, 2);
+      expect(result.first.productID, dummyProductWrapper.productIdentifier);
+    });
   });
 
   group('complete purchase', () {

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/in_app_purchase_storekit_platform_test.dart
@@ -510,7 +510,7 @@ void main() {
       final AppStorePurchaseParam purchaseParam = AppStorePurchaseParam(
         productDetails:
             AppStoreProductDetails.fromSKProduct(dummyProductWrapper),
-        applicationUserName: 'appName',
+        applicationUserName: 'userWithDiscount',
         discount: dummyPaymentDiscountWrapper,
       );
       await iapStoreKitPlatform.buyNonConsumable(purchaseParam: purchaseParam);
@@ -518,6 +518,8 @@ void main() {
       final List<PurchaseDetails> result = await completer.future;
       expect(result.length, 2);
       expect(result.first.productID, dummyProductWrapper.productIdentifier);
+      expect(fakeStoreKitPlatform.discountReceived,
+          dummyPaymentDiscountWrapper.toMap());
     });
   });
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_product_test.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_product_test.dart
@@ -141,6 +141,21 @@ void main() {
       expect(payment, equals(dummyPayment));
     });
 
+    test('SKPaymentWrapper should have propery values consistent with .toMap()',
+        () {
+      final Map<String, dynamic> mapResult = dummyPaymentWithDiscount.toMap();
+      expect(mapResult['productIdentifier'],
+          dummyPaymentWithDiscount.productIdentifier);
+      expect(mapResult['applicationUsername'],
+          dummyPaymentWithDiscount.applicationUsername);
+      expect(mapResult['requestData'], dummyPaymentWithDiscount.requestData);
+      expect(mapResult['quantity'], dummyPaymentWithDiscount.quantity);
+      expect(mapResult['simulatesAskToBuyInSandbox'],
+          dummyPaymentWithDiscount.simulatesAskToBuyInSandbox);
+      expect(mapResult['paymentDiscount'],
+          equals(dummyPaymentWithDiscount.paymentDiscount?.toMap()));
+    });
+
     test('Should construct correct SKError from json', () {
       final SKError error = SKError.fromJson(buildErrorMap(dummyError));
       expect(error, equals(dummyError));

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
@@ -186,3 +186,12 @@ Map<String, dynamic> buildTransactionMap(
   };
   return map;
 }
+
+final SKPaymentDiscountWrapper dummyPaymentDiscountWrapper =
+    SKPaymentDiscountWrapper.fromJson(const <String, dynamic>{
+  'identifier': 'dummy-discount-identifier',
+  'keyIdentifier': 'KEYIDTEST1',
+  'nonce': '00000000-0000-0000-0000-000000000000',
+  'signature': 'dummy-signature-string',
+  'timestamp': 1231231231,
+});

--- a/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/test/store_kit_wrappers/sk_test_stub_objects.dart
@@ -10,6 +10,15 @@ const SKPaymentWrapper dummyPayment = SKPaymentWrapper(
     requestData: 'fake-data-utf8',
     quantity: 2,
     simulatesAskToBuyInSandbox: true);
+
+final SKPaymentWrapper dummyPaymentWithDiscount = SKPaymentWrapper(
+    productIdentifier: 'prod-id',
+    applicationUsername: 'app-user-name',
+    requestData: 'fake-data-utf8',
+    quantity: 2,
+    simulatesAskToBuyInSandbox: true,
+    paymentDiscount: dummyPaymentDiscountWrapper);
+
 const SKError dummyError = SKError(
     code: 111,
     domain: 'dummy-domain',


### PR DESCRIPTION
Make iOS Promotional Offers in in_app_purchase plugin usable. `SKPaymentDiscountWrapper` was not being sent trough the method channel.
This is an update to an old (already closed) [PR here](https://github.com/flutter/plugins/pull/6099)

Resolves: [[in-app-purchase][iOS] Promotional Offers in iOS not working](https://github.com/flutter/flutter/issues/107533#issue-1303299545)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
