### PR TITLE
[image_picker_windows] Use const instead of final for XTypeGroup.

### DIFF
--- a/packages/image_picker/image_picker_windows/CHANGELOG.md
+++ b/packages/image_picker/image_picker_windows/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.1.0+3
 
+* Changes XTypeGroup initialization from final to const.
 * Updates minimum Flutter version to 2.10.
 
 ## 0.1.0+2

--- a/packages/image_picker/image_picker_windows/lib/image_picker_windows.dart
+++ b/packages/image_picker/image_picker_windows/lib/image_picker_windows.dart
@@ -118,9 +118,7 @@ class ImagePickerWindows extends ImagePickerPlatform {
       throw UnimplementedError(
           'ImageSource.gallery is currently the only supported source on Windows');
     }
-    final XTypeGroup typeGroup =
-        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-        // ignore: prefer_const_constructors
+    const XTypeGroup typeGroup =
         XTypeGroup(label: 'images', extensions: imageFormats);
     final XFile? file = await fileSelector
         .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
@@ -144,9 +142,7 @@ class ImagePickerWindows extends ImagePickerPlatform {
       throw UnimplementedError(
           'ImageSource.gallery is currently the only supported source on Windows');
     }
-    final XTypeGroup typeGroup =
-        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-        // ignore: prefer_const_constructors
+    const XTypeGroup typeGroup =
         XTypeGroup(label: 'videos', extensions: videoFormats);
     final XFile? file = await fileSelector
         .openFile(acceptedTypeGroups: <XTypeGroup>[typeGroup]);
@@ -162,9 +158,7 @@ class ImagePickerWindows extends ImagePickerPlatform {
     double? maxHeight,
     int? imageQuality,
   }) async {
-    final XTypeGroup typeGroup =
-        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/111906
-        // ignore: prefer_const_constructors
+    const XTypeGroup typeGroup =
         XTypeGroup(label: 'images', extensions: imageFormats);
     final List<XFile> files = await fileSelector
         .openFiles(acceptedTypeGroups: <XTypeGroup>[typeGroup]);

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -16,7 +16,7 @@ flutter:
         dartPluginClass: ImagePickerWindows
 
 dependencies:
-  file_selector_platform_interface: ^2.0.4
+  file_selector_platform_interface: ^2.2.0
   file_selector_windows: ^0.8.2
   flutter:
     sdk: flutter

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_windows
 description: Windows platform implementation of image_picker
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.1.0+2
+version: 0.1.0+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
The changes that were made on [#6476](https://github.com/flutter/plugins/pull/6476), affected the image_picker_windows package. So, in this pull request, the previously added `//ignore`'s are removed and converted XTypeGroup to `const` instead of `final`.
The version of `file_selector_platform_interface` was upgraded to 2.2.0 in the `pubspec.yaml` for windows.

Issue:
Fixes https://github.com/flutter/flutter/issues/111906 [file_selector] `XTypeGroup` should be immutable

Related PR's:
[#6476 [file_selector] Convert XTypeGroup to const](https://github.com/flutter/plugins/pull/6476)
[#6504 [image_picker_windows] Annotate all creation of XTypeGroup with // ignore: prefer_const_contructor](https://github.com/flutter/plugins/pull/6504)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
