### PR TITLE
[video_player] Removed AudioSession configuration on iOS

### DIFF
--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -553,8 +553,10 @@ NS_INLINE UIViewController *rootViewController() {
 }
 
 - (void)initialize:(FlutterError *__autoreleasing *)error {
+  // WE HAVE A CUSTOM AUDIO SESSION CONFIGURATION, SO IT SHOULDN'T BE CONFIGURED HERE.
+  //
   // Allow audio playback when the Ring/Silent switch is set to silent
-  [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  // [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
 
   [self.playersByTextureId
       enumerateKeysAndObjectsUsingBlock:^(NSNumber *textureId, FLTVideoPlayer *player, BOOL *stop) {
@@ -649,13 +651,15 @@ NS_INLINE UIViewController *rootViewController() {
 
 - (void)setMixWithOthers:(FLTMixWithOthersMessage *)input
                    error:(FlutterError *_Nullable __autoreleasing *)error {
-  if (input.mixWithOthers.boolValue) {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
-                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
-                                           error:nil];
-  } else {
-    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
-  }
+  // WE HAVE A CUSTOM AUDIO SESSION CONFIGURATION, SO IT SHOULDN'T BE CONFIGURED HERE.
+  //
+  //  if (input.mixWithOthers.boolValue) {
+  //    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback
+  //                                     withOptions:AVAudioSessionCategoryOptionMixWithOthers
+  //                                           error:nil];
+  //  } else {
+  //    [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
+  //  }
 }
 
 @end


### PR DESCRIPTION
We have a custom AudioSession configuration, so it shouldn't be set on video_player.