### PR TITLE
[camera] Interface method to allow concurrent recording and streaming of video

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0
 
-* Add new capture method for a camera to allow concurrent streaming and recording.
+* Adds new capture method for a camera to allow concurrent streaming and recording.
 
 ## 2.2.2
 

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+* Add new capture method for a camera to allow concurrent streaming and recording.
+
 ## 2.2.2
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
+++ b/packages/camera/camera_platform_interface/lib/src/platform_interface/camera_platform.dart
@@ -11,6 +11,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../../camera_platform_interface.dart';
 import '../method_channel/method_channel_camera.dart';
+import '../types/video_capture_options.dart';
 
 /// The interface that implementations of camera must implement.
 ///
@@ -131,8 +132,19 @@ abstract class CameraPlatform extends PlatformInterface {
   /// meaning the recording will continue until manually stopped.
   /// With [maxVideoDuration] set the video is returned in a [VideoRecordedEvent]
   /// through the [onVideoRecordedEvent] stream when the set duration is reached.
+  ///
+  /// This method is deprecated in favour of [startVideoCapturing].
   Future<void> startVideoRecording(int cameraId, {Duration? maxVideoDuration}) {
     throw UnimplementedError('startVideoRecording() is not implemented.');
+  }
+
+  /// Starts a video recording and/or streaming session.
+  ///
+  /// Please see [VideoCaptureOptions] for documentation on the
+  /// configuration options.
+  Future<void> startVideoCapturing(VideoCaptureOptions options) {
+    return startVideoRecording(options.cameraId,
+        maxVideoDuration: options.maxDuration);
   }
 
   /// Stops the video recording and returns the file where it was saved.

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -1,0 +1,52 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'camera_image_data.dart';
+
+/// Options wrapper for [CameraPlatform.startVideoCapturing] parameters.
+@immutable
+class VideoCaptureOptions {
+  /// Constructs a new instance.
+  const VideoCaptureOptions(
+    this.cameraId, {
+    this.maxDuration,
+    this.streamCallback,
+    this.streamOptions,
+  });
+
+  /// The ID of the camera to use for capturing.
+  final int cameraId;
+
+  /// The maximum time to perform capturing for.
+  /// By default there is no maximum on the capture time.
+  final Duration? maxDuration;
+
+  /// An optional callback to enable streaming.
+  /// If set, then each image captured by the camera will be
+  /// passed to this callback.
+  final Function(CameraImageData image)? streamCallback;
+
+  /// Configuration options for streaming.
+  /// Should only be set if a streamCallback is also present.
+  final CameraImageStreamOptions? streamOptions;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VideoCaptureOptions &&
+          runtimeType == other.runtimeType &&
+          cameraId == other.cameraId &&
+          maxDuration == other.maxDuration &&
+          streamCallback == other.streamCallback &&
+          streamOptions == other.streamOptions;
+
+  @override
+  int get hashCode =>
+      cameraId.hashCode ^
+      maxDuration.hashCode ^
+      streamCallback.hashCode ^
+      streamOptions.hashCode;
+}

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -10,17 +10,15 @@ import 'camera_image_data.dart';
 @immutable
 class VideoCaptureOptions {
   /// Constructs a new instance.
-  VideoCaptureOptions(
+  const VideoCaptureOptions(
     this.cameraId, {
     this.maxDuration,
     this.streamCallback,
     this.streamOptions,
-  }) {
-    if (streamOptions != null && streamCallback == null) {
-      throw ArgumentError(
-          'Must specify streamCallback if providing streamOptions');
-    }
-  }
+  }) : assert(
+          streamOptions == null || streamCallback != null,
+          'Must specify streamCallback if providing streamOptions.',
+        );
 
   /// The ID of the camera to use for capturing.
   final int cameraId;

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -17,7 +17,8 @@ class VideoCaptureOptions {
     this.streamOptions,
   }) {
     if (streamOptions != null && streamCallback == null) {
-      throw ArgumentError('Must specify streamCallback if providing streamOptions');
+      throw ArgumentError(
+          'Must specify streamCallback if providing streamOptions');
     }
   }
 

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -21,6 +21,7 @@ class VideoCaptureOptions {
   final int cameraId;
 
   /// The maximum time to perform capturing for.
+  ///
   /// By default there is no maximum on the capture time.
   final Duration? maxDuration;
 
@@ -45,8 +46,5 @@ class VideoCaptureOptions {
 
   @override
   int get hashCode =>
-      cameraId.hashCode ^
-      maxDuration.hashCode ^
-      streamCallback.hashCode ^
-      streamOptions.hashCode;
+      Object.hash(cameraId, maxDuration, streamCallback, streamOptions);
 }

--- a/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/video_capture_options.dart
@@ -10,12 +10,16 @@ import 'camera_image_data.dart';
 @immutable
 class VideoCaptureOptions {
   /// Constructs a new instance.
-  const VideoCaptureOptions(
+  VideoCaptureOptions(
     this.cameraId, {
     this.maxDuration,
     this.streamCallback,
     this.streamOptions,
-  });
+  }) {
+    if (streamOptions != null && streamCallback == null) {
+      throw ArgumentError('Must specify streamCallback if providing streamOptions');
+    }
+  }
 
   /// The ID of the camera to use for capturing.
   final int cameraId;
@@ -26,11 +30,13 @@ class VideoCaptureOptions {
   final Duration? maxDuration;
 
   /// An optional callback to enable streaming.
+  ///
   /// If set, then each image captured by the camera will be
   /// passed to this callback.
   final Function(CameraImageData image)? streamCallback;
 
   /// Configuration options for streaming.
+  ///
   /// Should only be set if a streamCallback is also present.
   final CameraImageStreamOptions? streamOptions;
 

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.2
+version: 2.3.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
This has been factored out of https://github.com/flutter/plugins/pull/6290 to isolate the interface changes. They are not wired up yet, as per the instructions at https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-platform-interface-method-parameters. I created a separate options object to make the interface easier to work with. I chose `startVideoCapturing` as a more generic method name that can be applied to both recording and streaming.

Related to https://github.com/flutter/flutter/issues/83634

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
