### PR TITLE
[tool] Fix version mistake in CHANGELOG

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.0
+## 0.12.0
 
 * Changes the behavior of `--packages-for-branch` on main/master to run for
   packages changed in the last commit, rather than running for all packages.
@@ -6,7 +6,7 @@
   tested in presubmit.
 * Adds a `fix` command to run `dart fix --apply` in target packages.
 
-## 0.11
+## 0.11.0
 
 * Renames `publish-plugin` to `publish`.
 * Renames arguments to `list`:


### PR DESCRIPTION
The last two versions in the CHANGELOG had typos (0.11 not following the full version format, and 0.12 being listed as 12.0). This fixes them prior to publishing.