### PR TITLE
[google_maps_flutter] Cloud-based map styling support

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 2.4.0
-
-* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
-
 ## 2.3.0
 
+* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.2.3

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,4 +1,8 @@
-## NEXT
+## 2.4.0
+
+* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
+
+## 2.3.0
 
 * Updates minimum Flutter version to 3.0.
 

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -58,6 +58,10 @@ The Android implementation supports multiple
 [platform view display modes](https://flutter.dev/docs/development/platform-integration/platform-views).
 For details, see [the Android README](https://pub.dev/packages/google_maps_flutter_android#display-mode).
 
+#### Cloud-based map styling
+Cloud-based map styling works on Android platform only if `AndroidMapRenderer.latest` has been initialized.
+For details, see [the Android README](https://pub.dev/packages/google_maps_flutter_android#map-renderer).
+
 ### iOS
 
 To set up, specify your API key in the application delegate `ios/Runner/AppDelegate.m`:

--- a/packages/google_maps_flutter/google_maps_flutter/README.md
+++ b/packages/google_maps_flutter/google_maps_flutter/README.md
@@ -59,7 +59,7 @@ The Android implementation supports multiple
 For details, see [the Android README](https://pub.dev/packages/google_maps_flutter_android#display-mode).
 
 #### Cloud-based map styling
-Cloud-based map styling works on Android platform only if `AndroidMapRenderer.latest` has been initialized.
+Cloud-based map styling works on Android platform only if `AndroidMapRenderer.latest` map renderer has been initialized.
 For details, see [the Android README](https://pub.dev/packages/google_maps_flutter_android#map-renderer).
 
 ### iOS

--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -17,7 +17,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
-const String _kCloudMapId = '8e0a97af9386fef';
+const String _kCloudMapId = '000000000000000'; // Dummy map ID.
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/integration_test/google_maps_test.dart
@@ -17,6 +17,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
+const String _kCloudMapId = '8e0a97af9386fef';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -1159,6 +1160,32 @@ void main() {
           await inspector.getTileOverlayInfo(tileOverlay1.mapsId, mapId: mapId);
 
       expect(tileOverlayInfo1, isNull);
+    },
+  );
+
+  testWidgets(
+    'testCloudMapId',
+    (WidgetTester tester) async {
+      final Completer<int> mapIdCompleter = Completer<int>();
+      final Key key = GlobalKey();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: GoogleMap(
+            key: key,
+            initialCameraPosition: _kInitialCameraPosition,
+            onMapCreated: (GoogleMapController controller) {
+              mapIdCompleter.complete(controller.mapId);
+            },
+            cloudMapId: _kCloudMapId,
+          ),
+        ),
+      );
+
+      // Await mapIdCompleter to finish to make sure map can be created with styledMapId
+      // Styled map
+      await mapIdCompleter.future;
     },
   );
 }

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/main.dart
@@ -10,6 +10,7 @@ import 'animate_camera.dart';
 import 'lite_mode.dart';
 import 'map_click.dart';
 import 'map_coordinates.dart';
+import 'map_map_id.dart';
 import 'map_ui.dart';
 import 'marker_icons.dart';
 import 'move_camera.dart';
@@ -39,6 +40,7 @@ final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
   const SnapshotPage(),
   const LiteModePage(),
   const TileOverlayPage(),
+  const MapIdPage(),
 ];
 
 /// MapsDemo is the Main Application.

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
@@ -4,13 +4,12 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
-import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'main.dart';
 import 'page.dart';
 
 class MapIdPage extends GoogleMapExampleAppPage {
@@ -42,7 +41,7 @@ class MapIdBodyState extends State<MapIdBody> {
 
   @override
   void initState() {
-    _initializeMapRenderer()
+    initializeMapRenderer()
         .then<void>((AndroidMapRenderer? initializedRenderer) => setState(() {
               _initializedRenderer = initializedRenderer;
             }));
@@ -56,7 +55,7 @@ class MapIdBodyState extends State<MapIdBody> {
       case AndroidMapRenderer.legacy:
         return 'legacy';
       default:
-        return 'initializing';
+        return 'unknown';
     }
   }
 
@@ -141,24 +140,4 @@ class MapIdBodyState extends State<MapIdBody> {
       controller = controllerParam;
     });
   }
-}
-
-Completer<AndroidMapRenderer?>? _initializedRendererCompleter;
-Future<AndroidMapRenderer?> _initializeMapRenderer() async {
-  if (_initializedRendererCompleter != null) {
-    return _initializedRendererCompleter!.future;
-  }
-
-  _initializedRendererCompleter = Completer<AndroidMapRenderer?>();
-  final GoogleMapsFlutterPlatform mapsImplementation =
-      GoogleMapsFlutterPlatform.instance;
-  if (mapsImplementation is GoogleMapsFlutterAndroid) {
-    mapsImplementation.initializeWithRenderer(AndroidMapRenderer.latest).then(
-        (AndroidMapRenderer initializedRenderer) =>
-            _initializedRendererCompleter!.complete(initializedRenderer));
-  } else {
-    _initializedRendererCompleter!.complete(null);
-  }
-
-  return _initializedRendererCompleter!.future;
 }

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
@@ -1,0 +1,164 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+import 'page.dart';
+
+class MapIdPage extends GoogleMapExampleAppPage {
+  const MapIdPage({Key? key})
+      : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MapIdBody();
+  }
+}
+
+class MapIdBody extends StatefulWidget {
+  const MapIdBody({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => MapIdBodyState();
+}
+
+const LatLng _kMapCenter = LatLng(52.4478, -3.5402);
+
+class MapIdBodyState extends State<MapIdBody> {
+  GoogleMapController? controller;
+
+  Key _key = const Key('mapId#');
+  String? _mapId;
+  final TextEditingController _mapIdController = TextEditingController();
+  AndroidMapRenderer? _initializedRenderer;
+
+  @override
+  void initState() {
+    _initializeMapRenderer()
+        .then<void>((AndroidMapRenderer? initializedRenderer) => setState(() {
+              _initializedRenderer = initializedRenderer;
+            }));
+    super.initState();
+  }
+
+  String _getInitializedsRendererType() {
+    switch (_initializedRenderer) {
+      case AndroidMapRenderer.latest:
+        return 'latest';
+      case AndroidMapRenderer.legacy:
+        return 'legacy';
+      default:
+        return 'initializing';
+    }
+  }
+
+  void _setMapId() {
+    setState(() {
+      _mapId = _mapIdController.text;
+
+      // Change key to initialize new map instance for new mapId.
+      _key = Key(_mapId ?? 'mapId#');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final GoogleMap googleMap = GoogleMap(
+        onMapCreated: _onMapCreated,
+        initialCameraPosition: const CameraPosition(
+          target: _kMapCenter,
+          zoom: 7.0,
+        ),
+        key: _key,
+        cloudMapId: _mapId);
+
+    final List<Widget> columnChildren = <Widget>[
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Center(
+          child: SizedBox(
+            width: 300.0,
+            height: 200.0,
+            child: googleMap,
+          ),
+        ),
+      ),
+      Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: TextField(
+            controller: _mapIdController,
+            decoration: const InputDecoration(
+              hintText: 'Map Id',
+            ),
+          )),
+      Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: ElevatedButton(
+            onPressed: () => _setMapId(),
+            child: const Text(
+              'Press to use specified map Id',
+            ),
+          )),
+      if (Platform.isAndroid)
+        Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: Text(
+              'On Android, Cloud-based maps styling only works with "latest" renderer.\n\n'
+              'Current initialized renderer is "${_getInitializedsRendererType()}".'),
+        ),
+      if (Platform.isIOS)
+        const Padding(
+          padding: EdgeInsets.all(10.0),
+          child:
+              Text('On iOS, cloud based map styling works only if iOS platform '
+                  'version 12 or above is targeted in project Podfile. '
+                  "Run command 'pod update GoogleMaps' to update plugin"),
+        )
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: columnChildren,
+    );
+  }
+
+  @override
+  void dispose() {
+    _mapIdController.dispose();
+    super.dispose();
+  }
+
+  void _onMapCreated(GoogleMapController controllerParam) {
+    setState(() {
+      controller = controllerParam;
+    });
+  }
+}
+
+Completer<AndroidMapRenderer?>? _initializedRendererCompleter;
+Future<AndroidMapRenderer?> _initializeMapRenderer() async {
+  if (_initializedRendererCompleter != null) {
+    return _initializedRendererCompleter!.future;
+  }
+
+  _initializedRendererCompleter = Completer<AndroidMapRenderer?>();
+  final GoogleMapsFlutterPlatform mapsImplementation =
+      GoogleMapsFlutterPlatform.instance;
+  if (mapsImplementation is GoogleMapsFlutterAndroid) {
+    mapsImplementation.initializeWithRenderer(AndroidMapRenderer.latest).then(
+        (AndroidMapRenderer initializedRenderer) =>
+            _initializedRendererCompleter!.complete(initializedRenderer));
+  } else {
+    _initializedRendererCompleter!.complete(null);
+  }
+
+  return _initializedRendererCompleter!.future;
+}

--- a/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/example/lib/map_map_id.dart
@@ -54,9 +54,11 @@ class MapIdBodyState extends State<MapIdBody> {
         return 'latest';
       case AndroidMapRenderer.legacy:
         return 'legacy';
-      default:
-        return 'unknown';
+      case AndroidMapRenderer.platformDefault:
+      case null:
+        break;
     }
+    return 'unknown';
   }
 
   void _setMapId() {

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
   google_maps_flutter_android: ^2.1.10
-  google_maps_flutter_ios: ^2.1.10
   google_maps_flutter_platform_interface: ^2.2.1
 
 dev_dependencies:

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
   google_maps_flutter_android: ^2.1.10
+  google_maps_flutter_ios: ^2.1.10
   google_maps_flutter_platform_interface: ^2.2.1
 
 dev_dependencies:
@@ -35,3 +36,15 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter:
+    path: ../../../google_maps_flutter/google_maps_flutter
+  google_maps_flutter_android:
+    path: ../../../google_maps_flutter/google_maps_flutter_android
+  google_maps_flutter_ios:
+    path: ../../../google_maps_flutter/google_maps_flutter_ios
+  google_maps_flutter_platform_interface:
+    path: ../../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -123,6 +123,7 @@ class GoogleMap extends StatefulWidget {
     this.onCameraIdle,
     this.onTap,
     this.onLongPress,
+    this.cloudMapId,
   })  : assert(initialCameraPosition != null),
         super(key: key);
 
@@ -282,6 +283,12 @@ class GoogleMap extends StatefulWidget {
   /// When this set is empty, the map will only handle pointer events for gestures that
   /// were not claimed by any other gesture recognizer.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
+
+  /// Identifier that's associated with a specific cloud bases map style.
+  ///
+  /// See https://developers.google.com/maps/documentation/get-map-id
+  /// for more details.
+  final String? cloudMapId;
 
   /// Creates a [State] for this [GoogleMap].
   @override
@@ -553,5 +560,6 @@ MapConfiguration _configurationFromMapWidget(GoogleMap map) {
     indoorViewEnabled: map.indoorViewEnabled,
     trafficEnabled: map.trafficEnabled,
     buildingsEnabled: map.buildingsEnabled,
+    cloudMapId: map.cloudMapId,
   );
 }

--- a/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/lib/src/google_map.dart
@@ -284,7 +284,7 @@ class GoogleMap extends StatefulWidget {
   /// were not claimed by any other gesture recognizer.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
-  /// Identifier that's associated with a specific cloud bases map style.
+  /// Identifier that's associated with a specific cloud-based map style.
   ///
   /// See https://developers.google.com/maps/documentation/get-map-id
   /// for more details.

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.2.3
+version: 2.4.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -20,7 +20,6 @@ dependencies:
   flutter:
     sdk: flutter
   google_maps_flutter_android: ^2.1.10
-  google_maps_flutter_ios: ^2.1.10
   google_maps_flutter_platform_interface: ^2.2.1
 
 dev_dependencies:
@@ -28,3 +27,13 @@ dev_dependencies:
     sdk: flutter
   plugin_platform_interface: ^2.0.0
   stream_transform: ^2.0.0
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_android:
+    path: ../../google_maps_flutter/google_maps_flutter_android
+  google_maps_flutter_ios:
+    path: ../../google_maps_flutter/google_maps_flutter_ios
+  google_maps_flutter_platform_interface:
+    path: ../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter
 description: A Flutter plugin for integrating Google Maps in iOS and Android applications.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.4.0
+version: 2.3.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.5.0
 
+* Adds implementation for `cloudMapId` parameter to support cloud-based map styling.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.4.3

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/Convert.java
@@ -376,6 +376,10 @@ class Convert {
     if (buildingsEnabled != null) {
       sink.setBuildingsEnabled(toBoolean(buildingsEnabled));
     }
+    final Object cloudMapId = data.get("cloudMapId");
+    if (buildingsEnabled != null) {
+      sink.setMapId(toString(cloudMapId));
+    }
   }
 
   /** Returns the dartMarkerId of the interpreted marker. */

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapBuilder.java
@@ -174,4 +174,9 @@ class GoogleMapBuilder implements GoogleMapOptionsSink {
   public void setInitialTileOverlays(List<Map<String, ?>> initialTileOverlays) {
     this.initialTileOverlays = initialTileOverlays;
   }
+
+  @Override
+  public void setMapId(String mapId) {
+    options.mapId(mapId);
+  }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapController.java
@@ -848,6 +848,11 @@ final class GoogleMapController
     }
   }
 
+  @Override
+  public void setMapId(String mapId) {
+    Log.e(TAG, "Cannot change MapId after map is initialized.");
+  }
+
   private void updateInitialTileOverlays() {
     tileOverlaysController.addTileOverlays(initialTileOverlays);
   }

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/GoogleMapOptionsSink.java
@@ -55,4 +55,6 @@ interface GoogleMapOptionsSink {
   void setInitialCircles(Object initialCircles);
 
   void setInitialTileOverlays(List<Map<String, ?>> initialTileOverlays);
+
+  void setMapId(String mapId);
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -17,6 +17,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
+const String _kCloudMapId = '8e0a97af9386fef';
 
 void googleMapsTests() {
   GoogleMapsFlutterPlatform.instance.enableDebugInspection();
@@ -1176,6 +1177,32 @@ void googleMapsTests() {
           await inspector.getTileOverlayInfo(tileOverlay1.mapsId, mapId: mapId);
 
       expect(tileOverlayInfo1, isNull);
+    },
+  );
+
+  testWidgets(
+    'testCloudMapId',
+    (WidgetTester tester) async {
+      final Completer<int> mapIdCompleter = Completer<int>();
+      final Key key = GlobalKey();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: ExampleGoogleMap(
+            key: key,
+            initialCameraPosition: _kInitialCameraPosition,
+            onMapCreated: (ExampleGoogleMapController controller) {
+              mapIdCompleter.complete(controller.mapId);
+            },
+            cloudMapId: _kCloudMapId,
+          ),
+        ),
+      );
+
+      // Await mapIdCompleter to finish to make sure map can be created with styledMapId
+      // Styled map
+      await mapIdCompleter.future;
     },
   );
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/integration_test/google_maps_tests.dart
@@ -17,7 +17,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
-const String _kCloudMapId = '8e0a97af9386fef';
+const String _kCloudMapId = '000000000000000'; // Dummy map ID.
 
 void googleMapsTests() {
   GoogleMapsFlutterPlatform.instance.enableDebugInspection();

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/example_google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/example_google_map.dart
@@ -350,7 +350,7 @@ class ExampleGoogleMap extends StatefulWidget {
   /// Which gestures should be consumed by the map.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
-  /// Identifier that's associated with a specific cloud bases map style.
+  /// Identifier that's associated with a specific cloud-based map style.
   ///
   /// See https://developers.google.com/maps/documentation/get-map-id
   /// for more details.

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/example_google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/example_google_map.dart
@@ -247,6 +247,7 @@ class ExampleGoogleMap extends StatefulWidget {
     this.onCameraIdle,
     this.onTap,
     this.onLongPress,
+    this.cloudMapId,
   }) : super(key: key);
 
   /// Callback method for when the map is ready to be used.
@@ -348,6 +349,12 @@ class ExampleGoogleMap extends StatefulWidget {
 
   /// Which gestures should be consumed by the map.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
+
+  /// Identifier that's associated with a specific cloud bases map style.
+  ///
+  /// See https://developers.google.com/maps/documentation/get-map-id
+  /// for more details.
+  final String? cloudMapId;
 
   /// Creates a [State] for this [ExampleGoogleMap].
   @override
@@ -534,5 +541,6 @@ MapConfiguration _configurationFromMapWidget(ExampleGoogleMap map) {
     indoorViewEnabled: map.indoorViewEnabled,
     trafficEnabled: map.trafficEnabled,
     buildingsEnabled: map.buildingsEnabled,
+    cloudMapId: map.cloudMapId,
   );
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/main.dart
@@ -10,6 +10,7 @@ import 'animate_camera.dart';
 import 'lite_mode.dart';
 import 'map_click.dart';
 import 'map_coordinates.dart';
+import 'map_map_id.dart';
 import 'map_ui.dart';
 import 'marker_icons.dart';
 import 'move_camera.dart';
@@ -39,6 +40,7 @@ final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
   const SnapshotPage(),
   const LiteModePage(),
   const TileOverlayPage(),
+  const MapIdPage(),
 ];
 
 /// MapsDemo is the Main Application.

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
@@ -76,5 +78,29 @@ void main() {
   final GoogleMapsFlutterPlatform platform = GoogleMapsFlutterPlatform.instance;
   // Default to Hybrid Composition for the example.
   (platform as GoogleMapsFlutterAndroid).useAndroidViewSurface = true;
+  initializeMapRenderer();
   runApp(const MaterialApp(home: MapsDemo()));
+}
+
+Completer<AndroidMapRenderer?>? _initializedRendererCompleter;
+
+/// Initializes map renderer to with `latest` renderer type.
+/// The renderer must be requested before creating GoogleMap instances,
+/// as the renderer can be initialized only once per application context.
+Future<AndroidMapRenderer?> initializeMapRenderer() async {
+  if (_initializedRendererCompleter != null) {
+    return _initializedRendererCompleter!.future;
+  }
+
+  _initializedRendererCompleter = Completer<AndroidMapRenderer?>();
+
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final GoogleMapsFlutterPlatform platform = GoogleMapsFlutterPlatform.instance;
+  (platform as GoogleMapsFlutterAndroid)
+      .initializeWithRenderer(AndroidMapRenderer.latest)
+      .then((AndroidMapRenderer initializedRenderer) =>
+          _initializedRendererCompleter!.complete(initializedRenderer));
+
+  return _initializedRendererCompleter!.future;
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
@@ -1,0 +1,158 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+import 'example_google_map.dart';
+import 'page.dart';
+
+class MapIdPage extends GoogleMapExampleAppPage {
+  const MapIdPage({Key? key})
+      : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MapIdBody();
+  }
+}
+
+class MapIdBody extends StatefulWidget {
+  const MapIdBody({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => MapIdBodyState();
+}
+
+const LatLng _kMapCenter = LatLng(52.4478, -3.5402);
+
+class MapIdBodyState extends State<MapIdBody> {
+  ExampleGoogleMapController? controller;
+
+  Key _key = const Key('mapId#');
+  String? _mapId;
+  final TextEditingController _mapIdController = TextEditingController();
+  AndroidMapRenderer? _initializedRenderer;
+
+  @override
+  void initState() {
+    _initializeMapRenderer()
+        .then<void>((AndroidMapRenderer? initializedRenderer) => setState(() {
+              _initializedRenderer = initializedRenderer;
+            }));
+    super.initState();
+  }
+
+  String _getInitializedsRendererType() {
+    switch (_initializedRenderer) {
+      case AndroidMapRenderer.latest:
+        return 'latest';
+      case AndroidMapRenderer.legacy:
+        return 'legacy';
+      default:
+        return 'initializing';
+    }
+  }
+
+  void _setMapId() {
+    setState(() {
+      _mapId = _mapIdController.text;
+
+      // Change key to initialize new map instance for new mapId.
+      _key = Key(_mapId ?? 'mapId#');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ExampleGoogleMap googleMap = ExampleGoogleMap(
+      onMapCreated: _onMapCreated,
+      initialCameraPosition: const CameraPosition(
+        target: _kMapCenter,
+        zoom: 7.0,
+      ),
+      key: _key,
+      cloudMapId: _mapId,
+    );
+
+    final List<Widget> columnChildren = <Widget>[
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Center(
+          child: SizedBox(
+            width: 300.0,
+            height: 200.0,
+            child: googleMap,
+          ),
+        ),
+      ),
+      Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: TextField(
+            controller: _mapIdController,
+            decoration: const InputDecoration(
+              hintText: 'Map Id',
+            ),
+          )),
+      Padding(
+          padding: const EdgeInsets.all(10.0),
+          child: ElevatedButton(
+            onPressed: () => _setMapId(),
+            child: const Text(
+              'Press to use specified map Id',
+            ),
+          )),
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Text(
+            'On Android, Cloud-based maps styling only works with "latest" renderer.\n\n'
+            'Current initialized renderer is "${_getInitializedsRendererType()}".'),
+      ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: columnChildren,
+    );
+  }
+
+  @override
+  void dispose() {
+    _mapIdController.dispose();
+    super.dispose();
+  }
+
+  void _onMapCreated(ExampleGoogleMapController controllerParam) {
+    setState(() {
+      controller = controllerParam;
+    });
+  }
+}
+
+Completer<AndroidMapRenderer?>? _initializedRendererCompleter;
+Future<AndroidMapRenderer?> _initializeMapRenderer() async {
+  // Map renderer can be requested only once.
+  // Returns existing copleter future for serial requests.
+  if (_initializedRendererCompleter != null) {
+    return _initializedRendererCompleter!.future;
+  }
+
+  _initializedRendererCompleter = Completer<AndroidMapRenderer?>();
+  final GoogleMapsFlutterPlatform mapsImplementation =
+      GoogleMapsFlutterPlatform.instance;
+  if (mapsImplementation is GoogleMapsFlutterAndroid) {
+    mapsImplementation.initializeWithRenderer(AndroidMapRenderer.latest).then(
+        (AndroidMapRenderer initializedRenderer) =>
+            _initializedRendererCompleter!.complete(initializedRenderer));
+  } else {
+    _initializedRendererCompleter!.complete(null);
+  }
+
+  return _initializedRendererCompleter!.future;
+}

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
@@ -54,9 +54,11 @@ class MapIdBodyState extends State<MapIdBody> {
         return 'latest';
       case AndroidMapRenderer.legacy:
         return 'legacy';
-      default:
-        return 'unknown';
+      case AndroidMapRenderer.platformDefault:
+      case null:
+        break;
     }
+    return 'unknown';
   }
 
   void _setMapId() {

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart
@@ -4,13 +4,12 @@
 
 // ignore_for_file: public_member_api_docs
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter_android/google_maps_flutter_android.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 
 import 'example_google_map.dart';
+import 'main.dart';
 import 'page.dart';
 
 class MapIdPage extends GoogleMapExampleAppPage {
@@ -42,7 +41,7 @@ class MapIdBodyState extends State<MapIdBody> {
 
   @override
   void initState() {
-    _initializeMapRenderer()
+    initializeMapRenderer()
         .then<void>((AndroidMapRenderer? initializedRenderer) => setState(() {
               _initializedRenderer = initializedRenderer;
             }));
@@ -56,7 +55,7 @@ class MapIdBodyState extends State<MapIdBody> {
       case AndroidMapRenderer.legacy:
         return 'legacy';
       default:
-        return 'initializing';
+        return 'unknown';
     }
   }
 
@@ -133,26 +132,4 @@ class MapIdBodyState extends State<MapIdBody> {
       controller = controllerParam;
     });
   }
-}
-
-Completer<AndroidMapRenderer?>? _initializedRendererCompleter;
-Future<AndroidMapRenderer?> _initializeMapRenderer() async {
-  // Map renderer can be requested only once.
-  // Returns existing copleter future for serial requests.
-  if (_initializedRendererCompleter != null) {
-    return _initializedRendererCompleter!.future;
-  }
-
-  _initializedRendererCompleter = Completer<AndroidMapRenderer?>();
-  final GoogleMapsFlutterPlatform mapsImplementation =
-      GoogleMapsFlutterPlatform.instance;
-  if (mapsImplementation is GoogleMapsFlutterAndroid) {
-    mapsImplementation.initializeWithRenderer(AndroidMapRenderer.latest).then(
-        (AndroidMapRenderer initializedRenderer) =>
-            _initializedRendererCompleter!.complete(initializedRenderer));
-  } else {
-    _initializedRendererCompleter!.complete(null);
-  }
-
-  return _initializedRendererCompleter!.future;
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -34,3 +34,11 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_android:
+    path: ../../../google_maps_flutter/google_maps_flutter_android
+  google_maps_flutter_platform_interface:
+    path: ../../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/lib/src/google_maps_flutter_android.dart
@@ -751,6 +751,7 @@ Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
     if (config.trafficEnabled != null) 'trafficEnabled': config.trafficEnabled!,
     if (config.buildingsEnabled != null)
       'buildingsEnabled': config.buildingsEnabled!,
+    if (config.cloudMapId != null) 'cloudMapId': config.cloudMapId!,
   };
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.4.3
+version: 2.5.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -29,3 +29,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.0.0
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_platform_interface:
+    path: ../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,4 +1,8 @@
-## NEXT
+## 2.3.0
+
+* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
+
+## 2.2.0
 
 * Updates minimum Flutter version to 3.0.
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 2.3.0
-
-* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
-
 ## 2.2.0
 
+* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.1.13

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
@@ -16,7 +16,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
-const String _kCloudMapId = '8e0a97af9386fef';
+const String _kCloudMapId = '000000000000000'; // Dummy map ID.
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/integration_test/google_maps_test.dart
@@ -16,6 +16,7 @@ const LatLng _kInitialMapCenter = LatLng(0, 0);
 const double _kInitialZoomLevel = 5;
 const CameraPosition _kInitialCameraPosition =
     CameraPosition(target: _kInitialMapCenter, zoom: _kInitialZoomLevel);
+const String _kCloudMapId = '8e0a97af9386fef';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -1024,6 +1025,19 @@ void main() {
       expect(tileOverlayInfo1, isNull);
     },
   );
+
+  testWidgets('testSetStyleMapId', (WidgetTester tester) async {
+    final Key key = GlobalKey();
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: ExampleGoogleMap(
+        key: key,
+        initialCameraPosition: _kInitialCameraPosition,
+        cloudMapId: _kCloudMapId,
+      ),
+    ));
+  });
 }
 
 class _DebugTileProvider implements TileProvider {

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/example_google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/example_google_map.dart
@@ -350,7 +350,7 @@ class ExampleGoogleMap extends StatefulWidget {
   /// Which gestures should be consumed by the map.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
 
-  /// Identifier that's associated with a specific cloud bases map style.
+  /// Identifier that's associated with a specific cloud-based map style.
   ///
   /// See https://developers.google.com/maps/documentation/get-map-id
   /// for more details.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/example_google_map.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/example_google_map.dart
@@ -247,6 +247,7 @@ class ExampleGoogleMap extends StatefulWidget {
     this.onCameraIdle,
     this.onTap,
     this.onLongPress,
+    this.cloudMapId,
   }) : super(key: key);
 
   /// Callback method for when the map is ready to be used.
@@ -348,6 +349,12 @@ class ExampleGoogleMap extends StatefulWidget {
 
   /// Which gestures should be consumed by the map.
   final Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers;
+
+  /// Identifier that's associated with a specific cloud bases map style.
+  ///
+  /// See https://developers.google.com/maps/documentation/get-map-id
+  /// for more details.
+  final String? cloudMapId;
 
   /// Creates a [State] for this [ExampleGoogleMap].
   @override
@@ -534,5 +541,6 @@ MapConfiguration _configurationFromMapWidget(ExampleGoogleMap map) {
     indoorViewEnabled: map.indoorViewEnabled,
     trafficEnabled: map.trafficEnabled,
     buildingsEnabled: map.buildingsEnabled,
+    cloudMapId: map.cloudMapId,
   );
 }

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/main.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'animate_camera.dart';
 import 'lite_mode.dart';
 import 'map_click.dart';
 import 'map_coordinates.dart';
+import 'map_map_id.dart';
 import 'map_ui.dart';
 import 'marker_icons.dart';
 import 'move_camera.dart';
@@ -37,6 +38,7 @@ final List<GoogleMapExampleAppPage> _allPages = <GoogleMapExampleAppPage>[
   const SnapshotPage(),
   const LiteModePage(),
   const TileOverlayPage(),
+  const MapIdPage(),
 ];
 
 /// MapsDemo is the Main Application.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/map_map_id.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/lib/map_map_id.dart
@@ -1,0 +1,115 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
+
+import 'example_google_map.dart';
+import 'page.dart';
+
+class MapIdPage extends GoogleMapExampleAppPage {
+  const MapIdPage({Key? key})
+      : super(const Icon(Icons.map), 'Cloud-based maps styling', key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return const MapIdBody();
+  }
+}
+
+class MapIdBody extends StatefulWidget {
+  const MapIdBody({Key? key}) : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => MapIdBodyState();
+}
+
+const LatLng _kMapCenter = LatLng(52.4478, -3.5402);
+
+class MapIdBodyState extends State<MapIdBody> {
+  ExampleGoogleMapController? controller;
+
+  Key _key = const Key('mapId#');
+  String? _mapId;
+  final TextEditingController _mapIdController = TextEditingController();
+
+  void _setMapId() {
+    setState(() {
+      _mapId = _mapIdController.text;
+
+      // Change key to initialize new map instance for new mapId.
+      _key = Key(_mapId ?? 'mapId#');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ExampleGoogleMap googleMap = ExampleGoogleMap(
+      onMapCreated: _onMapCreated,
+      initialCameraPosition: const CameraPosition(
+        target: _kMapCenter,
+        zoom: 7.0,
+      ),
+      key: _key,
+      cloudMapId: _mapId,
+    );
+
+    final List<Widget> columnChildren = <Widget>[
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: Center(
+          child: SizedBox(
+            width: 300.0,
+            height: 200.0,
+            child: googleMap,
+          ),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: TextField(
+          controller: _mapIdController,
+          decoration: const InputDecoration(
+            hintText: 'Map Id',
+          ),
+        ),
+      ),
+      Padding(
+        padding: const EdgeInsets.all(10.0),
+        child: ElevatedButton(
+          onPressed: () => _setMapId(),
+          child: const Text(
+            'Press to use specified map Id',
+          ),
+        ),
+      ),
+      const Padding(
+        padding: EdgeInsets.all(10.0),
+        child:
+            Text('On iOS, cloud based map styling works only if iOS platform '
+                'version 12 or above is targeted in project Podfile. '
+                "Run command 'pod update GoogleMaps' to update plugin"),
+      )
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: columnChildren,
+    );
+  }
+
+  @override
+  void dispose() {
+    _mapIdController.dispose();
+    super.dispose();
+  }
+
+  void _onMapCreated(ExampleGoogleMapController controllerParam) {
+    setState(() {
+      controller = controllerParam;
+    });
+  }
+}

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -32,3 +32,11 @@ flutter:
   uses-material-design: true
   assets:
     - assets/
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_ios:
+    path: ../../../google_maps_flutter/google_maps_flutter_ios
+  google_maps_flutter_platform_interface:
+    path: ../../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapController.m
@@ -78,7 +78,19 @@
                     registrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   GMSCameraPosition *camera =
       [FLTGoogleMapJSONConversions cameraPostionFromDictionary:args[@"initialCameraPosition"]];
-  GMSMapView *mapView = [GMSMapView mapWithFrame:frame camera:camera];
+  GMSMapView *mapView;
+
+#if defined(__IPHONE_12_0) && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_12_0
+  if (args[@"options"][@"cloudMapId"]) {
+    GMSMapID *mapID = [GMSMapID mapIDWithIdentifier:args[@"options"][@"cloudMapId"]];
+    mapView = [GMSMapView mapWithFrame:frame mapID:mapID camera:camera];
+  } else {
+    mapView = [GMSMapView mapWithFrame:frame camera:camera];
+  }
+#else
+  mapView = [GMSMapView mapWithFrame:frame camera:camera];
+#endif
+
   return [self initWithMapView:mapView viewIdentifier:viewId arguments:args registrar:registrar];
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/lib/src/google_maps_flutter_ios.dart
@@ -641,6 +641,7 @@ Map<String, Object> _jsonForMapConfiguration(MapConfiguration config) {
     if (config.trafficEnabled != null) 'trafficEnabled': config.trafficEnabled!,
     if (config.buildingsEnabled != null)
       'buildingsEnabled': config.buildingsEnabled!,
+    if (config.cloudMapId != null) 'cloudMapId': config.cloudMapId!,
   };
 }
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.1.13
+version: 2.3.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -27,3 +27,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   plugin_platform_interface: ^2.0.0
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_platform_interface:
+    path: ../../google_maps_flutter/google_maps_flutter_platform_interface

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.3.0
+version: 2.2.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.3.0
 
+* Adds a `cloudMapId` parameter to support cloud-based map styling.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.2.5

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -33,6 +33,7 @@ class MapConfiguration {
     this.indoorViewEnabled,
     this.trafficEnabled,
     this.buildingsEnabled,
+    this.cloudMapId,
   });
 
   /// True if the compass UI should be shown.
@@ -90,6 +91,12 @@ class MapConfiguration {
   /// True if 3D building display should be enabled.
   final bool? buildingsEnabled;
 
+  /// Identifier that's associated with a specific cloud bases map style.
+  ///
+  /// See https://developers.google.com/maps/documentation/get-map-id
+  /// for more details.
+  final String? cloudMapId;
+
   /// Returns a new options object containing only the values of this instance
   /// that are different from [other].
   MapConfiguration diffFrom(MapConfiguration other) {
@@ -143,6 +150,7 @@ class MapConfiguration {
           trafficEnabled != other.trafficEnabled ? trafficEnabled : null,
       buildingsEnabled:
           buildingsEnabled != other.buildingsEnabled ? buildingsEnabled : null,
+      cloudMapId: cloudMapId != other.cloudMapId ? cloudMapId : null,
     );
   }
 
@@ -171,6 +179,7 @@ class MapConfiguration {
       indoorViewEnabled: diff.indoorViewEnabled ?? indoorViewEnabled,
       trafficEnabled: diff.trafficEnabled ?? trafficEnabled,
       buildingsEnabled: diff.buildingsEnabled ?? buildingsEnabled,
+      cloudMapId: diff.cloudMapId ?? cloudMapId,
     );
   }
 
@@ -193,7 +202,8 @@ class MapConfiguration {
       padding == null &&
       indoorViewEnabled == null &&
       trafficEnabled == null &&
-      buildingsEnabled == null;
+      buildingsEnabled == null &&
+      cloudMapId == null;
 
   @override
   bool operator ==(Object other) {
@@ -221,7 +231,8 @@ class MapConfiguration {
         padding == other.padding &&
         indoorViewEnabled == other.indoorViewEnabled &&
         trafficEnabled == other.trafficEnabled &&
-        buildingsEnabled == other.buildingsEnabled;
+        buildingsEnabled == other.buildingsEnabled &&
+        cloudMapId == other.cloudMapId;
   }
 
   @override
@@ -244,5 +255,6 @@ class MapConfiguration {
         indoorViewEnabled,
         trafficEnabled,
         buildingsEnabled,
+        cloudMapId,
       );
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/map_configuration.dart
@@ -91,7 +91,7 @@ class MapConfiguration {
   /// True if 3D building display should be enabled.
   final bool? buildingsEnabled;
 
-  /// Identifier that's associated with a specific cloud bases map style.
+  /// Identifier that's associated with a specific cloud-based map style.
   ///
   /// See https://developers.google.com/maps/documentation/get-map-id
   /// for more details.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_fl
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.2.5
+version: 2.3.0
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.4.1
 
+* Adds implementation for `cloudMapId` parameter to support cloud-based maps styling.
 * Updates minimum Flutter version to 3.0.
 
 ## 0.4.0+5

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
@@ -19,6 +19,7 @@ import 'google_maps_controller_test.mocks.dart';
 // This value is used when comparing long~num, like
 // LatLng values.
 const double _acceptableDelta = 0.0000000001;
+const String _kCloudMapId = '8e0a97af9386fef';
 
 @GenerateMocks(<Type>[], customMocks: <MockSpec<dynamic>>[
   MockSpec<CirclesController>(onMissingStub: OnMissingStub.returnDefault),
@@ -387,6 +388,7 @@ void main() {
               mapConfiguration: const MapConfiguration(
             mapType: MapType.satellite,
             zoomControlsEnabled: true,
+            cloudMapId: _kCloudMapId,
           ));
           controller.debugSetOverrides(
               createMap: (_, gmaps.MapOptions options) {
@@ -399,6 +401,7 @@ void main() {
           expect(capturedOptions, isNotNull);
           expect(capturedOptions!.mapTypeId, gmaps.MapTypeId.SATELLITE);
           expect(capturedOptions!.zoomControl, true);
+          expect(capturedOptions!.mapId, _kCloudMapId);
           expect(capturedOptions!.gestureHandling, 'auto',
               reason:
                   'by default the map handles zoom/pan gestures internally');

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/google_maps_controller_test.dart
@@ -19,7 +19,7 @@ import 'google_maps_controller_test.mocks.dart';
 // This value is used when comparing long~num, like
 // LatLng values.
 const double _acceptableDelta = 0.0000000001;
-const String _kCloudMapId = '8e0a97af9386fef';
+const String _kCloudMapId = '000000000000000'; // Dummy map ID.
 
 @GenerateMocks(<Type>[], customMocks: <MockSpec<dynamic>>[
   MockSpec<CirclesController>(onMissingStub: OnMissingStub.returnDefault),

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -26,3 +26,13 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   mockito: ^5.3.2
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter:
+    path: ../../../google_maps_flutter/google_maps_flutter
+  google_maps_flutter_platform_interface:
+    path: ../../../google_maps_flutter/google_maps_flutter_platform_interface
+  google_maps_flutter_web:
+    path: ../../../google_maps_flutter/google_maps_flutter_web

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -122,6 +122,14 @@ gmaps.MapOptions _applyInitialPosition(
   return options;
 }
 
+gmaps.MapOptions _applyMapId(
+  String? mapId,
+  gmaps.MapOptions options,
+) {
+  options.mapId = mapId;
+  return options;
+}
+
 // The keys we'd expect to see in a serialized MapTypeStyle JSON object.
 final Set<String> _mapStyleKeys = <String>{
   'elementType',

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/google_maps_controller.dart
@@ -160,6 +160,7 @@ class GoogleMapController {
         _lastMapConfiguration, _lastStyles);
     // Initial position can only to be set here!
     options = _applyInitialPosition(_initialCameraPosition, options);
+    options = _applyMapId(_lastMapConfiguration.cloudMapId, options);
 
     // Create the map...
     final gmaps.GMap map = _createMap(_div, options);

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.4.0+5
+version: 0.4.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -33,3 +33,9 @@ dev_dependencies:
 # The example deliberately includes limited-use secrets.
 false_secrets:
   - /example/web/index.html
+
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  google_maps_flutter_platform_interface:
+    path: ../../google_maps_flutter/google_maps_flutter_platform_interface


### PR DESCRIPTION
Adds support for [cloud-based map styling](https://developers.google.com/maps/documentation/cloud-customization/overview).

On Android, cloud-based maps styling works only with the [new (opt-in) renderer](https://developers.google.com/maps/documentation/android-sdk/renderer), and feature to prefer latest renderer via AndroidManifest [meta-data field](https://github.com/CodemateLtd/plugins/blob/google_maps_flutter_map_id_support/packages/google_maps_flutter/google_maps_flutter_android/example/android/app/src/main/AndroidManifest.xml#L15-L17) is added as well. 
New renderer will be rolled as default renderer in future releases of the Google Maps Android SDK. After that this feature can be still used to prefer legacy renderer, or can be obsoleted/removed from the package.

When using a cloud-based map Id, it can only be set during map initialization. Changing the map Id for an existing map instance is not supported. If the developer wants to change the map Id, this is easy to implement by [changing the key of the widget](https://github.com/CodemateLtd/plugins/blob/google_maps_flutter_map_id_support/packages/google_maps_flutter/google_maps_flutter_android/example/lib/map_map_id.dart#L39-L44), in which case the widget is re-initialized with a new map Id.

This is first step of the federated plugin [multi-package PR process](https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changing-federated-plugins)

Resolves flutter/flutter#67631

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
