### PR TITLE
[file_selector] Add getDirectoryPaths method to the file_selector_platform_interface.

### DIFF
--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 2.3.0
+## 2.3.0+1
 
+* Adds `getDirectoriesPaths` method to interface.
 * Replaces `macUTIs` with `uniformTypeIdentifiers`. `macUTIs` is available as an alias, but will be deprecated in a future release.
 
 ## 2.2.0

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 2.3.0+1
+## 2.4.0
 
-* Adds `getDirectoriesPaths` method to the interface.
+* Adds `getDirectoryPaths` method to the interface.
+
+## 2.3.0
+
 * Replaces `macUTIs` with `uniformTypeIdentifiers`. `macUTIs` is available as an alias, but will be deprecated in a future release.
 
 ## 2.2.0

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.0+1
 
-* Adds `getDirectoriesPaths` method to interface.
+* Adds `getDirectoriesPaths` method to the interface.
 * Replaces `macUTIs` with `uniformTypeIdentifiers`. `macUTIs` is available as an alias, but will be deprecated in a future release.
 
 ## 2.2.0

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -93,4 +93,18 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
       },
     );
   }
+
+  /// Gets a list of directories paths from a dialog
+  @override
+  Future<List<String>?> getDirectoriesPaths(
+      {String? initialDirectory, String? confirmButtonText}) async {
+    return _channel.invokeListMethod<String>(
+      'getDirectoriesPaths',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -16,7 +16,6 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
   @visibleForTesting
   MethodChannel get channel => _channel;
 
-  /// Load a file from user's computer and return it as an XFile
   @override
   Future<XFile?> openFile({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -37,7 +36,6 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     return path == null ? null : XFile(path.first);
   }
 
-  /// Load multiple files from user's computer and return it as an XFile
   @override
   Future<List<XFile>> openFiles({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -58,7 +56,6 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     return pathList?.map((String path) => XFile(path)).toList() ?? <XFile>[];
   }
 
-  /// Gets the path from a save dialog
   @override
   Future<String?> getSavePath({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -79,7 +76,6 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     );
   }
 
-  /// Gets a directory path from a dialog
   @override
   Future<String?> getDirectoryPath({
     String? initialDirectory,
@@ -94,17 +90,16 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     );
   }
 
-  /// Gets a list of directories paths from a dialog
   @override
-  Future<List<String>?> getDirectoriesPaths(
+  Future<List<String>> getDirectoryPaths(
       {String? initialDirectory, String? confirmButtonText}) async {
-    return _channel.invokeListMethod<String>(
-      'getDirectoriesPaths',
+    final List<String>? pathList = await _channel.invokeListMethod<String>(
+      'getDirectoryPaths',
       <String, dynamic>{
         'initialDirectory': initialDirectory,
         'confirmButtonText': confirmButtonText,
-        'multiple': true,
       },
     );
+    return pathList ?? <String>[];
   }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -74,4 +74,13 @@ abstract class FileSelectorPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
+
+  /// Open file dialog for loading directories and return multiple directories paths
+  /// Returns `null` if user cancels the operation.
+  Future<List<String?>> getDirectoriesPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) {
+    throw UnimplementedError('getDirectoriesPaths() has not been implemented.');
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -77,7 +77,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
 
   /// Open file dialog for loading directories and return multiple directories paths
   /// Returns `null` if user cancels the operation.
-  Future<List<String?>> getDirectoriesPaths({
+  Future<List<String>?> getDirectoriesPaths({
     String? initialDirectory,
     String? confirmButtonText,
   }) {

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -36,7 +36,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  /// Open file dialog for loading files and return a file path
+  /// Opens a file dialog for loading files and returns a file path.
   /// Returns `null` if user cancels the operation.
   Future<XFile?> openFile({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -46,7 +46,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
     throw UnimplementedError('openFile() has not been implemented.');
   }
 
-  /// Open file dialog for loading files and return a list of file paths
+  /// Opens a file dialog for loading files and returns a list of file paths.
   Future<List<XFile>> openFiles({
     List<XTypeGroup>? acceptedTypeGroups,
     String? initialDirectory,
@@ -55,7 +55,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
     throw UnimplementedError('openFiles() has not been implemented.');
   }
 
-  /// Open file dialog for saving files and return a file path at which to save
+  /// Opens a file dialog for saving files and returns a file path at which to save.
   /// Returns `null` if user cancels the operation.
   Future<String?> getSavePath({
     List<XTypeGroup>? acceptedTypeGroups,
@@ -66,7 +66,7 @@ abstract class FileSelectorPlatform extends PlatformInterface {
     throw UnimplementedError('getSavePath() has not been implemented.');
   }
 
-  /// Open file dialog for loading directories and return a directory path
+  /// Opens a file dialog for loading directories and returns a directory path.
   /// Returns `null` if user cancels the operation.
   Future<String?> getDirectoryPath({
     String? initialDirectory,
@@ -75,12 +75,11 @@ abstract class FileSelectorPlatform extends PlatformInterface {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
 
-  /// Open file dialog for loading directories and return multiple directories paths
-  /// Returns `null` if user cancels the operation.
-  Future<List<String>?> getDirectoriesPaths({
+  /// Opens a file dialog for loading directories and returns multiple directory paths.
+  Future<List<String>> getDirectoryPaths({
     String? initialDirectory,
     String? confirmButtonText,
   }) {
-    throw UnimplementedError('getDirectoriesPaths() has not been implemented.');
+    throw UnimplementedError('getDirectoryPaths() has not been implemented.');
   }
 }

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.3.0+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0+1
+version: 2.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
@@ -22,10 +22,10 @@ void main() {
 
   group('#GetDirectoryPaths', () {
     test('Should throw unimplemented exception', () async {
-      final FileSelectorPlatform sut = ExtendsFileSelectorPlatform();
+      final FileSelectorPlatform fileSelector = ExtendsFileSelectorPlatform();
 
       await expectLater(() async {
-        return sut.getDirectoryPaths();
+        return fileSelector.getDirectoryPaths();
       }, throwsA(isA<UnimplementedError>()));
     });
   });

--- a/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/file_selector_platform_interface_test.dart
@@ -19,6 +19,16 @@ void main() {
       FileSelectorPlatform.instance = ExtendsFileSelectorPlatform();
     });
   });
+
+  group('#GetDirectoryPaths', () {
+    test('Should throw unimplemented exception', () async {
+      final FileSelectorPlatform sut = ExtendsFileSelectorPlatform();
+
+      await expectLater(() async {
+        return sut.getDirectoryPaths();
+      }, throwsA(isA<UnimplementedError>()));
+    });
+  });
 }
 
 class ExtendsFileSelectorPlatform extends FileSelectorPlatform {}

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -247,6 +247,37 @@ void main() {
           );
         });
       });
+      group('#getDirectoriesPaths', () {
+        test('passes initialDirectory correctly', () async {
+          await plugin.getDirectoriesPaths(
+              initialDirectory: '/example/directory');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+                'initialDirectory': '/example/directory',
+                'confirmButtonText': null,
+                'multiple': true
+              }),
+            ],
+          );
+        });
+        test('passes confirmButtonText correctly', () async {
+          await plugin.getDirectoriesPaths(confirmButtonText: 'Open File');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
+                'initialDirectory': null,
+                'confirmButtonText': 'Open File',
+                'multiple': true
+              }),
+            ],
+          );
+        });
+      });
     });
   });
 }

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -219,64 +219,62 @@ void main() {
           ],
         );
       });
-      group('#getDirectoryPath', () {
-        test('passes initialDirectory correctly', () async {
-          await plugin.getDirectoryPath(initialDirectory: '/example/directory');
+    });
+    group('#getDirectoryPath', () {
+      test('passes initialDirectory correctly', () async {
+        await plugin.getDirectoryPath(initialDirectory: '/example/directory');
 
-          expect(
-            log,
-            <Matcher>[
-              isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-                'initialDirectory': '/example/directory',
-                'confirmButtonText': null,
-              }),
-            ],
-          );
-        });
-        test('passes confirmButtonText correctly', () async {
-          await plugin.getDirectoryPath(confirmButtonText: 'Open File');
-
-          expect(
-            log,
-            <Matcher>[
-              isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-                'initialDirectory': null,
-                'confirmButtonText': 'Open File',
-              }),
-            ],
-          );
-        });
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+              'initialDirectory': '/example/directory',
+              'confirmButtonText': null,
+            }),
+          ],
+        );
       });
-      group('#getDirectoriesPaths', () {
-        test('passes initialDirectory correctly', () async {
-          await plugin.getDirectoriesPaths(
-              initialDirectory: '/example/directory');
+      test('passes confirmButtonText correctly', () async {
+        await plugin.getDirectoryPath(confirmButtonText: 'Select Folder');
 
-          expect(
-            log,
-            <Matcher>[
-              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
-                'initialDirectory': '/example/directory',
-                'confirmButtonText': null,
-                'multiple': true
-              }),
-            ],
-          );
-        });
-        test('passes confirmButtonText correctly', () async {
-          await plugin.getDirectoriesPaths(confirmButtonText: 'Open File');
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+              'initialDirectory': null,
+              'confirmButtonText': 'Select Folder',
+            }),
+          ],
+        );
+      });
+    });
+    group('#getDirectoryPaths', () {
+      test('passes initialDirectory correctly', () async {
+        await plugin.getDirectoryPaths(initialDirectory: '/example/directory');
 
-          expect(
-            log,
-            <Matcher>[
-              isMethodCall('getDirectoriesPaths', arguments: <String, dynamic>{
-                'initialDirectory': null,
-                'confirmButtonText': 'Open File',
-                'multiple': true
-              }),
-            ],
-          );
-        });
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
+              'initialDirectory': '/example/directory',
+              'confirmButtonText': null,
+            }),
+          ],
+        );
+      });
+      test('passes confirmButtonText correctly', () async {
+        await plugin.getDirectoryPaths(
+            confirmButtonText: 'Select one or more Folders');
+
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
+              'initialDirectory': null,
+              'confirmButtonText': 'Select one or more Folders',
+            }),
+          ],
+        );
       });
     });
   });

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -43,49 +43,46 @@ void main() {
         await plugin
             .openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': <Map<String, dynamic>>[
-                group.toJSON(),
-                groupTwo.toJSON()
-              ],
-              'initialDirectory': null,
-              'confirmButtonText': null,
-              'multiple': false,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': false,
+          },
         );
       });
       test('passes initialDirectory correctly', () async {
         await plugin.openFile(initialDirectory: '/example/directory');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': '/example/directory',
-              'confirmButtonText': null,
-              'multiple': false,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': false,
+          },
         );
       });
       test('passes confirmButtonText correctly', () async {
         await plugin.openFile(confirmButtonText: 'Open File');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': null,
-              'confirmButtonText': 'Open File',
-              'multiple': false,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+            'multiple': false,
+          },
         );
       });
     });
@@ -108,49 +105,46 @@ void main() {
         await plugin
             .openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': <Map<String, dynamic>>[
-                group.toJSON(),
-                groupTwo.toJSON()
-              ],
-              'initialDirectory': null,
-              'confirmButtonText': null,
-              'multiple': true,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true,
+          },
         );
       });
       test('passes initialDirectory correctly', () async {
         await plugin.openFiles(initialDirectory: '/example/directory');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': '/example/directory',
-              'confirmButtonText': null,
-              'multiple': true,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true,
+          },
         );
       });
       test('passes confirmButtonText correctly', () async {
         await plugin.openFiles(confirmButtonText: 'Open File');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('openFile', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': null,
-              'confirmButtonText': 'Open File',
-              'multiple': true,
-            }),
-          ],
+          'openFile',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'confirmButtonText': 'Open File',
+            'multiple': true,
+          },
         );
       });
     });
@@ -174,49 +168,46 @@ void main() {
         await plugin
             .getSavePath(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getSavePath', arguments: <String, dynamic>{
-              'acceptedTypeGroups': <Map<String, dynamic>>[
-                group.toJSON(),
-                groupTwo.toJSON()
-              ],
-              'initialDirectory': null,
-              'suggestedName': null,
-              'confirmButtonText': null,
-            }),
-          ],
+          'getSavePath',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': <Map<String, dynamic>>[
+              group.toJSON(),
+              groupTwo.toJSON()
+            ],
+            'initialDirectory': null,
+            'suggestedName': null,
+            'confirmButtonText': null,
+          },
         );
       });
       test('passes initialDirectory correctly', () async {
         await plugin.getSavePath(initialDirectory: '/example/directory');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getSavePath', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': '/example/directory',
-              'suggestedName': null,
-              'confirmButtonText': null,
-            }),
-          ],
+          'getSavePath',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': '/example/directory',
+            'suggestedName': null,
+            'confirmButtonText': null,
+          },
         );
       });
       test('passes confirmButtonText correctly', () async {
         await plugin.getSavePath(confirmButtonText: 'Open File');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getSavePath', arguments: <String, dynamic>{
-              'acceptedTypeGroups': null,
-              'initialDirectory': null,
-              'suggestedName': null,
-              'confirmButtonText': 'Open File',
-            }),
-          ],
+          'getSavePath',
+          arguments: <String, dynamic>{
+            'acceptedTypeGroups': null,
+            'initialDirectory': null,
+            'suggestedName': null,
+            'confirmButtonText': 'Open File',
+          },
         );
       });
     });
@@ -224,27 +215,25 @@ void main() {
       test('passes initialDirectory correctly', () async {
         await plugin.getDirectoryPath(initialDirectory: '/example/directory');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-              'initialDirectory': '/example/directory',
-              'confirmButtonText': null,
-            }),
-          ],
+          'getDirectoryPath',
+          arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+          },
         );
       });
       test('passes confirmButtonText correctly', () async {
         await plugin.getDirectoryPath(confirmButtonText: 'Select Folder');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-              'initialDirectory': null,
-              'confirmButtonText': 'Select Folder',
-            }),
-          ],
+          'getDirectoryPath',
+          arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Select Folder',
+          },
         );
       });
     });
@@ -252,30 +241,36 @@ void main() {
       test('passes initialDirectory correctly', () async {
         await plugin.getDirectoryPaths(initialDirectory: '/example/directory');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
-              'initialDirectory': '/example/directory',
-              'confirmButtonText': null,
-            }),
-          ],
+          'getDirectoryPaths',
+          arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+          },
         );
       });
       test('passes confirmButtonText correctly', () async {
         await plugin.getDirectoryPaths(
             confirmButtonText: 'Select one or more Folders');
 
-        expect(
+        expectMethodCall(
           log,
-          <Matcher>[
-            isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
-              'initialDirectory': null,
-              'confirmButtonText': 'Select one or more Folders',
-            }),
-          ],
+          'getDirectoryPaths',
+          arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Select one or more Folders',
+          },
         );
       });
     });
   });
+}
+
+void expectMethodCall(
+  List<MethodCall> log,
+  String methodName, {
+  Map<String, dynamic>? arguments,
+}) {
+  expect(log, <Matcher>[isMethodCall(methodName, arguments: arguments)]);
 }


### PR DESCRIPTION
This PR adds the implementation of the method `getDirectoryPaths` to the `file_selector_platform_interface`.

Next, we will proceed this way:
1. Add implementations for Windows, macOS and Linux in parallel. (The Windows implementation will be done when the [Dart migration](https://github.com/flutter/plugins/pull/6568) is ready)
2. Add the new published version to the file_selector package with its example when at least one platform is published.
3. Repeat 2 when the other new implementations are published.

Issue:
[Support for selection of multiple directories, through desktop's native open panel, in 'file_selector' package #74323](https://github.com/flutter/flutter/issues/74323)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
