### PR TITLE
[file_selector] Add getDirectoryPaths implementation on macOS

### DIFF
--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+4
+
+* Adds `getDirectoryPaths` implementation.
+
 ## 0.9.0+3
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.0+4
+## 0.9.1
 
 * Adds `getDirectoryPaths` implementation.
 

--- a/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
@@ -17,17 +17,14 @@ class GetMultipleDirectoriesPage extends StatelessWidget {
         await FileSelectorPlatform.instance.getDirectoryPaths(
       confirmButtonText: confirmButtonText,
     );
-    if (directoriesPaths == null || directoriesPaths.isEmpty) {
+    if (directoriesPaths.isEmpty) {
       // Operation was canceled by the user.
       return;
     }
-    String paths = '';
-    for (final String? path in directoriesPaths) {
-      paths += '${path!} \n';
-    }
     await showDialog<void>(
       context: context,
-      builder: (BuildContext context) => TextDisplay(paths),
+      builder: (BuildContext context) =>
+          TextDisplay(directoriesPaths.join('\n')),
     );
   }
 

--- a/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/get_multiple_directories_page.dart
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector_platform_interface/file_selector_platform_interface.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select one or more directories using `getDirectoryPaths`,
+/// then displays the selected directories in a dialog.
+class GetMultipleDirectoriesPage extends StatelessWidget {
+  /// Default Constructor
+  const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoryPaths(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final List<String> directoriesPaths =
+        await FileSelectorPlatform.instance.getDirectoryPaths(
+      confirmButtonText: confirmButtonText,
+    );
+    if (directoriesPaths == null || directoriesPaths.isEmpty) {
+      // Operation was canceled by the user.
+      return;
+    }
+    String paths = '';
+    for (final String? path in directoriesPaths) {
+      paths += '${path!} \n';
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => TextDisplay(paths),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select multiple directories'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
+              child: const Text(
+                  'Press to ask user to choose multiple directories'),
+              onPressed: () => _getDirectoryPaths(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class TextDisplay extends StatelessWidget {
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoryPath, {Key? key}) : super(key: key);
+
+  /// The path selected in the dialog.
+  final String directoryPath;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Selected Directories'),
+      content: Scrollbar(
+        child: SingleChildScrollView(
+          child: Text(directoryPath),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -55,6 +55,13 @@ class HomePage extends StatelessWidget {
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
+              child: const Text('Open a get multi directories dialog'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/multi-directories'),
+            ),
           ],
         ),
       ),

--- a/packages/file_selector/file_selector_macos/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/home_page.dart
@@ -58,7 +58,7 @@ class HomePage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               style: style,
-              child: const Text('Open a get multi directories dialog'),
+              child: const Text('Open a get directories dialog'),
               onPressed: () =>
                   Navigator.pushNamed(context, '/multi-directories'),
             ),

--- a/packages/file_selector/file_selector_macos/example/lib/main.dart
+++ b/packages/file_selector/file_selector_macos/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
+import 'get_multiple_directories_page.dart';
 import 'home_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
@@ -36,6 +37,8 @@ class MyApp extends StatelessWidget {
         '/open/text': (BuildContext context) => const OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
         '/directory': (BuildContext context) => const GetDirectoryPage(),
+        '/multi-directories': (BuildContext context) =>
+            const GetMultipleDirectoriesPage(),
       },
     );
   }

--- a/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -257,8 +257,7 @@ class exampleTests: XCTestCase {
       XCTAssertTrue(panel.canChooseDirectories)
       // For consistency across platforms, file selection is disabled.
       XCTAssertFalse(panel.canChooseFiles)
-      // The Dart API only allows a single directory to be returned, so users shouldn't be allowed
-      // to select multiple.
+
       XCTAssertFalse(panel.allowsMultipleSelection)
     }
   }
@@ -279,5 +278,46 @@ class exampleTests: XCTestCase {
     wait(for: [called], timeout: 0.5)
     XCTAssertNotNil(panelController.openPanel)
   }
+  
+    func testGetDirectoryMultiple() throws {
+      let panelController = TestPanelController()
+      let plugin = FileSelectorPlugin(
+        viewProvider: TestViewProvider(),
+        panelController: panelController)
 
+    let returnPaths = ["/foo/bar", "/foo/test"]
+      panelController.openURLs = returnPaths.map({ path in URL(fileURLWithPath: path) })
+
+      let called = XCTestExpectation()
+      let call = FlutterMethodCall(methodName: "getDirectoryPath", arguments: ["multiple": true])
+      plugin.handle(call) { result in
+        XCTAssertEqual(result as! [String]?, returnPaths)
+        called.fulfill()
+      }
+
+      wait(for: [called], timeout: 0.5)
+      XCTAssertNotNil(panelController.openPanel)
+      if let panel = panelController.openPanel {
+        XCTAssertTrue(panel.canChooseDirectories)
+        XCTAssertFalse(panel.canChooseFiles)
+        XCTAssertTrue(panel.allowsMultipleSelection)
+      }
+    }
+    
+    func testGetDirectoryMultipleCancel() throws {
+      let panelController = TestPanelController()
+      let plugin = FileSelectorPlugin(
+        viewProvider: TestViewProvider(),
+        panelController: panelController)
+
+      let called = XCTestExpectation()
+      let call = FlutterMethodCall(methodName: "getDirectoryPath", arguments: ["multiple": true])
+      plugin.handle(call) { result in
+        XCTAssertNil(result)
+        called.fulfill()
+      }
+
+      wait(for: [called], timeout: 0.5)
+      XCTAssertNotNil(panelController.openPanel)
+    }
 }

--- a/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
+++ b/packages/file_selector/file_selector_macos/example/macos/RunnerTests/RunnerTests.swift
@@ -241,13 +241,13 @@ class exampleTests: XCTestCase {
       viewProvider: TestViewProvider(),
       panelController: panelController)
 
-    let returnPath = "/foo/bar"
-    panelController.openURLs = [URL(fileURLWithPath: returnPath)]
+    let returnPaths = ["/foo/bar"]
+    panelController.openURLs = returnPaths.map({ path in URL(fileURLWithPath: path) })
 
     let called = XCTestExpectation()
     let call = FlutterMethodCall(methodName: "getDirectoryPath", arguments: [:])
     plugin.handle(call) { result in
-      XCTAssertEqual(result as! String?, returnPath)
+      XCTAssertEqual(result as! [String]?, returnPaths)
       called.fulfill()
     }
 
@@ -285,7 +285,7 @@ class exampleTests: XCTestCase {
         viewProvider: TestViewProvider(),
         panelController: panelController)
 
-    let returnPaths = ["/foo/bar", "/foo/test"]
+      let returnPaths = ["/foo/bar", "/foo/test"]
       panelController.openURLs = returnPaths.map({ path in URL(fileURLWithPath: path) })
 
       let called = XCTestExpectation()

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -15,7 +15,9 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.2.0
+  # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface/
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -15,9 +15,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
-  file_selector_platform_interface:
-    path: ../../file_selector_platform_interface/
+  file_selector_platform_interface: ^2.4.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -88,6 +88,22 @@ class FileSelectorMacOS extends FileSelectorPlatform {
     );
   }
 
+  @override
+  Future<List<String>> getDirectoryPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    final List<String>? pathList = await _channel.invokeListMethod<String>(
+      'getDirectoryPath',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+    return pathList ?? <String>[];
+  }
+
   // Converts the type group list into a flat list of all allowed types, since
   // macOS doesn't support filter groups.
   Map<String, List<String>>? _allowedTypeListFromTypeGroups(

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -35,7 +35,8 @@ class FileSelectorMacOS extends FileSelectorPlatform {
         'multiple': false,
       },
     );
-    return path == null ? null : XFile(path.first);
+    final String? filePath = _firstOrNull(path);
+    return filePath == null ? null : XFile(filePath);
   }
 
   @override
@@ -86,7 +87,7 @@ class FileSelectorMacOS extends FileSelectorPlatform {
         'confirmButtonText': confirmButtonText,
       },
     );
-    return pathList?.first;
+    return _firstOrNull(pathList);
   }
 
   @override
@@ -142,5 +143,9 @@ class FileSelectorMacOS extends FileSelectorPlatform {
     }
 
     return allowedTypes;
+  }
+
+  String? _firstOrNull(List<String>? list) {
+    return (list?.isEmpty ?? true) ? null : list?.first;
   }
 }

--- a/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
+++ b/packages/file_selector/file_selector_macos/lib/file_selector_macos.dart
@@ -79,13 +79,14 @@ class FileSelectorMacOS extends FileSelectorPlatform {
     String? initialDirectory,
     String? confirmButtonText,
   }) async {
-    return _channel.invokeMethod<String>(
+    final List<String>? pathList = await _channel.invokeListMethod<String>(
       'getDirectoryPath',
       <String, dynamic>{
         'initialDirectory': initialDirectory,
         'confirmButtonText': confirmButtonText,
       },
     );
+    return pathList?.first;
   }
 
   @override

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -73,7 +73,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
       configure(panel: panel, with: arguments)
       configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory)
       panelController.display(panel, for: viewProvider.view?.window) { (selection: [URL]?) in
-          result(selection?.map({ item in item.path }))
+        result(selection?.map({ item in item.path }))
       }
     case saveMethod:
       let panel = NSSavePanel()

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -73,7 +73,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
       configure(panel: panel, with: arguments)
       configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory)
       panelController.display(panel, for: viewProvider.view?.window) { (selection: [URL]?) in
-        if (choosingDirectory) {
+        if (choosingDirectory && panel.allowsMultipleSelection == false) {
           result(selection?.first?.path)
         } else {
           result(selection?.map({ item in item.path }))

--- a/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
+++ b/packages/file_selector/file_selector_macos/macos/Classes/FileSelectorPlugin.swift
@@ -73,11 +73,7 @@ public class FileSelectorPlugin: NSObject, FlutterPlugin {
       configure(panel: panel, with: arguments)
       configure(openPanel: panel, with: arguments, choosingDirectory: choosingDirectory)
       panelController.display(panel, for: viewProvider.view?.window) { (selection: [URL]?) in
-        if (choosingDirectory && panel.allowsMultipleSelection == false) {
-          result(selection?.first?.path)
-        } else {
           result(selection?.map({ item in item.path }))
-        }
       }
     case saveMethod:
       let panel = NSSavePanel()

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+3
+version: 0.9.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,7 +18,9 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+   # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: file_selector_macos
 description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
-version: 0.9.0+4
+version: 0.9.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -18,9 +18,7 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-   # TODO(VanesaOshiro): This should be 2.3.0 once it is published.
-  file_selector_platform_interface:
-    path: ../file_selector_platform_interface
+  file_selector_platform_interface: ^2.4.0
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -355,4 +355,52 @@ void main() {
       ],
     );
   });
+
+  group('getDirectoryPaths', () {
+    test('passes initialDirectory correctly', () async {
+      await plugin.getDirectoryPaths(initialDirectory: '/example/directory');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+            'initialDirectory': '/example/directory',
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('passes confirmButtonText correctly', () async {
+      await plugin.getDirectoryPaths(confirmButtonText: 'Open Directories');
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': 'Open Directories',
+            'multiple': true
+          }),
+        ],
+      );
+    });
+
+    test('receives argument multiple as true even if the others are null',
+        () async {
+      await plugin.getDirectoryPaths();
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
+            'initialDirectory': null,
+            'confirmButtonText': null,
+            'multiple': true
+          }),
+        ],
+      );
+    });
+  });
 }

--- a/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
+++ b/packages/file_selector/file_selector_macos/test/file_selector_macos_test.dart
@@ -46,52 +46,49 @@ void main() {
 
       await plugin.openFile(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': <String, dynamic>{
-              'extensions': <String>['txt', 'jpg'],
-              'mimeTypes': <String>['text/plain', 'image/jpg'],
-              'UTIs': <String>['public.text', 'public.image'],
-            },
-            'initialDirectory': null,
-            'confirmButtonText': null,
-            'multiple': false,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': <String, dynamic>{
+            'extensions': <String>['txt', 'jpg'],
+            'mimeTypes': <String>['text/plain', 'image/jpg'],
+            'UTIs': <String>['public.text', 'public.image'],
+          },
+          'initialDirectory': null,
+          'confirmButtonText': null,
+          'multiple': false,
+        },
       );
     });
 
     test('passes initialDirectory correctly', () async {
       await plugin.openFile(initialDirectory: '/example/directory');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': '/example/directory',
-            'confirmButtonText': null,
-            'multiple': false,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': '/example/directory',
+          'confirmButtonText': null,
+          'multiple': false,
+        },
       );
     });
 
     test('passes confirmButtonText correctly', () async {
       await plugin.openFile(confirmButtonText: 'Open File');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': null,
-            'confirmButtonText': 'Open File',
-            'multiple': false,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': null,
+          'confirmButtonText': 'Open File',
+          'multiple': false,
+        },
       );
     });
 
@@ -134,52 +131,49 @@ void main() {
 
       await plugin.openFiles(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': <String, List<dynamic>>{
-              'extensions': <String>['txt', 'jpg'],
-              'mimeTypes': <String>['text/plain', 'image/jpg'],
-              'UTIs': <String>['public.text', 'public.image'],
-            },
-            'initialDirectory': null,
-            'confirmButtonText': null,
-            'multiple': true,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': <String, List<dynamic>>{
+            'extensions': <String>['txt', 'jpg'],
+            'mimeTypes': <String>['text/plain', 'image/jpg'],
+            'UTIs': <String>['public.text', 'public.image'],
+          },
+          'initialDirectory': null,
+          'confirmButtonText': null,
+          'multiple': true,
+        },
       );
     });
 
     test('passes initialDirectory correctly', () async {
       await plugin.openFiles(initialDirectory: '/example/directory');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': '/example/directory',
-            'confirmButtonText': null,
-            'multiple': true,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': '/example/directory',
+          'confirmButtonText': null,
+          'multiple': true,
+        },
       );
     });
 
     test('passes confirmButtonText correctly', () async {
       await plugin.openFiles(confirmButtonText: 'Open File');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('openFile', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': null,
-            'confirmButtonText': 'Open File',
-            'multiple': true,
-          }),
-        ],
+        'openFile',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': null,
+          'confirmButtonText': 'Open File',
+          'multiple': true,
+        },
       );
     });
 
@@ -223,52 +217,49 @@ void main() {
       await plugin
           .getSavePath(acceptedTypeGroups: <XTypeGroup>[group, groupTwo]);
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getSavePath', arguments: <String, dynamic>{
-            'acceptedTypes': <String, List<dynamic>>{
-              'extensions': <String>['txt', 'jpg'],
-              'mimeTypes': <String>['text/plain', 'image/jpg'],
-              'UTIs': <String>['public.text', 'public.image'],
-            },
-            'initialDirectory': null,
-            'suggestedName': null,
-            'confirmButtonText': null,
-          }),
-        ],
+        'getSavePath',
+        arguments: <String, dynamic>{
+          'acceptedTypes': <String, List<dynamic>>{
+            'extensions': <String>['txt', 'jpg'],
+            'mimeTypes': <String>['text/plain', 'image/jpg'],
+            'UTIs': <String>['public.text', 'public.image'],
+          },
+          'initialDirectory': null,
+          'suggestedName': null,
+          'confirmButtonText': null,
+        },
       );
     });
 
     test('passes initialDirectory correctly', () async {
       await plugin.getSavePath(initialDirectory: '/example/directory');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getSavePath', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': '/example/directory',
-            'suggestedName': null,
-            'confirmButtonText': null,
-          }),
-        ],
+        'getSavePath',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': '/example/directory',
+          'suggestedName': null,
+          'confirmButtonText': null,
+        },
       );
     });
 
     test('passes confirmButtonText correctly', () async {
       await plugin.getSavePath(confirmButtonText: 'Open File');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getSavePath', arguments: <String, dynamic>{
-            'acceptedTypes': null,
-            'initialDirectory': null,
-            'suggestedName': null,
-            'confirmButtonText': 'Open File',
-          }),
-        ],
+        'getSavePath',
+        arguments: <String, dynamic>{
+          'acceptedTypes': null,
+          'initialDirectory': null,
+          'suggestedName': null,
+          'confirmButtonText': 'Open File',
+        },
       );
     });
 
@@ -298,28 +289,26 @@ void main() {
     test('passes initialDirectory correctly', () async {
       await plugin.getDirectoryPath(initialDirectory: '/example/directory');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-            'initialDirectory': '/example/directory',
-            'confirmButtonText': null,
-          }),
-        ],
+        'getDirectoryPath',
+        arguments: <String, dynamic>{
+          'initialDirectory': '/example/directory',
+          'confirmButtonText': null,
+        },
       );
     });
 
     test('passes confirmButtonText correctly', () async {
       await plugin.getDirectoryPath(confirmButtonText: 'Open File');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-            'initialDirectory': null,
-            'confirmButtonText': 'Open File',
-          }),
-        ],
+        'getDirectoryPath',
+        arguments: <String, dynamic>{
+          'initialDirectory': null,
+          'confirmButtonText': 'Open File',
+        },
       );
     });
   });
@@ -343,16 +332,15 @@ void main() {
       ),
     ]);
 
-    expect(
+    expectMethodCall(
       log,
-      <Matcher>[
-        isMethodCall('getSavePath', arguments: <String, dynamic>{
-          'acceptedTypes': null,
-          'initialDirectory': null,
-          'suggestedName': null,
-          'confirmButtonText': null,
-        }),
-      ],
+      'getSavePath',
+      arguments: <String, dynamic>{
+        'acceptedTypes': null,
+        'initialDirectory': null,
+        'suggestedName': null,
+        'confirmButtonText': null,
+      },
     );
   });
 
@@ -360,30 +348,28 @@ void main() {
     test('passes initialDirectory correctly', () async {
       await plugin.getDirectoryPaths(initialDirectory: '/example/directory');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-            'initialDirectory': '/example/directory',
-            'confirmButtonText': null,
-            'multiple': true
-          }),
-        ],
+        'getDirectoryPath',
+        arguments: <String, dynamic>{
+          'initialDirectory': '/example/directory',
+          'confirmButtonText': null,
+          'multiple': true
+        },
       );
     });
 
     test('passes confirmButtonText correctly', () async {
       await plugin.getDirectoryPaths(confirmButtonText: 'Open Directories');
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-            'initialDirectory': null,
-            'confirmButtonText': 'Open Directories',
-            'multiple': true
-          }),
-        ],
+        'getDirectoryPath',
+        arguments: <String, dynamic>{
+          'initialDirectory': null,
+          'confirmButtonText': 'Open Directories',
+          'multiple': true
+        },
       );
     });
 
@@ -391,16 +377,23 @@ void main() {
         () async {
       await plugin.getDirectoryPaths();
 
-      expect(
+      expectMethodCall(
         log,
-        <Matcher>[
-          isMethodCall('getDirectoryPath', arguments: <String, dynamic>{
-            'initialDirectory': null,
-            'confirmButtonText': null,
-            'multiple': true
-          }),
-        ],
+        'getDirectoryPath',
+        arguments: <String, dynamic>{
+          'initialDirectory': null,
+          'confirmButtonText': null,
+          'multiple': true
+        },
       );
     });
   });
+}
+
+void expectMethodCall(
+  List<MethodCall> log,
+  String methodName, {
+  Map<String, dynamic>? arguments,
+}) {
+  expect(log, <Matcher>[isMethodCall(methodName, arguments: arguments)]);
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -81,14 +81,13 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     String? initialDirectory,
     String? confirmButtonText,
   }) async {
-    final List<String>? pathList = await _channel.invokeListMethod<String>(
+    return _channel.invokeMethod<String>(
       'getDirectoryPath',
       <String, dynamic>{
         'initialDirectory': initialDirectory,
         'confirmButtonText': confirmButtonText,
       },
     );
-    return pathList?.first;
   }
 
   @override

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -81,13 +81,14 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
     String? initialDirectory,
     String? confirmButtonText,
   }) async {
-    return _channel.invokeMethod<String>(
+    final List<String>? pathList = await _channel.invokeListMethod<String>(
       'getDirectoryPath',
       <String, dynamic>{
         'initialDirectory': initialDirectory,
         'confirmButtonText': confirmButtonText,
       },
     );
+    return pathList?.first;
   }
 
   @override


### PR DESCRIPTION
This PR adds the macOS implementation for retrieving multiple directories paths from a select folder dialog.

Issue: [Support for selection of multiple directories, through desktop's native open panel, in 'file_selector' package](https://github.com/flutter/flutter/issues/74323)

![image](https://user-images.githubusercontent.com/64811191/195885449-e540a243-1a7d-49d7-ad79-31d2b40bfed6.png)
_New option on example application_

![image](https://user-images.githubusercontent.com/64811191/195885539-7ec4a7ba-93d3-42f2-b905-e90767773345.png)
_GetDirectoriesPaths_

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
