### PR TITLE
[file_selector] Add getDirectoryPaths method to the file_selector

### DIFF
--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.9.2+2
 
+* Adds `getDirectoryPaths` method.
+
+## 0.9.2+1
+
 * Improves API docs and examples.
 * Changes XTypeGroup initialization from final to const.
 * Updates minimum Flutter version to 2.10.

--- a/packages/file_selector/file_selector/example/lib/get_multiple_directories_page.dart
+++ b/packages/file_selector/file_selector/example/lib/get_multiple_directories_page.dart
@@ -1,0 +1,87 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+
+/// Screen that allows the user to select one or more directories using `getDirectoryPaths`,
+/// then displays the selected directories in a dialog.
+class GetMultipleDirectoriesPage extends StatelessWidget {
+  /// Default Constructor
+  const GetMultipleDirectoriesPage({Key? key}) : super(key: key);
+
+  Future<void> _getDirectoryPaths(BuildContext context) async {
+    const String confirmButtonText = 'Choose';
+    final List<String?>? directoryPaths = await getDirectoryPaths(
+      confirmButtonText: confirmButtonText,
+    );
+    if (directoryPaths == null) {
+      // Operation was canceled by the user.
+      return;
+    }
+    String paths = '';
+    for (final String? path in directoryPaths) {
+      paths += '${path!} \n';
+    }
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => TextDisplay(paths),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Select multiple directories'),
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                // TODO(darrenaustin): Migrate to new API once it lands in stable: https://github.com/flutter/flutter/issues/105724
+                // ignore: deprecated_member_use
+                primary: Colors.blue,
+                // ignore: deprecated_member_use
+                onPrimary: Colors.white,
+              ),
+              child: const Text(
+                  'Press to ask user to choose multiple directories'),
+              onPressed: () => _getDirectoryPaths(context),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Widget that displays a text file in a dialog.
+class TextDisplay extends StatelessWidget {
+  /// Creates a `TextDisplay`.
+  const TextDisplay(this.directoriesPaths, {Key? key}) : super(key: key);
+
+  /// The path selected in the dialog.
+  final String directoriesPaths;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Selected Directories'),
+      content: Scrollbar(
+        child: SingleChildScrollView(
+          child: Text(directoriesPaths),
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Close'),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/file_selector/file_selector/example/lib/home_page.dart
+++ b/packages/file_selector/file_selector/example/lib/home_page.dart
@@ -55,6 +55,13 @@ class HomePage extends StatelessWidget {
               child: const Text('Open a get directory dialog'),
               onPressed: () => Navigator.pushNamed(context, '/directory'),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              style: style,
+              child: const Text('Open a get multi directories dialog'),
+              onPressed: () =>
+                  Navigator.pushNamed(context, '/multi-directories'),
+            ),
           ],
         ),
       ),

--- a/packages/file_selector/file_selector/example/lib/main.dart
+++ b/packages/file_selector/file_selector/example/lib/main.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import 'get_directory_page.dart';
+import 'get_multiple_directories_page.dart';
 import 'home_page.dart';
 import 'open_image_page.dart';
 import 'open_multiple_images_page.dart';
@@ -36,6 +37,8 @@ class MyApp extends StatelessWidget {
         '/open/text': (BuildContext context) => const OpenTextPage(),
         '/save/text': (BuildContext context) => SaveTextPage(),
         '/directory': (BuildContext context) => GetDirectoryPage(),
+        '/multi-directories': (BuildContext context) =>
+            const GetMultipleDirectoriesPage()
       },
     );
   }

--- a/packages/file_selector/file_selector/lib/file_selector.dart
+++ b/packages/file_selector/file_selector/lib/file_selector.dart
@@ -123,3 +123,22 @@ Future<String?> getDirectoryPath({
   return FileSelectorPlatform.instance.getDirectoryPath(
       initialDirectory: initialDirectory, confirmButtonText: confirmButtonText);
 }
+
+/// Opens a directory selection dialog and returns a list of the paths chosen by the user.
+/// This always returns `null` on the web.
+///
+/// [initialDirectory] is the full path to the directory that will be displayed
+/// when the dialog is opened. When not provided, the platform will pick an
+/// initial location.
+///
+/// [confirmButtonText] is the text in the confirmation button of the dialog.
+/// When not provided, the default OS label is used (for example, "Open").
+///
+/// Returns `null` if the user cancels the operation.
+Future<List<String?>?> getDirectoryPaths({
+  String? initialDirectory,
+  String? confirmButtonText,
+}) async {
+  return FileSelectorPlatform.instance.getDirectoryPaths(
+      initialDirectory: initialDirectory, confirmButtonText: confirmButtonText);
+}

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -4,6 +4,8 @@ description: Flutter plugin for opening and saving files, or selecting
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.2+2
+# TODO(eugerossetto): This should be reverted once file_selector_platform_interface 2.3.0 is published.
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -23,13 +25,20 @@ flutter:
       windows:
         default_package: file_selector_windows
 
+# TODO(eugerossetto): This should be reverted once file_selector_platform_interface 2.3.0 is published.
 dependencies:
-  file_selector_ios: ^0.5.0
-  file_selector_linux: ^0.9.0
-  file_selector_macos: ^0.9.0
-  file_selector_platform_interface: ^2.2.0
-  file_selector_web: ^0.9.0
-  file_selector_windows: ^0.9.0
+  file_selector_ios:
+    path: ../file_selector_ios
+  file_selector_linux: 
+    path: ../file_selector_linux
+  file_selector_macos: 
+    path: ../file_selector_macos
+  file_selector_platform_interface: 
+    path: ../file_selector_platform_interface
+  file_selector_web: 
+    path: ../file_selector_web
+  file_selector_windows:
+    path: ../file_selector_windows
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector/test/file_selector_test.dart
+++ b/packages/file_selector/file_selector/test/file_selector_test.dart
@@ -258,6 +258,55 @@ void main() {
       expect(directoryPath, expectedDirectoryPath);
     });
   });
+
+  group('getDirectoryPaths', () {
+    const List<String> expectedDirectoryPaths = <String>[
+      '/example/path',
+      '/example/2/path'
+    ];
+
+    test('works', () async {
+      fakePlatformImplementation
+        ..setExpectations(
+            initialDirectory: initialDirectory,
+            confirmButtonText: confirmButtonText)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths = await getDirectoryPaths(
+        initialDirectory: initialDirectory,
+        confirmButtonText: confirmButtonText,
+      );
+
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('works with no arguments', () async {
+      fakePlatformImplementation.setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths = await getDirectoryPaths();
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('sets the initial directory', () async {
+      fakePlatformImplementation
+        ..setExpectations(initialDirectory: initialDirectory)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths =
+          await getDirectoryPaths(initialDirectory: initialDirectory);
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+
+    test('sets the button confirmation label', () async {
+      fakePlatformImplementation
+        ..setExpectations(confirmButtonText: confirmButtonText)
+        ..setPathsResponse(expectedDirectoryPaths);
+
+      final List<String?>? directoryPaths =
+          await getDirectoryPaths(confirmButtonText: confirmButtonText);
+      expect(directoryPaths, expectedDirectoryPaths);
+    });
+  });
 }
 
 class FakeFileSelector extends Fake
@@ -271,6 +320,7 @@ class FakeFileSelector extends Fake
   // Return values.
   List<XFile>? files;
   String? path;
+  List<String>? paths;
 
   void setExpectations({
     List<XTypeGroup> acceptedTypeGroups = const <XTypeGroup>[],
@@ -292,6 +342,11 @@ class FakeFileSelector extends Fake
   // ignore: use_setters_to_change_properties
   void setPathResponse(String path) {
     this.path = path;
+  }
+
+  // ignore: use_setters_to_change_properties
+  void setPathsResponse(List<String> paths) {
+    this.paths = paths;
   }
 
   @override
@@ -340,5 +395,15 @@ class FakeFileSelector extends Fake
     expect(initialDirectory, this.initialDirectory);
     expect(confirmButtonText, this.confirmButtonText);
     return path;
+  }
+
+  @override
+  Future<List<String>?> getDirectoryPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) async {
+    expect(initialDirectory, this.initialDirectory);
+    expect(confirmButtonText, this.confirmButtonText);
+    return paths;
   }
 }

--- a/packages/file_selector/file_selector_ios/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/example/pubspec.yaml
@@ -17,7 +17,9 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -3,6 +3,8 @@ description: iOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.5.0+2
+# TODO(eugerossetto): remove this once file_selector_platform_interface version is updated to 2.4.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.14.4 <3.0.0"
@@ -17,7 +19,9 @@ flutter:
         pluginClass: FFSFileSelectorPlugin
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 
@@ -27,4 +31,4 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.1.0
   pigeon: ^3.2.5
-  
+

--- a/packages/file_selector/file_selector_linux/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/example/pubspec.yaml
@@ -9,7 +9,9 @@ environment:
 dependencies:
   file_selector_linux:
     path: ../
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -3,6 +3,8 @@ description: Liunx implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.0+1
+# TODO(eugerossetto): remove this once file_selector_platform_interface version is updated to 2.4.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,7 +20,9 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -15,7 +15,9 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ..
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -3,6 +3,8 @@ description: macOS implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_macos
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.0+3
+# TODO(eugerossetto): remove this once file_selector_platform_interface version is updated to 2.4.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,7 +20,9 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+* Adds `getDirectoryPaths` method to the interface.
+
 ## 2.3.0
 
 * Replaces `macUTIs` with `uniformTypeIdentifiers`. `macUTIs` is available as an alias, but will be deprecated in a future release.

--- a/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/method_channel/method_channel_file_selector.dart
@@ -93,4 +93,18 @@ class MethodChannelFileSelector extends FileSelectorPlatform {
       },
     );
   }
+
+  /// Gets a list of directories paths from a dialog
+  @override
+  Future<List<String>?> getDirectoryPaths(
+      {String? initialDirectory, String? confirmButtonText}) async {
+    return _channel.invokeListMethod<String>(
+      'getDirectoryPaths',
+      <String, dynamic>{
+        'initialDirectory': initialDirectory,
+        'confirmButtonText': confirmButtonText,
+        'multiple': true,
+      },
+    );
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
+++ b/packages/file_selector/file_selector_platform_interface/lib/src/platform_interface/file_selector_interface.dart
@@ -74,4 +74,13 @@ abstract class FileSelectorPlatform extends PlatformInterface {
   }) {
     throw UnimplementedError('getDirectoryPath() has not been implemented.');
   }
+
+  /// Open file dialog for loading directories and return multiple directories paths
+  /// Returns `null` if user cancels the operation.
+  Future<List<String>?> getDirectoryPaths({
+    String? initialDirectory,
+    String? confirmButtonText,
+  }) {
+    throw UnimplementedError('getDirectoryPaths() has not been implemented.');
+  }
 }

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
+++ b/packages/file_selector/file_selector_platform_interface/test/method_channel_file_selector_test.dart
@@ -247,6 +247,37 @@ void main() {
           );
         });
       });
+      group('#getDirectoryPaths', () {
+        test('passes initialDirectory correctly', () async {
+          await plugin.getDirectoryPaths(
+              initialDirectory: '/example/directory');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
+                'initialDirectory': '/example/directory',
+                'confirmButtonText': null,
+                'multiple': true
+              }),
+            ],
+          );
+        });
+        test('passes confirmButtonText correctly', () async {
+          await plugin.getDirectoryPaths(confirmButtonText: 'Open File');
+
+          expect(
+            log,
+            <Matcher>[
+              isMethodCall('getDirectoryPaths', arguments: <String, dynamic>{
+                'initialDirectory': null,
+                'confirmButtonText': 'Open File',
+                'multiple': true
+              }),
+            ],
+          );
+        });
+      });
     });
   });
 }

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -6,7 +6,9 @@ environment:
   flutter: ">=2.10.0"
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface
   file_selector_web:
     path: ../
   flutter:

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -3,6 +3,8 @@ description: Web platform implementation of file_selector
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.0+2
+# TODO(eugerossetto): remove this once file_selector_platform_interface version is updated to 2.4.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -17,7 +19,9 @@ flutter:
         fileName: file_selector_web.dart
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/file_selector/file_selector_windows/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/example/pubspec.yaml
@@ -8,7 +8,9 @@ environment:
   flutter: ">=2.10.0"
 
 dependencies:
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../../file_selector_platform_interface
   file_selector_windows:
     # When depending on this package from a real application you should use:
     #   file_selector_windows: ^x.y.z

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -3,6 +3,8 @@ description: Windows implementation of the file_selector plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/file_selector/file_selector_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+file_selector%22
 version: 0.9.1+4
+# TODO(eugerossetto): remove this once file_selector_platform_interface version is updated to 2.4.0
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -18,7 +20,9 @@ flutter:
 
 dependencies:
   cross_file: ^0.3.1
-  file_selector_platform_interface: ^2.2.0
+  # TODO(eugerossetto): This should be 2.4.0 once it is published.
+  file_selector_platform_interface:
+    path: ../file_selector_platform_interface
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
This PR adds the file_selector implementation for retrieving multiple directories paths from a select folder dialog.

This is a continuation of PR [#6572](https://github.com/flutter/plugins/pull/6572), PR [#6573](https://github.com/flutter/plugins/pull/6573) and PR [#6575](https://github.com/flutter/plugins/pull/6575) so these changes will be ready to merge once the new version `2.3.0` in `file_selector_platform_interface` becomes available and the Linux and MacOS implementations are ready, before that, there's no point for this to be merged.

Issue:
[Support for selection of multiple directories, through desktop's native open panel, in 'file_selector' package #74323](https://github.com/flutter/flutter/issues/74323)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
