### PR TITLE
[tool] Get dependencies in package examples before publish check.

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.1
+
+* Modifies `publish_check_command.dart` to do a `dart pub get` in all examples
+  of the package being checked. Workaround for [dart-lang/pub#3618](https://github.com/dart-lang/pub/issues/3618).
+
 ## 0.12.0
 
 * Changes the behavior of `--packages-for-branch` on main/master to run for

--- a/script/tool/lib/src/publish_check_command.dart
+++ b/script/tool/lib/src/publish_check_command.dart
@@ -130,7 +130,23 @@ class PublishCheckCommand extends PackageLoopingCommand {
     }
   }
 
+  // Run `dart pub get` on the examples of [package].
+  Future<void> _fetchExampleDeps(RepositoryPackage package) async {
+    for (final RepositoryPackage example in package.getExamples()) {
+      await processRunner.runAndStream(
+        'dart',
+        <String>['pub', 'get'],
+        workingDir: example.directory,
+      );
+    }
+  }
+
   Future<bool> _hasValidPublishCheckRun(RepositoryPackage package) async {
+    // `pub publish` does not do `dart pub get` inside `example` directories
+    // of a package (but they're part of the analysis output!).
+    // Issue: https://github.com/flutter/flutter/issues/113788
+    await _fetchExampleDeps(package);
+
     print('Running pub publish --dry-run:');
     final io.Process process = await processRunner.start(
       flutterCommand,

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.12.0
+version: 0.12.1
 
 dependencies:
   args: ^2.1.0


### PR DESCRIPTION
It seems that `dart pub publish --dry-run` is failing in `main` because dependencies for `example` directories are not being fetched, which is causing new analyze errors that weren't being surfaced before. See: https://github.com/dart-lang/pub/issues/3618.

This PR modifies the `publish-check` command to recurse into every example of each package being analyzed, and getting its dependencies before the actual `pub publish` command runs.

Works around: https://github.com/dart-lang/pub/issues/3618

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [~] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
