### PR TITLE
[tool] Update tool to set macOS deployment target to 10.15.

### DIFF
--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -15,6 +15,9 @@ import 'common/repository_package.dart';
 
 const String _outputDirectoryFlag = 'output-dir';
 
+const int _exitUpdateMacosPodfileFailed = 3;
+const int _exitUpdateMacosPbxprojFailed = 4;
+
 /// A command to create an application that builds all in a single application.
 class CreateAllPluginsAppCommand extends PackageCommand {
   /// Creates an instance of the builder command.
@@ -270,12 +273,6 @@ dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
   }
 
   Future<int> _genNativeBuildFiles() async {
-    // Only run on macOS.
-    // Other platforms don't need generation of additional files.
-    if (!io.Platform.isMacOS) {
-      return 0;
-    }
-
     final io.ProcessResult result = io.Process.runSync(
       flutterCommand,
       <String>[
@@ -291,15 +288,10 @@ dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
   }
 
   Future<void> _updateMacosPodfile() async {
-    // Only change the macOS deployment target if the host platform is macOS.
-    if (!io.Platform.isMacOS) {
-      return;
-    }
-
     final File podfileFile =
         app.platformDirectory(FlutterPlatform.macos).childFile('Podfile');
     if (!podfileFile.existsSync()) {
-      throw ToolExit(64);
+      throw ToolExit(_exitUpdateMacosPodfileFailed);
     }
 
     final StringBuffer newPodfile = StringBuffer();
@@ -315,17 +307,12 @@ dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
   }
 
   Future<void> _updateMacosPbxproj() async {
-    // Only change the macOS deployment target if the host platform is macOS.
-    if (!io.Platform.isMacOS) {
-      return;
-    }
-
     final File pbxprojFile = app
         .platformDirectory(FlutterPlatform.macos)
         .childDirectory('Runner.xcodeproj')
         .childFile('project.pbxproj');
     if (!pbxprojFile.existsSync()) {
-      throw ToolExit(64);
+      throw ToolExit(_exitUpdateMacosPbxprojFailed);
     }
 
     final StringBuffer newPbxproj = StringBuffer();

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -205,7 +205,7 @@ class CreateAllPluginsAppCommand extends PackageCommand {
       },
       dependencyOverrides: pluginDeps,
     );
-    app.pubspecFile.writeAsStringSync(_pubspecToString(pubspec), flush: true);
+    app.pubspecFile.writeAsStringSync(_pubspecToString(pubspec));
   }
 
   Future<Map<String, PathDependency>> _getValidPathDependencies() async {

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -6,6 +6,7 @@ import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:path/path.dart' as p;
+import 'package:platform/platform.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_parse/pubspec_parse.dart';
 
@@ -27,7 +28,8 @@ class CreateAllPluginsAppCommand extends PackageCommand {
     Directory packagesDir, {
     ProcessRunner processRunner = const ProcessRunner(),
     Directory? pluginsRoot,
-  }) : super(packagesDir, processRunner: processRunner) {
+    Platform platform = const LocalPlatform(),
+  }) : super(packagesDir, processRunner: processRunner, platform: platform) {
     final Directory defaultDir =
         pluginsRoot ?? packagesDir.fileSystem.currentDirectory;
     argParser.addOption(_outputDirectoryFlag,

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -11,6 +11,7 @@ import 'package:pubspec_parse/pubspec_parse.dart';
 
 import 'common/core.dart';
 import 'common/package_command.dart';
+import 'common/process_runner.dart';
 import 'common/repository_package.dart';
 
 const String _outputDirectoryFlag = 'output-dir';
@@ -24,8 +25,9 @@ class CreateAllPluginsAppCommand extends PackageCommand {
   /// Creates an instance of the builder command.
   CreateAllPluginsAppCommand(
     Directory packagesDir, {
+    ProcessRunner processRunner = const ProcessRunner(),
     Directory? pluginsRoot,
-  }) : super(packagesDir) {
+  }) : super(packagesDir, processRunner: processRunner) {
     final Directory defaultDir =
         pluginsRoot ?? packagesDir.fileSystem.currentDirectory;
     argParser.addOption(_outputDirectoryFlag,

--- a/script/tool/lib/src/create_all_plugins_app_command.dart
+++ b/script/tool/lib/src/create_all_plugins_app_command.dart
@@ -288,6 +288,11 @@ dev_dependencies:${_pubspecMapString(pubspec.devDependencies)}
   }
 
   Future<void> _updateMacosPodfile() async {
+    // Only change the macOS deployment target if the host platform is macOS.
+    if (!io.Platform.isMacOS) {
+      return;
+    }
+
     final File podfileFile =
         app.platformDirectory(FlutterPlatform.macos).childFile('Podfile');
     if (!podfileFile.existsSync()) {

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -103,23 +103,28 @@ void main() {
           baselinePubspec.environment?[dartSdkKey]);
     });
 
-    test('macOS deployment target is modified', () async {
+    test('macOS deployment target is modified in Podfile', () async {
       await runCapturingPrint(runner, <String>['all-plugins-app']);
-
       final List<String> podfile = command.app
           .platformDirectory(FlutterPlatform.macos)
           .childFile('Podfile')
-          .readAsLinesSync();
-      final List<String> pbxproj = command.app
-          .platformDirectory(FlutterPlatform.macos)
-          .childDirectory('Runner.xcodeproj')
-          .childFile('project.pbxproj')
           .readAsLinesSync();
 
       expect(
           podfile,
           everyElement((String line) =>
               !line.contains('platform :osx') || line.contains("'10.15'")));
+    },
+        // Podfile is only generated on macOS.
+        skip: !io.Platform.isMacOS);
+
+    test('macOS deployment target is modified in pbxproj', () async {
+      await runCapturingPrint(runner, <String>['all-plugins-app']);
+      final List<String> pbxproj = command.app
+          .platformDirectory(FlutterPlatform.macos)
+          .childDirectory('Runner.xcodeproj')
+          .childFile('project.pbxproj')
+          .readAsLinesSync();
 
       expect(
           pbxproj,

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -103,6 +103,31 @@ void main() {
           baselinePubspec.environment?[dartSdkKey]);
     });
 
+    test('macOS deployment target is modified', () async {
+      await runCapturingPrint(runner, <String>['all-plugins-app']);
+
+      final List<String> podfile = command.app
+          .platformDirectory(FlutterPlatform.macos)
+          .childFile('Podfile')
+          .readAsLinesSync();
+      final List<String> pbxproj = command.app
+          .platformDirectory(FlutterPlatform.macos)
+          .childDirectory('Runner.xcodeproj')
+          .childFile('project.pbxproj')
+          .readAsLinesSync();
+
+      expect(
+          podfile,
+          everyElement((String line) =>
+              !line.contains('platform :osx') || line.contains("'10.15'")));
+
+      expect(
+          pbxproj,
+          everyElement((String line) =>
+              !line.contains('MACOSX_DEPLOYMENT_TARGET') ||
+              line.contains('10.15')));
+    });
+
     test('handles --output-dir', () async {
       createFakePlugin('plugina', packagesDir);
 

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -20,6 +20,7 @@ void main() {
     late FileSystem fileSystem;
     late Directory testRoot;
     late Directory packagesDir;
+    late RecordingProcessRunner processRunner;
 
     setUp(() {
       // Since the core of this command is a call to 'flutter create', the test
@@ -28,9 +29,11 @@ void main() {
       fileSystem = const LocalFileSystem();
       testRoot = fileSystem.systemTempDirectory.createTempSync();
       packagesDir = testRoot.childDirectory('packages');
+      processRunner = RecordingProcessRunner();
 
       command = CreateAllPluginsAppCommand(
         packagesDir,
+        processRunner: processRunner,
         pluginsRoot: testRoot,
       );
       runner = CommandRunner<void>(

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -171,7 +171,9 @@ platform :osx, '10.11'
                 const <String>['pub', 'get'],
                 testRoot.childDirectory('all_plugins').path),
           ]));
-    });
+    },
+        // See comment about Windows in create_all_plugins_app_command.dart
+        skip: io.Platform.isWindows);
 
     test('fails if flutter pub get fails', () async {
       createFakePlugin('plugina', packagesDir);
@@ -193,7 +195,9 @@ platform :osx, '10.11'
             contains(
                 "Failed to generate native build files via 'flutter pub get'"),
           ]));
-    });
+    },
+        // See comment about Windows in create_all_plugins_app_command.dart
+        skip: io.Platform.isWindows);
 
     test('handles --output-dir', () async {
       createFakePlugin('plugina', packagesDir);

--- a/script/tool/test/create_all_plugins_app_command_test.dart
+++ b/script/tool/test/create_all_plugins_app_command_test.dart
@@ -109,9 +109,12 @@ void main() {
     });
 
     test('macOS deployment target is modified in Podfile', () async {
-      final RepositoryPackage plugin = createFakePlugin('plugina', packagesDir);
-      final File podfileFile =
-          plugin.directory.childDirectory('macos').childFile('Podfile');
+      createFakePlugin('plugina', packagesDir);
+
+      final File podfileFile = command.packagesDir.parent
+          .childDirectory('all_plugins')
+          .childDirectory('macos')
+          .childFile('Podfile');
       podfileFile.createSync(recursive: true);
       podfileFile.writeAsStringSync("""
 platform :osx, '10.11'
@@ -133,16 +136,7 @@ platform :osx, '10.11'
         skip: !io.Platform.isMacOS);
 
     test('macOS deployment target is modified in pbxproj', () async {
-      final RepositoryPackage plugin = createFakePlugin('plugina', packagesDir);
-      final File pbxprojFile = plugin.directory
-          .childDirectory('Runner.xcodeproj')
-          .childFile('project.pbxproj');
-      pbxprojFile.createSync(recursive: true);
-      pbxprojFile.writeAsStringSync('''
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-/* some other line */
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-''');
+      createFakePlugin('plugina', packagesDir);
 
       await runCapturingPrint(runner, <String>['all-plugins-app']);
       final List<String> pbxproj = command.app


### PR DESCRIPTION
This change is a necessary precondition for https://github.com/flutter/plugins/pull/6517.

Adding support for macOS to `in_app_purchase` requires the macOS apps deployment target to be set to 10.15.
This PR makes the necessary changes to the `all-plugins-app` command.

Closes https://github.com/flutter/flutter/issues/113913

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
