### PR TITLE
fix npe in closeCaptureSession

### DIFF
--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -669,10 +669,11 @@ class Camera
 
   /** Stops the background thread and its {@link Handler}. */
   public void stopBackgroundThread() {
+    HandlerThread backgroundHandlerThread = this.backgroundHandlerThread;
     if (backgroundHandlerThread != null) {
       backgroundHandlerThread.quitSafely();
     }
-    backgroundHandlerThread = null;
+    this.backgroundHandlerThread = null;
     backgroundHandler = null;
   }
 
@@ -1158,20 +1159,26 @@ class Camera
   }
 
   private void closeCaptureSession() {
-    if (captureSession != null) {
+    CameraCaptureSession session = this.captureSession;
+    if (session != null) {
       Log.i(TAG, "closeCaptureSession");
 
-      captureSession.close();
-      captureSession = null;
+      session.close();
+      this.captureSession = null;
     }
   }
 
   public void close() {
     Log.i(TAG, "close");
 
+    final CameraDeviceWrapper cameraDevice = this.cameraDevice;
+    final ImageReader pictureImageReader = this.pictureImageReader;
+    final ImageReader imageStreamReader = this.imageStreamReader;
+    final MediaRecorder mediaRecorder = this.mediaRecorder;
+
     if (cameraDevice != null) {
       cameraDevice.close();
-      cameraDevice = null;
+      this.cameraDevice = null;
 
       // Closing the CameraDevice without closing the CameraCaptureSession is recommended
       // for quickly closing the camera:
@@ -1183,16 +1190,16 @@ class Camera
 
     if (pictureImageReader != null) {
       pictureImageReader.close();
-      pictureImageReader = null;
+      this.pictureImageReader = null;
     }
     if (imageStreamReader != null) {
       imageStreamReader.close();
-      imageStreamReader = null;
+      this.imageStreamReader = null;
     }
     if (mediaRecorder != null) {
       mediaRecorder.reset();
       mediaRecorder.release();
-      mediaRecorder = null;
+      this.mediaRecorder = null;
     }
 
     stopBackgroundThread();


### PR DESCRIPTION
We have such npe:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.camera2.CameraCaptureSession.close()' on a null object reference
	at io.flutter.plugins.camera.Camera.closeCaptureSession(Camera.java:1244)
	at io.flutter.plugins.camera.Camera$1.onClosed(Camera.java:372)
	at android.hardware.camera2.impl.CameraDeviceImpl$5.run(CameraDeviceImpl.java:234)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:210)
	at android.os.Looper.loop(Looper.java:299)
	at android.os.HandlerThread.run(HandlerThread.java:67)
```

This code is racy, so I've added a simple protection to it and similar places

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [ ] I signed the [CLA].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests