### PR TITLE
Add `Mac_x64 darwin_lint_podspecs` to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -45,7 +45,7 @@ targets:
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
-      target_file: darwin_lint_podspecs.yaml
+      target_file: mac_darwin_lint_podspecs.yaml
 
   - name: Windows win32-platform_tests master
     recipe: plugins/plugins

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -41,6 +41,7 @@ platform_properties:
 targets:
   - name: Mac_x64 darwin_lint_podspecs
     recipe: plugins/plugins
+    bringup: true # New target: https://github.com/flutter/plugins/pull/6637
     timeout: 30
     properties:
       add_recipes_cq: "true"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -25,8 +25,28 @@ platform_properties:
         ]
       device_type: none
       os: Windows
+  mac_x64:
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
+      os: Mac-12
+      device_type: none
+      cpu: x86
+      xcode: 14a5294e # xcode 14.0 beta 5
+      
 
 targets:
+  - name: Mac_x64 darwin_lint_podspecs
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: darwin_lint_podspecs.yaml
+
   - name: Windows win32-platform_tests master
     recipe: plugins/plugins
     timeout: 30

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -39,14 +39,17 @@ platform_properties:
       
 
 targets:
-  - name: Mac_x64 darwin_lint_podspecs
+  # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
+  # support. `pod lint` makes a synthetic target that doesn't respect the
+  # pod's arch exclusions, so fails to build.
+  - name: Mac_x64 lint_podspecs
     recipe: plugins/plugins
     bringup: true # New target: https://github.com/flutter/plugins/pull/6637
     timeout: 30
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
-      target_file: mac_darwin_lint_podspecs.yaml
+      target_file: mac_lint_podspecs.yaml
 
   - name: Windows win32-platform_tests master
     recipe: plugins/plugins

--- a/.ci/targets/mac_darwin_lint_podspecs.yaml
+++ b/.ci/targets/mac_darwin_lint_podspecs.yaml
@@ -2,5 +2,5 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
   - name: create all_plugins app
-    script: script/tool_runner.sh podspecs
+    script: script/tool_runner.sh
     args: podspecs

--- a/.ci/targets/mac_darwin_lint_podspecs.yaml
+++ b/.ci/targets/mac_darwin_lint_podspecs.yaml
@@ -2,5 +2,5 @@ tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
   - name: create all_plugins app
-    script: ./script/tool_runner.sh podspecs
+    script: script/tool_runner.sh podspecs
     args: podspecs

--- a/.ci/targets/mac_darwin_lint_podspecs.yaml
+++ b/.ci/targets/mac_darwin_lint_podspecs.yaml
@@ -3,4 +3,4 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
   - name: create all_plugins app
     script: script/tool_runner.sh
-    args: podspecs
+    args: ["podspecs"]

--- a/.ci/targets/mac_darwin_lint_podspecs.yaml
+++ b/.ci/targets/mac_darwin_lint_podspecs.yaml
@@ -1,0 +1,5 @@
+tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
+  - name: create all_plugins app
+    script: ./script/tool_runner.sh podspecs

--- a/.ci/targets/mac_darwin_lint_podspecs.yaml
+++ b/.ci/targets/mac_darwin_lint_podspecs.yaml
@@ -3,3 +3,4 @@ tasks:
     script: .ci/scripts/prepare_tool.sh
   - name: create all_plugins app
     script: ./script/tool_runner.sh podspecs
+    args: podspecs

--- a/.ci/targets/mac_lint_podspecs.yaml
+++ b/.ci/targets/mac_lint_podspecs.yaml
@@ -1,6 +1,6 @@
 tasks:
   - name: prepare tool
     script: .ci/scripts/prepare_tool.sh
-  - name: create all_plugins app
+  - name: lint iOS and macOS podspecs
     script: script/tool_runner.sh
     args: ["podspecs"]


### PR DESCRIPTION
This is the first Mac target to be enabled in LUCI, and should be landed after recipes support CL: https://flutter-review.googlesource.com/c/recipes/+/35303

Bug: https://github.com/flutter/flutter/issues/114373