### PR TITLE
[video_player]add integration test for inverted aspect ratio bug

### DIFF
--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Adds an integration test for a bug where the aspect ratios of some HLS videos are incorrectly inverted.
+
 ## 2.3.7
 
 * Fixes a bug where the aspect ratio of some HLS videos are incorrectly inverted.

--- a/packages/video_player/video_player_avfoundation/example/integration_test/video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/example/integration_test/video_player_test.dart
@@ -177,5 +177,19 @@ void main() {
       expect(livestreamController.value.duration,
           (Duration duration) => duration != Duration.zero);
     });
+
+    testWidgets('rotated m3u8 has correct aspect ratio',
+        (WidgetTester tester) async {
+      // Some m3u8 files contain rotation data that may incorrectly invert the aspect ratio.
+      // More info [here](https://github.com/flutter/flutter/issues/109116).
+      final MiniController livestreamController = MiniController.network(
+        'https://flutter.github.io/assets-for-api-docs/assets/videos/hls/rotated_nail_manifest.m3u8',
+      );
+      await livestreamController.initialize();
+
+      expect(livestreamController.value.isInitialized, true);
+      expect(livestreamController.value.size.width,
+          lessThan(livestreamController.value.size.height));
+    });
   });
 }


### PR DESCRIPTION
Added integration test for the aspect ratio bug. I've verified that old code failed this test, and the new code passed it. 

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/109116

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
