### PR TITLE
[camera] Implement interface methods to allow concurrent stream and record

### DIFF
--- a/packages/camera/camera/CHANGELOG.md
+++ b/packages/camera/camera/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* Implements option to also stream when recording a video.
+
 ## 0.10.0+4
 
 * Removes usage of `_ambiguate` method in example.

--- a/packages/camera/camera/lib/src/camera_controller.dart
+++ b/packages/camera/camera/lib/src/camera_controller.dart
@@ -459,12 +459,6 @@ class CameraController extends ValueNotifier<CameraValue> {
     assert(defaultTargetPlatform == TargetPlatform.android ||
         defaultTargetPlatform == TargetPlatform.iOS);
     _throwIfNotInitialized('stopImageStream');
-    if (value.isRecordingVideo) {
-      throw CameraException(
-        'A video recording is already started.',
-        'stopImageStream was called while a video is being recorded.',
-      );
-    }
     if (!value.isStreamingImages) {
       throw CameraException(
         'No camera is streaming images',
@@ -483,9 +477,13 @@ class CameraController extends ValueNotifier<CameraValue> {
 
   /// Start a video recording.
   ///
+  /// You may optionally pass an [onAvailable] callback to also have the
+  /// video frames streamed to this callback.
+  ///
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
-  Future<void> startVideoRecording() async {
+  Future<void> startVideoRecording(
+      {onLatestImageAvailable? onAvailable}) async {
     _throwIfNotInitialized('startVideoRecording');
     if (value.isRecordingVideo) {
       throw CameraException(
@@ -493,18 +491,21 @@ class CameraController extends ValueNotifier<CameraValue> {
         'startVideoRecording was called when a recording is already started.',
       );
     }
-    if (value.isStreamingImages) {
-      throw CameraException(
-        'A camera has started streaming images.',
-        'startVideoRecording was called while a camera was streaming images.',
-      );
+
+    Function(CameraImageData image)? streamCallback;
+    if (onAvailable != null) {
+      streamCallback = (CameraImageData imageData) {
+        onAvailable(CameraImage.fromPlatformInterface(imageData));
+      };
     }
 
     try {
-      await CameraPlatform.instance.startVideoRecording(_cameraId);
+      await CameraPlatform.instance.startVideoCapturing(
+          VideoCaptureOptions(_cameraId, streamCallback: streamCallback));
       value = value.copyWith(
           isRecordingVideo: true,
           isRecordingPaused: false,
+          isStreamingImages: onAvailable != null,
           recordingOrientation: Optional<DeviceOrientation>.of(
               value.lockedCaptureOrientation ?? value.deviceOrientation));
     } on PlatformException catch (e) {
@@ -523,6 +524,11 @@ class CameraController extends ValueNotifier<CameraValue> {
         'stopVideoRecording was called when no video is recording.',
       );
     }
+
+    if (value.isStreamingImages) {
+      stopImageStream();
+    }
+
     try {
       final XFile file =
           await CameraPlatform.instance.stopVideoRecording(_cameraId);

--- a/packages/camera/camera/pubspec.yaml
+++ b/packages/camera/camera/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter plugin for controlling the camera. Supports previewing
   Dart.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.0+4
+version: 0.10.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -21,10 +21,10 @@ flutter:
         default_package: camera_web
 
 dependencies:
-  camera_android: ^0.10.0
-  camera_avfoundation: ^0.9.7+1
-  camera_platform_interface: ^2.2.0
-  camera_web: ^0.3.0
+  camera_android: ^0.10.1
+  camera_avfoundation: ^0.10.0
+  camera_platform_interface: ^2.3.1
+  camera_web: ^0.3.1
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2

--- a/packages/camera/camera/test/camera_image_stream_test.dart
+++ b/packages/camera/camera/test/camera_image_stream_test.dart
@@ -130,28 +130,6 @@ void main() {
     );
   });
 
-  test('stopImageStream() throws $CameraException when recording videos',
-      () async {
-    final CameraController cameraController = CameraController(
-        const CameraDescription(
-            name: 'cam',
-            lensDirection: CameraLensDirection.back,
-            sensorOrientation: 90),
-        ResolutionPreset.max);
-    await cameraController.initialize();
-
-    await cameraController.startImageStream((CameraImage image) => null);
-    cameraController.value =
-        cameraController.value.copyWith(isRecordingVideo: true);
-    expect(
-        cameraController.stopImageStream,
-        throwsA(isA<CameraException>().having(
-          (CameraException error) => error.description,
-          'A video recording is already started.',
-          'stopImageStream was called while a video is being recorded.',
-        )));
-  });
-
   test('stopImageStream() throws $CameraException when not streaming images',
       () async {
     final CameraController cameraController = CameraController(
@@ -185,6 +163,39 @@ void main() {
     expect(mockPlatform.streamCallLog,
         <String>['onStreamedFrameAvailable', 'listen', 'cancel']);
   });
+
+  test('startVideoRecording() can stream images', () async {
+    final CameraController cameraController = CameraController(
+        const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90),
+        ResolutionPreset.max);
+
+    await cameraController.initialize();
+
+    cameraController.startVideoRecording(
+        onAvailable: (CameraImage image) => null);
+
+    expect(mockPlatform.streamCallLog,
+        <String>['startVideoRecording with stream']);
+  });
+
+  test('startVideoRecording() by default does not stream', () async {
+    final CameraController cameraController = CameraController(
+        const CameraDescription(
+            name: 'cam',
+            lensDirection: CameraLensDirection.back,
+            sensorOrientation: 90),
+        ResolutionPreset.max);
+
+    await cameraController.initialize();
+
+    cameraController.startVideoRecording();
+
+    expect(mockPlatform.streamCallLog,
+        <String>['startVideoRecording without stream']);
+  });
 }
 
 class MockStreamingCameraPlatform extends MockCameraPlatform {
@@ -201,6 +212,20 @@ class MockStreamingCameraPlatform extends MockCameraPlatform {
       onCancel: _onFrameStreamCancel,
     );
     return _streamController!.stream;
+  }
+
+  @override
+  Future<XFile> startVideoRecording(int cameraId,
+      {Duration? maxVideoDuration}) {
+    streamCallLog.add('startVideoRecording');
+    return super
+        .startVideoRecording(cameraId, maxVideoDuration: maxVideoDuration);
+  }
+
+  @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) {
+    streamCallLog.add('startVideoCapturing');
+    return super.startVideoCapturing(options);
   }
 
   void _onFrameStreamListen() {

--- a/packages/camera/camera/test/camera_preview_test.dart
+++ b/packages/camera/camera/test/camera_preview_test.dart
@@ -98,7 +98,8 @@ class FakeController extends ValueNotifier<CameraValue>
   Future<void> startImageStream(onLatestImageAvailable onAvailable) async {}
 
   @override
-  Future<void> startVideoRecording() async {}
+  Future<void> startVideoRecording(
+      {onLatestImageAvailable? onAvailable}) async {}
 
   @override
   Future<void> stopImageStream() async {}

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -1460,6 +1460,12 @@ class MockCameraPlatform extends Mock
       Future<XFile>.value(mockVideoRecordingXFile);
 
   @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) {
+    return startVideoRecording(options.cameraId,
+        maxVideoDuration: options.maxDuration);
+  }
+
+  @override
   Future<void> lockCaptureOrientation(
           int? cameraId, DeviceOrientation? orientation) async =>
       super.noSuchMethod(Invocation.method(

--- a/packages/camera/camera/test/camera_test.dart
+++ b/packages/camera/camera/test/camera_test.dart
@@ -336,30 +336,6 @@ void main() {
           )));
     });
 
-    test(
-        'startVideoRecording() throws $CameraException when already streaming images',
-        () async {
-      final CameraController cameraController = CameraController(
-          const CameraDescription(
-              name: 'cam',
-              lensDirection: CameraLensDirection.back,
-              sensorOrientation: 90),
-          ResolutionPreset.max);
-
-      await cameraController.initialize();
-
-      cameraController.value =
-          cameraController.value.copyWith(isStreamingImages: true);
-
-      expect(
-          cameraController.startVideoRecording(),
-          throwsA(isA<CameraException>().having(
-            (CameraException error) => error.description,
-            'A camera has started streaming images.',
-            'startVideoRecording was called while a camera was streaming images.',
-          )));
-    });
-
     test('getMaxZoomLevel() throws $CameraException when uninitialized',
         () async {
       final CameraController cameraController = CameraController(

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+* Implements option to also stream when recording a video.
+
 ## 0.10.0+4
 
 * Upgrades `androidx.annotation` version to 1.5.0.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -522,6 +522,21 @@ class Camera
     }
   }
 
+  private void startCapture(boolean record, boolean stream) throws CameraAccessException {
+    List<Surface> surfaces = new ArrayList<>();
+    Runnable successCallback = null;
+    if (record) {
+      surfaces.add(mediaRecorder.getSurface());
+      successCallback = () -> mediaRecorder.start();
+    }
+    if (stream) {
+      surfaces.add(imageStreamReader.getSurface());
+    }
+
+    createCaptureSession(
+        CameraDevice.TEMPLATE_RECORD, successCallback, surfaces.toArray(new Surface[0]));
+  }
+
   public void takePicture(@NonNull final Result result) {
     // Only take one picture at a time.
     if (cameraCaptureCallback.getCameraState() != CameraState.STATE_PREVIEW) {
@@ -731,29 +746,17 @@ class Camera
             dartMessenger.error(flutterResult, errorCode, errorMessage, null));
   }
 
-  public void startVideoRecording(@NonNull Result result) {
-    final File outputDir = applicationContext.getCacheDir();
-    try {
-      captureFile = File.createTempFile("REC", ".mp4", outputDir);
-    } catch (IOException | SecurityException e) {
-      result.error("cannotCreateFile", e.getMessage(), null);
-      return;
+  public void startVideoRecording(
+      @NonNull Result result, @Nullable EventChannel imageStreamChannel) {
+    prepareRecording(result);
+
+    if (imageStreamChannel != null) {
+      setStreamHandler(imageStreamChannel);
     }
-    try {
-      prepareMediaRecorder(captureFile.getAbsolutePath());
-    } catch (IOException e) {
-      recordingVideo = false;
-      captureFile = null;
-      result.error("videoRecordingFailed", e.getMessage(), null);
-      return;
-    }
-    // Re-create autofocus feature so it's using video focus mode now.
-    cameraFeatures.setAutoFocus(
-        cameraFeatureFactory.createAutoFocusFeature(cameraProperties, true));
+
     recordingVideo = true;
     try {
-      createCaptureSession(
-          CameraDevice.TEMPLATE_RECORD, () -> mediaRecorder.start(), mediaRecorder.getSurface());
+      startCapture(true, imageStreamChannel != null);
       result.success(null);
     } catch (CameraAccessException e) {
       recordingVideo = false;
@@ -1073,21 +1076,10 @@ class Camera
 
   public void startPreviewWithImageStream(EventChannel imageStreamChannel)
       throws CameraAccessException {
-    createCaptureSession(CameraDevice.TEMPLATE_RECORD, imageStreamReader.getSurface());
+    setStreamHandler(imageStreamChannel);
+
+    startCapture(false, true);
     Log.i(TAG, "startPreviewWithImageStream");
-
-    imageStreamChannel.setStreamHandler(
-        new EventChannel.StreamHandler() {
-          @Override
-          public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
-            setImageStreamImageAvailableListener(imageStreamSink);
-          }
-
-          @Override
-          public void onCancel(Object o) {
-            imageStreamReader.setOnImageAvailableListener(null, backgroundHandler);
-          }
-        });
   }
 
   /**
@@ -1115,6 +1107,42 @@ class Camera
               }
             }));
     cameraCaptureCallback.setCameraState(CameraState.STATE_PREVIEW);
+  }
+
+  private void prepareRecording(@NonNull Result result) {
+    final File outputDir = applicationContext.getCacheDir();
+    try {
+      captureFile = File.createTempFile("REC", ".mp4", outputDir);
+    } catch (IOException | SecurityException e) {
+      result.error("cannotCreateFile", e.getMessage(), null);
+      return;
+    }
+    try {
+      prepareMediaRecorder(captureFile.getAbsolutePath());
+    } catch (IOException e) {
+      recordingVideo = false;
+      captureFile = null;
+      result.error("videoRecordingFailed", e.getMessage(), null);
+      return;
+    }
+    // Re-create autofocus feature so it's using video focus mode now.
+    cameraFeatures.setAutoFocus(
+        cameraFeatureFactory.createAutoFocusFeature(cameraProperties, true));
+  }
+
+  private void setStreamHandler(EventChannel imageStreamChannel) {
+    imageStreamChannel.setStreamHandler(
+        new EventChannel.StreamHandler() {
+          @Override
+          public void onListen(Object o, EventChannel.EventSink imageStreamSink) {
+            setImageStreamImageAvailableListener(imageStreamSink);
+          }
+
+          @Override
+          public void onCancel(Object o) {
+            imageStreamReader.setOnImageAvailableListener(null, backgroundHandler);
+          }
+        });
   }
 
   private void setImageStreamImageAvailableListener(final EventChannel.EventSink imageStreamSink) {

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/MethodCallHandlerImpl.java
@@ -26,6 +26,7 @@ import io.flutter.plugins.camera.features.resolution.ResolutionPreset;
 import io.flutter.view.TextureRegistry;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
   private final Activity activity;
@@ -118,7 +119,9 @@ final class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
         }
       case "startVideoRecording":
         {
-          camera.startVideoRecording(result);
+          camera.startVideoRecording(
+              result,
+              Objects.equals(call.argument("enableStream"), true) ? imageStreamChannel : null);
           break;
         }
       case "stopVideoRecording":

--- a/packages/camera/camera_android/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_android/example/integration_test/camera_test.dart
@@ -245,4 +245,44 @@ void main() {
       await controller.dispose();
     },
   );
+
+  testWidgets(
+    'recording with image stream',
+    (WidgetTester tester) async {
+      final List<CameraDescription> cameras =
+          await CameraPlatform.instance.availableCameras();
+      if (cameras.isEmpty) {
+        return;
+      }
+
+      final CameraController controller = CameraController(
+        cameras[0],
+        ResolutionPreset.low,
+        enableAudio: false,
+      );
+
+      await controller.initialize();
+      bool _isDetecting = false;
+
+      await controller.startVideoRecording(
+          streamCallback: (CameraImageData image) {
+        if (_isDetecting) {
+          return;
+        }
+
+        _isDetecting = true;
+
+        expectLater(image, isNotNull).whenComplete(() => _isDetecting = false);
+      });
+
+      expect(controller.value.isStreamingImages, true);
+
+      sleep(const Duration(milliseconds: 500));
+
+      await controller.stopVideoRecording();
+      await controller.dispose();
+
+      expect(controller.value.isStreamingImages, false);
+    },
+  );
 }

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  camera_platform_interface: ^2.2.0
+  camera_platform_interface: ^2.3.1
   flutter:
     sdk: flutter
   path_provider: ^2.0.0

--- a/packages/camera/camera_android/lib/src/android_camera.dart
+++ b/packages/camera/camera_android/lib/src/android_camera.dart
@@ -248,13 +248,25 @@ class AndroidCamera extends CameraPlatform {
   @override
   Future<void> startVideoRecording(int cameraId,
       {Duration? maxVideoDuration}) async {
+    return startVideoCapturing(
+        VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
+  }
+
+  @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) async {
     await _channel.invokeMethod<void>(
       'startVideoRecording',
       <String, dynamic>{
-        'cameraId': cameraId,
-        'maxVideoDuration': maxVideoDuration?.inMilliseconds,
+        'cameraId': options.cameraId,
+        'maxVideoDuration': options.maxDuration?.inMilliseconds,
+        'enableStream': options.streamCallback != null,
       },
     );
+
+    if (options.streamCallback != null) {
+      _installStreamController().stream.listen(options.streamCallback);
+      _startStreamListener();
+    }
   }
 
   @override
@@ -290,13 +302,19 @@ class AndroidCamera extends CameraPlatform {
   @override
   Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
       {CameraImageStreamOptions? options}) {
+    _installStreamController(onListen: _onFrameStreamListen);
+    return _frameStreamController!.stream;
+  }
+
+  StreamController<CameraImageData> _installStreamController(
+      {Function()? onListen}) {
     _frameStreamController = StreamController<CameraImageData>(
-      onListen: _onFrameStreamListen,
+      onListen: onListen ?? () {},
       onPause: _onFrameStreamPauseResume,
       onResume: _onFrameStreamPauseResume,
       onCancel: _onFrameStreamCancel,
     );
-    return _frameStreamController!.stream;
+    return _frameStreamController!;
   }
 
   void _onFrameStreamListen() {
@@ -305,6 +323,10 @@ class AndroidCamera extends CameraPlatform {
 
   Future<void> _startPlatformStream() async {
     await _channel.invokeMethod<void>('startImageStream');
+    _startStreamListener();
+  }
+
+  void _startStreamListener() {
     const EventChannel cameraEventChannel =
         EventChannel('plugins.flutter.io/camera_android/imageStream');
     _platformImageStreamSubscription =

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -18,8 +18,7 @@ flutter:
         dartPluginClass: AndroidCamera
 
 dependencies:
-  camera_platform_interface:
-    path: ../camera_platform_interface
+  camera_platform_interface: ^2.3.1
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android
 description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.0+4
+version: 0.10.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -18,7 +18,8 @@ flutter:
         dartPluginClass: AndroidCamera
 
 dependencies:
-  camera_platform_interface: ^2.2.0
+  camera_platform_interface:
+    path: ../camera_platform_interface
   flutter:
     sdk: flutter
   flutter_plugin_android_lifecycle: ^2.0.2

--- a/packages/camera/camera_android/test/android_camera_test.dart
+++ b/packages/camera/camera_android/test/android_camera_test.dart
@@ -587,6 +587,7 @@ void main() {
         isMethodCall('startVideoRecording', arguments: <String, Object?>{
           'cameraId': cameraId,
           'maxVideoDuration': null,
+          'enableStream': false,
         }),
       ]);
     });
@@ -609,7 +610,33 @@ void main() {
       expect(channel.log, <Matcher>[
         isMethodCall('startVideoRecording', arguments: <String, Object?>{
           'cameraId': cameraId,
-          'maxVideoDuration': 10000
+          'maxVideoDuration': 10000,
+          'enableStream': false,
+        }),
+      ]);
+    });
+
+    test(
+        'Should pass enableStream if callback is passed when starting recording a video',
+        () async {
+      // Arrange
+      final MethodChannelMock channel = MethodChannelMock(
+        channelName: _channelName,
+        methods: <String, dynamic>{'startVideoRecording': null},
+      );
+
+      // Act
+      await camera.startVideoRecording(
+        cameraId,
+        streamCallback: (imageData) {},
+      );
+
+      // Assert
+      expect(channel.log, <Matcher>[
+        isMethodCall('startVideoRecording', arguments: <String, Object?>{
+          'cameraId': cameraId,
+          'maxVideoDuration': null,
+          'enableStream': true,
         }),
       ]);
     });

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+* Implements option to also stream when recording a video.
+
 ## 0.9.8+6
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/camera/camera_avfoundation/example/integration_test/camera_test.dart
+++ b/packages/camera/camera_avfoundation/example/integration_test/camera_test.dart
@@ -253,4 +253,33 @@ void main() {
       expect(image.planes.length, 1);
     },
   );
+
+  testWidgets('Recording with video streaming', (WidgetTester tester) async {
+    final List<CameraDescription> cameras =
+        await CameraPlatform.instance.availableCameras();
+    if (cameras.isEmpty) {
+      return;
+    }
+
+    final CameraController controller = CameraController(
+      cameras[0],
+      ResolutionPreset.low,
+      enableAudio: false,
+    );
+
+    await controller.initialize();
+    await controller.prepareForVideoRecording();
+    final Completer<CameraImageData> _completer = Completer<CameraImageData>();
+    await controller.startVideoRecording(
+        streamCallback: (CameraImageData image) {
+      if (!_completer.isCompleted) {
+        _completer.complete(image);
+      }
+    });
+    sleep(const Duration(milliseconds: 500));
+    await controller.stopVideoRecording();
+    await controller.dispose();
+
+    expect(await _completer.future, isNotNull);
+  });
 }

--- a/packages/camera/camera_avfoundation/example/lib/camera_controller.dart
+++ b/packages/camera/camera_avfoundation/example/lib/camera_controller.dart
@@ -306,11 +306,14 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// The video is returned as a [XFile] after calling [stopVideoRecording].
   /// Throws a [CameraException] if the capture fails.
-  Future<void> startVideoRecording() async {
-    await CameraPlatform.instance.startVideoRecording(_cameraId);
+  Future<void> startVideoRecording(
+      {Function(CameraImageData image)? streamCallback}) async {
+    await CameraPlatform.instance.startVideoCapturing(
+        VideoCaptureOptions(_cameraId, streamCallback: streamCallback));
     value = value.copyWith(
         isRecordingVideo: true,
         isRecordingPaused: false,
+        isStreamingImages: streamCallback != null,
         recordingOrientation: Optional<DeviceOrientation>.of(
             value.lockedCaptureOrientation ?? value.deviceOrientation));
   }
@@ -319,6 +322,10 @@ class CameraController extends ValueNotifier<CameraValue> {
   ///
   /// Throws a [CameraException] if the capture failed.
   Future<XFile> stopVideoRecording() async {
+    if (value.isStreamingImages) {
+      await stopImageStream();
+    }
+
     final XFile file =
         await CameraPlatform.instance.stopVideoRecording(_cameraId);
     value = value.copyWith(

--- a/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/CameraPlugin.m
@@ -201,7 +201,12 @@
       [self.camera setUpCaptureSessionForAudio];
       [result sendSuccess];
     } else if ([@"startVideoRecording" isEqualToString:call.method]) {
-      [_camera startVideoRecordingWithResult:result];
+      BOOL enableStream = [call.arguments[@"enableStream"] boolValue];
+      if (enableStream) {
+        [_camera startVideoRecordingWithResult:result messengerForStreaming:_messenger];
+      } else {
+        [_camera startVideoRecordingWithResult:result];
+      }
     } else if ([@"stopVideoRecording" isEqualToString:call.method]) {
       [_camera stopVideoRecordingWithResult:result];
     } else if ([@"pauseVideoRecording" isEqualToString:call.method]) {

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.h
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.h
@@ -50,6 +50,15 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)captureToFile:(FLTThreadSafeFlutterResult *)result API_AVAILABLE(ios(10));
 - (void)close;
 - (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;
+/**
+ * Starts recording a video with an optional streaming messenger.
+ * If the messenger is non-null then it will be called for each
+ * captured frame, allowing streaming concurrently with recording.
+ *
+ * @param messengerForStreaming Nullable messenger for capturing each frame.
+ */
+- (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result
+                messengerForStreaming:(nullable NSObject<FlutterBinaryMessenger> *)messenger;
 - (void)stopVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;
 - (void)pauseVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;
 - (void)resumeVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result;

--- a/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
+++ b/packages/camera/camera_avfoundation/ios/Classes/FLTCam.m
@@ -623,7 +623,16 @@ NSString *const errorMethod = @"error";
 }
 
 - (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result {
+  [self startVideoRecordingWithResult:result messengerForStreaming:nil];
+}
+
+- (void)startVideoRecordingWithResult:(FLTThreadSafeFlutterResult *)result
+                messengerForStreaming:(nullable NSObject<FlutterBinaryMessenger> *)messenger {
   if (!_isRecording) {
+    if (messenger != nil) {
+      [self startImageStreamWithMessenger:messenger];
+    }
+
     NSError *error;
     _videoRecordingPath = [self getTemporaryFilePathWithExtension:@"mp4"
                                                         subfolder:@"videos"

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -247,14 +247,29 @@ class AVFoundationCamera extends CameraPlatform {
 
   @override
   Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration}) async {
+      {Duration? maxVideoDuration,
+      Function(CameraImageData image)? streamCallback,
+      CameraImageStreamOptions? streamOptions}) async {
+    return startVideoCapturing(
+        VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
+  }
+
+  @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) async {
     await _channel.invokeMethod<void>(
       'startVideoRecording',
       <String, dynamic>{
-        'cameraId': cameraId,
-        'maxVideoDuration': maxVideoDuration?.inMilliseconds,
+        'cameraId': options.cameraId,
+        'maxVideoDuration': options.maxDuration?.inMilliseconds,
+        'enableStream': options.streamCallback != null,
       },
     );
+
+    if (options.streamCallback != null) {
+      _frameStreamController = _createStreamController();
+      _frameStreamController!.stream.listen(options.streamCallback);
+      _startStreamListener();
+    }
   }
 
   @override
@@ -290,13 +305,20 @@ class AVFoundationCamera extends CameraPlatform {
   @override
   Stream<CameraImageData> onStreamedFrameAvailable(int cameraId,
       {CameraImageStreamOptions? options}) {
-    _frameStreamController = StreamController<CameraImageData>(
-      onListen: _onFrameStreamListen,
+    _frameStreamController =
+        _createStreamController(onListen: _onFrameStreamListen);
+    return _frameStreamController!.stream;
+  }
+
+  StreamController<CameraImageData> _createStreamController(
+      {Function()? onListen}) {
+    return StreamController<CameraImageData>(
+      onListen: onListen ?? () {},
       onPause: _onFrameStreamPauseResume,
       onResume: _onFrameStreamPauseResume,
       onCancel: _onFrameStreamCancel,
     );
-    return _frameStreamController!.stream;
+    return _frameStreamController!;
   }
 
   void _onFrameStreamListen() {
@@ -305,6 +327,10 @@ class AVFoundationCamera extends CameraPlatform {
 
   Future<void> _startPlatformStream() async {
     await _channel.invokeMethod<void>('startImageStream');
+    _startStreamListener();
+  }
+
+  void _startStreamListener() {
     const EventChannel cameraEventChannel =
         EventChannel('plugins.flutter.io/camera_avfoundation/imageStream');
     _platformImageStreamSubscription =

--- a/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
+++ b/packages/camera/camera_avfoundation/lib/src/avfoundation_camera.dart
@@ -247,9 +247,7 @@ class AVFoundationCamera extends CameraPlatform {
 
   @override
   Future<void> startVideoRecording(int cameraId,
-      {Duration? maxVideoDuration,
-      Function(CameraImageData image)? streamCallback,
-      CameraImageStreamOptions? streamOptions}) async {
+      {Duration? maxVideoDuration}) async {
     return startVideoCapturing(
         VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
   }
@@ -318,7 +316,6 @@ class AVFoundationCamera extends CameraPlatform {
       onResume: _onFrameStreamPauseResume,
       onCancel: _onFrameStreamCancel,
     );
-    return _frameStreamController!;
   }
 
   void _onFrameStreamListen() {

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_avfoundation
 description: iOS implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.9.8+6
+version: 0.10.0
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -17,7 +17,7 @@ flutter:
         dartPluginClass: AVFoundationCamera
 
 dependencies:
-  camera_platform_interface: ^2.2.0
+  camera_platform_interface: ^2.3.1
   flutter:
     sdk: flutter
   stream_transform: ^2.0.0

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -587,6 +587,7 @@ void main() {
         isMethodCall('startVideoRecording', arguments: <String, Object?>{
           'cameraId': cameraId,
           'maxVideoDuration': null,
+          'enableStream': false,
         }),
       ]);
     });
@@ -609,7 +610,33 @@ void main() {
       expect(channel.log, <Matcher>[
         isMethodCall('startVideoRecording', arguments: <String, Object?>{
           'cameraId': cameraId,
-          'maxVideoDuration': 10000
+          'maxVideoDuration': 10000,
+          'enableStream': false,
+        }),
+      ]);
+    });
+
+    test(
+        'Should pass enableStream if callback is passed when starting recording a video',
+        () async {
+      // Arrange
+      final MethodChannelMock channel = MethodChannelMock(
+        channelName: _channelName,
+        methods: <String, dynamic>{'startVideoRecording': null},
+      );
+
+      // Act
+      await camera.startVideoRecording(
+        cameraId,
+        streamCallback: (imageData) {},
+      );
+
+      // Assert
+      expect(channel.log, <Matcher>[
+        isMethodCall('startVideoRecording', arguments: <String, Object?>{
+          'cameraId': cameraId,
+          'maxVideoDuration': null,
+          'enableStream': true,
         }),
       ]);
     });

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Exports VideoCaptureOptions to allow dependencies to implement concurrent stream and record
+
 ## 2.3.0
 
 * Adds new capture method for a camera to allow concurrent streaming and recording.

--- a/packages/camera/camera_platform_interface/lib/src/types/types.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/types.dart
@@ -10,3 +10,4 @@ export 'flash_mode.dart';
 export 'focus_mode.dart';
 export 'image_format_group.dart';
 export 'resolution_preset.dart';
+export 'video_capture_options.dart';

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.0
+version: 2.3.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -5,6 +5,10 @@
 * Fixes avoid_redundant_argument_values lint warnings and minor typos.
 * Ignores unnecessary import warnings in preparation for [upcoming Flutter changes](https://github.com/flutter/flutter/pull/106316).
 
+## 0.3.1
+
+* Update to latest camera platform interface, and fail if user attempts to use streaming with recording (since streaming is currently unsupported on web).
+
 ## 0.3.0
 
 * **BREAKING CHANGE**: Renames error code `cameraPermission` to `CameraAccessDenied` to be consistent with other platforms.

--- a/packages/camera/camera_web/lib/src/camera_web.dart
+++ b/packages/camera/camera_web/lib/src/camera_web.dart
@@ -451,23 +451,33 @@ class CameraPlugin extends CameraPlatform {
 
   @override
   Future<void> startVideoRecording(int cameraId, {Duration? maxVideoDuration}) {
+    return startVideoCapturing(
+        VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
+  }
+
+  @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) {
+    if (options.streamCallback != null || options.streamOptions != null) {
+      throw UnimplementedError('Streaming is not currently supported on web');
+    }
+
     try {
-      final Camera camera = getCamera(cameraId);
+      final Camera camera = getCamera(options.cameraId);
 
       // Add camera's video recording errors to the camera events stream.
       // The error event fires when the video recording is not allowed or an unsupported
       // codec is used.
-      _cameraVideoRecordingErrorSubscriptions[cameraId] =
+      _cameraVideoRecordingErrorSubscriptions[options.cameraId] =
           camera.onVideoRecordingError.listen((html.ErrorEvent errorEvent) {
         cameraEventStreamController.add(
           CameraErrorEvent(
-            cameraId,
+            options.cameraId,
             'Error code: ${errorEvent.type}, error message: ${errorEvent.message}.',
           ),
         );
       });
 
-      return camera.startVideoRecording(maxVideoDuration: maxVideoDuration);
+      return camera.startVideoRecording(maxVideoDuration: options.maxDuration);
     } on html.DomException catch (e) {
       throw PlatformException(code: e.name, message: e.message);
     } on CameraWebException catch (e) {

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_web
 description: A Flutter plugin for getting information about and controlling the camera on Web.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.3.0+1
+version: 0.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -17,7 +17,7 @@ flutter:
         fileName: camera_web.dart
 
 dependencies:
-  camera_platform_interface: ^2.1.0
+  camera_platform_interface: ^2.3.1
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates to latest camera platform interface but fails if user attempts to use streaming with recording (since streaming is currently unsupported on Windows).
+
 ## 0.2.1+2
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/camera/camera_windows/lib/camera_windows.dart
+++ b/packages/camera/camera_windows/lib/camera_windows.dart
@@ -214,15 +214,24 @@ class CameraWindows extends CameraPlatform {
       pluginChannel.invokeMethod<void>('prepareForVideoRecording');
 
   @override
-  Future<void> startVideoRecording(
-    int cameraId, {
-    Duration? maxVideoDuration,
-  }) async {
+  Future<void> startVideoRecording(int cameraId,
+      {Duration? maxVideoDuration}) async {
+    return startVideoCapturing(
+        VideoCaptureOptions(cameraId, maxDuration: maxVideoDuration));
+  }
+
+  @override
+  Future<void> startVideoCapturing(VideoCaptureOptions options) async {
+    if (options.streamCallback != null || options.streamOptions != null) {
+      throw UnimplementedError(
+          'Streaming is not currently supported on Windows');
+    }
+
     await pluginChannel.invokeMethod<void>(
       'startVideoRecording',
       <String, dynamic>{
-        'cameraId': cameraId,
-        'maxVideoDuration': maxVideoDuration?.inMilliseconds,
+        'cameraId': options.cameraId,
+        'maxVideoDuration': options.maxDuration?.inMilliseconds,
       },
     );
   }

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -17,7 +17,7 @@ flutter:
         dartPluginClass: CameraWindows
 
 dependencies:
-  camera_platform_interface: ^2.1.2
+  camera_platform_interface: ^2.3.1
   cross_file: ^0.3.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
_Recreated from https://github.com/flutter/plugins/pull/6290, that PR got messed up with some bad git merge. I tried to reset and force but GitHub closed the PR and I couldn't re-open it._

Implemented method to concurrently stream and record introduced in https://github.com/flutter/plugins/pull/6550. This feature is useful, for example, in applications that use image recognition. The customer will want some immediate feedback as the video is being recorded (where an ML model might be run on the captured images), as well as to upload the video to a server at the end for final server-side processing.

I have added unit tests to the higher-level dart abstractions, added integration tests for the underlying android and iOS implementations, and tested manually on Android and iOS devices. I have updated `camera_web` to throw an exception if the user attempts to enable streaming when recording (given that streaming is not yet supported).

Closes https://github.com/flutter/flutter/issues/83634

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
