### PR TITLE
Revert "[camera]: Bump robolectric from 4.5 to 4.8.2 in /packages/cam…

### DIFF
--- a/packages/camera/camera_android/android/build.gradle
+++ b/packages/camera/camera_android/android/build.gradle
@@ -63,5 +63,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.7.0'
     testImplementation 'androidx.test:core:1.4.0'
-    testImplementation 'org.robolectric:robolectric:4.8.2'
+    testImplementation 'org.robolectric:robolectric:4.5'
 }


### PR DESCRIPTION
verison：
  camera: ^0.10.0+4


------bug
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.camera2.CameraCaptureSession.close()' on a null object reference
        at io.flutter.plugins.camera.Camera.closeCaptureSession(Camera.java:1164)
        at io.flutter.plugins.camera.Camera.access$500(Camera.java:100)
        at io.flutter.plugins.camera.Camera$1.onClosed(Camera.java:342)
        at android.hardware.camera2.impl.CameraDeviceImpl$5.run(CameraDeviceImpl.java:249)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:257)

![Uploading image.png…]()
