### PR TITLE
[google_sign_in] Correctly passes `serverClientId` to native libs

### DIFF
--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.2
+
+* Fixes passing `serverClientId` via the channelled `init` call
+
 ## 6.1.1
 
 * Corrects typos in plugin error logs and removes not actionable warnings.

--- a/packages/google_sign_in/google_sign_in_android/lib/google_sign_in_android.dart
+++ b/packages/google_sign_in/google_sign_in_android/lib/google_sign_in_android.dart
@@ -45,6 +45,7 @@ class GoogleSignInAndroid extends GoogleSignInPlatform {
       'scopes': params.scopes,
       'hostedDomain': params.hostedDomain,
       'clientId': params.clientId,
+      'serverClientId': params.serverClientId,
       'forceCodeForRefreshToken': params.forceCodeForRefreshToken,
     });
   }

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.1.1
+version: 6.1.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_android/test/google_sign_in_android_test.dart
+++ b/packages/google_sign_in/google_sign_in_android/test/google_sign_in_android_test.dart
@@ -111,6 +111,7 @@ void main() {
         'scopes': <String>['two', 'scopes'],
         'signInOption': 'SignInOption.games',
         'clientId': 'fakeClientId',
+        'serverClientId': null,
         'forceCodeForRefreshToken': false,
       }),
       () {
@@ -119,12 +120,14 @@ void main() {
             scopes: <String>['two', 'scopes'],
             signInOption: SignInOption.games,
             clientId: 'fakeClientId',
+            serverClientId: 'fakeServerClientId',
             forceCodeForRefreshToken: true));
       }: isMethodCall('init', arguments: <String, dynamic>{
         'hostedDomain': 'example.com',
         'scopes': <String>['two', 'scopes'],
         'signInOption': 'SignInOption.games',
         'clientId': 'fakeClientId',
+        'serverClientId': 'fakeServerClientId',
         'forceCodeForRefreshToken': true,
       }),
       () {

--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 5.5.1
 
+* Fixes passing `serverClientId` via the channelled `init` call
 * Updates minimum Flutter version to 2.10.
 
 ## 5.5.0

--- a/packages/google_sign_in/google_sign_in_ios/lib/google_sign_in_ios.dart
+++ b/packages/google_sign_in/google_sign_in_ios/lib/google_sign_in_ios.dart
@@ -49,6 +49,7 @@ class GoogleSignInIOS extends GoogleSignInPlatform {
       'scopes': params.scopes,
       'hostedDomain': params.hostedDomain,
       'clientId': params.clientId,
+      'serverClientId': params.serverClientId,
     });
   }
 

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_ios
 description: iOS implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 5.5.0
+version: 5.5.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_sign_in/google_sign_in_ios/test/google_sign_in_ios_test.dart
+++ b/packages/google_sign_in/google_sign_in_ios/test/google_sign_in_ios_test.dart
@@ -124,16 +124,19 @@ void main() {
         'hostedDomain': 'example.com',
         'scopes': <String>['two', 'scopes'],
         'clientId': 'fakeClientId',
+        'serverClientId': null,
       }),
       () {
         googleSignIn.initWithParams(const SignInInitParameters(
             hostedDomain: 'example.com',
             scopes: <String>['two', 'scopes'],
-            clientId: 'fakeClientId'));
+            clientId: 'fakeClientId',
+            serverClientId: 'fakeServerClientId'));
       }: isMethodCall('init', arguments: <String, dynamic>{
         'hostedDomain': 'example.com',
         'scopes': <String>['two', 'scopes'],
         'clientId': 'fakeClientId',
+        'serverClientId': 'fakeServerClientId',
       }),
       () {
         googleSignIn.getTokens(


### PR DESCRIPTION
This PR compliments https://github.com/flutter/plugins/pull/5250 and https://github.com/flutter/plugins/pull/6034 to fully implement passing `serverClientId` to the native libs during channelled call.

Current implementation works fine if the value is provided via the corresponding plist / json file. But if provided via code only – it doesn't work properly. This PR addresses that problem.

Fixes https://github.com/flutter/flutter/issues/110099

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
