### PR TITLE
Switch Mac intel tasks from Cirrus to LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -45,7 +45,6 @@ targets:
   # pod's arch exclusions, so fails to build.
   - name: Mac_x64 lint_podspecs
     recipe: plugins/plugins
-    bringup: true # New target: https://github.com/flutter/plugins/pull/6637
     timeout: 30
     properties:
       add_recipes_cq: "true"
@@ -57,7 +56,6 @@ targets:
   # on Intel to give us build coverage of both host types.
   - name: Mac_x64 build_all_plugins master
     recipe: plugins/plugins
-    bringup: true # New target: https://github.com/flutter/plugins/pull/6671
     timeout: 30
     properties:
       add_recipes_cq: "true"
@@ -67,7 +65,6 @@ targets:
 
   - name: Mac_x64 build_all_plugins stable
     recipe: plugins/plugins
-    bringup: true # New target: https://github.com/flutter/plugins/pull/6671
     timeout: 30
     properties:
       add_recipes_cq: "true"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -340,13 +340,6 @@ task:
   << : *MACOS_INTEL_TEMPLATE
   << : *FLUTTER_UPGRADE_TEMPLATE
   matrix:
-    ### iOS+macOS tasks ***
-    # TODO(stuartmorgan): Move this to ARM once google_maps_flutter has ARM
-    # support. `pod lint` makes a synthetic target that doesn't respect the
-    # pod's arch exclusions, so fails to build.
-    - name: darwin-lint_podspecs
-      script:
-        - ./script/tool_runner.sh podspecs
     ### iOS tasks ###
     # TODO(stuartmorgan): Swap this and ios-build_all_plugins once simulator
     # tests are reliable on the ARM infrastructure. See discussion at
@@ -382,14 +375,3 @@ task:
         # This UI change sometimes affects `xctest`.
         # So we run `drive-examples` after `native-test`; changing the order will result ci failure.
         - ./script/tool_runner.sh drive-examples --ios --exclude=script/configs/exclude_integration_ios.yaml
-    ### macOS desktop tasks ###
-    # macos-platform_tests builds all the plugins on M1, so this build is run
-    # on Intel to give us build coverage of both host types.
-    - name: macos-build_all_plugins
-      env:
-        BUILD_ALL_ARGS: "macos"
-        matrix:
-          CHANNEL: "master"
-          CHANNEL: "stable"
-      setup_script:
-      << : *BUILD_ALL_PLUGINS_APP_TEMPLATE


### PR DESCRIPTION
This is a follow up of
https://github.com/flutter/plugins/pull/6637
https://github.com/flutter/plugins/pull/6671

This PR enables these three tasks in LUCI prod and disables them from Cirrus:
```
darwin_lint_podspecs
build_all_plugins master
build_all_plugins stable
```

These three tasks have been passing consistently in CI:
https://ci.chromium.org/p/flutter/builders/staging/Mac_x64%20lint_podspecs
https://ci.chromium.org/p/flutter/builders/staging/Mac_x64%20build_all_plugins%20master
https://ci.chromium.org/p/flutter/builders/staging/Mac_x64%20build_all_plugins%20stable

(part of https://github.com/flutter/flutter/issues/114373)