### PR TITLE
[video_player] Add optional web options

### DIFF
--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -14,7 +14,12 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 import 'src/closed_caption_file.dart';
 
 export 'package:video_player_platform_interface/video_player_platform_interface.dart'
-    show DurationRange, DataSourceType, VideoFormat, VideoPlayerOptions;
+    show
+        DurationRange,
+        DataSourceType,
+        VideoFormat,
+        VideoPlayerOptions,
+        VideoPlayerWebOptions;
 
 export 'src/closed_caption_file.dart';
 
@@ -363,6 +368,11 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         kUninitializedTextureId;
     _creatingCompleter!.complete(null);
     final Completer<void> initializingCompleter = Completer<void>();
+
+    if (videoPlayerOptions?.webOptions != null) {
+      await _videoPlayerPlatform.setWebOptions(
+          _textureId, videoPlayerOptions!.webOptions!);
+    }
 
     void eventListener(VideoEvent event) {
       if (_isDisposed) {

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -4,6 +4,7 @@ description: Flutter plugin for displaying inline video with other Flutter
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 version: 2.5.1
+publish_to: 'none'
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -23,10 +24,14 @@ dependencies:
   flutter:
     sdk: flutter
   html: ^0.15.0
-  video_player_android: ^2.3.5
-  video_player_avfoundation: ^2.2.17
-  video_player_platform_interface: ">=5.1.1 <7.0.0"
-  video_player_web: ^2.0.0
+  video_player_android:
+    path: ../video_player_android
+  video_player_avfoundation:
+    path: ../video_player_avfoundation
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
+  video_player_web:
+    path: ../video_player_web
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  video_player_platform_interface: ">=5.1.1 <7.0.0"
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface
 
 dev_dependencies:
   flutter_driver:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -3,6 +3,7 @@ description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 version: 2.3.10
+publish_to: 'none'
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -20,7 +21,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ">=5.1.1 <7.0.0"
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_avfoundation/example/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/example/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  video_player_platform_interface: ">=4.2.0 <7.0.0"
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface
 
 dev_dependencies:
   flutter_driver:

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -3,6 +3,7 @@ description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 version: 2.3.8
+publish_to: 'none'
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -19,7 +20,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ">=4.2.0 <7.0.0"
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -102,6 +102,11 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   Future<void> setMixWithOthers(bool mixWithOthers) {
     throw UnimplementedError('setMixWithOthers() has not been implemented.');
   }
+
+  /// Sets additional options on web
+  Future<void> setWebOptions(int textureId, VideoPlayerWebOptions controls) {
+    throw UnimplementedError('setWebOptions() has not been implemented.');
+  }
 }
 
 class _PlaceholderImplementation extends VideoPlayerPlatform {}
@@ -359,6 +364,7 @@ class VideoPlayerOptions {
   VideoPlayerOptions({
     this.mixWithOthers = false,
     this.allowBackgroundPlayback = false,
+    this.webOptions,
   });
 
   /// Set this to true to keep playing video in background, when app goes in background.
@@ -371,4 +377,41 @@ class VideoPlayerOptions {
   /// Note: This option will be silently ignored in the web platform (there is
   /// currently no way to implement this feature in this platform).
   final bool mixWithOthers;
+
+  /// Additional web controls
+  final VideoPlayerWebOptions? webOptions;
+}
+
+/// [VideoPlayerWebOptions] can be optionally used to set additional web settings
+@immutable
+class VideoPlayerWebOptions {
+  /// [VideoPlayerWebOptions] can be optionally used to set additional web settings
+  const VideoPlayerWebOptions({
+    this.controlsEnabled = false,
+    this.allowDownload = true,
+    this.allowFullscreen = true,
+    this.allowPlaybackRate = true,
+    this.allowContextMenu = true,
+  });
+
+  /// Whether native controls are enabled
+  final bool controlsEnabled;
+
+  /// Whether downloaded control is displayed
+  ///
+  /// Only applicable when [controlsEnabled] is true
+  final bool allowDownload;
+
+  /// Whether fullscreen control is enabled
+  ///
+  /// Only applicable when [controlsEnabled] is true
+  final bool allowFullscreen;
+
+  /// Whether playback rate control is displayed
+  ///
+  /// Only applicable when [controlsEnabled] is true
+  final bool allowPlaybackRate;
+
+  /// Whether context menu (right click) is allowed
+  final bool allowContextMenu;
 }

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -9,7 +9,8 @@ dependencies:
   flutter:
     sdk: flutter
   js: ^0.6.0
-  video_player_platform_interface: ">=4.2.0 <7.0.0"
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface
   video_player_web:
     path: ../
 

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -45,6 +45,7 @@ class VideoPlayer {
 
   final StreamController<VideoEvent> _eventController;
   final html.VideoElement _videoElement;
+  dynamic Function(html.Event)? _onContextMenu;
 
   bool _isInitialized = false;
   bool _isBuffering = false;
@@ -188,9 +189,40 @@ class VideoPlayer {
     return Duration(milliseconds: (_videoElement.currentTime * 1000).round());
   }
 
+  /// Sets control options
+  Future<void> setControls(VideoPlayerWebOptions controls) async {
+    if (controls.controlsEnabled) {
+      _videoElement.controls = true;
+      final List<String> attributes = <String>[];
+      if (!controls.allowDownload) {
+        attributes.add('nodownload');
+      }
+      if (!controls.allowFullscreen) {
+        attributes.add('nofullscreen');
+      }
+      if (!controls.allowPlaybackRate) {
+        attributes.add('noplaybackrate');
+      }
+      if (attributes.isNotEmpty) {
+        _videoElement.setAttribute(
+          'controlsList',
+          attributes
+              .reduce((String value, String element) => '$value $element'),
+        );
+      }
+    }
+
+    if (!controls.allowContextMenu) {
+      _onContextMenu = (html.Event event) => event.preventDefault();
+      _videoElement.addEventListener('contextmenu', _onContextMenu);
+    }
+  }
+
   /// Disposes of the current [html.VideoElement].
   void dispose() {
     _videoElement.removeAttribute('src');
+    _videoElement.removeEventListener('contextmenu', _onContextMenu);
+    _onContextMenu = null;
     _videoElement.load();
   }
 

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -132,6 +132,11 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
     return _player(textureId).events;
   }
 
+  @override
+  Future<void> setWebOptions(int textureId, VideoPlayerWebOptions controls) {
+    return _player(textureId).setControls(controls);
+  }
+
   // Retrieves a [VideoPlayer] by its internal `id`.
   // It must have been created earlier from the [create] method.
   VideoPlayer _player(int id) {

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -3,6 +3,7 @@ description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 version: 2.0.13
+publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -21,7 +22,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  video_player_platform_interface: ">=4.2.0 <7.0.0"
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
* Fixes https://github.com/flutter/flutter/issues/62192
* Fixes first part of https://github.com/flutter/flutter/issues/88151 (ability to show controls)

Currently opening this PR as a draft in order to receive feedback on the api

Can be used as follows:

```dart
_controller = VideoPlayerController.asset(
  'assets/Butterfly-209.mp4',
  videoPlayerOptions: VideoPlayerOptions(
    webOptions: const VideoPlayerWebOptions(
      controlsEnabled: true,
      allowDownload: false,
      allowContextMenu: false,
      allowFullscreen: false,
      allowPlaybackRate: false,
    ),
  ),
);
```

![Bildschirmfoto 2022-11-18 um 10 44 22](https://user-images.githubusercontent.com/13286425/202671840-e491c9e0-97b3-448a-b7f4-488f57b1f05a.png)


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
