### PR TITLE
[webview_flutter] Added missing settings when developing initial AndroidWebViewController

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/lib/src/v4/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/v4/src/android_webview_controller.dart
@@ -15,10 +15,32 @@ import 'package:webview_flutter_platform_interface/v4/webview_flutter_platform_i
 
 import '../../android_webview.dart' as android_webview;
 import '../../android_webview.dart';
-import '../../instance_manager.dart';
 import '../../weak_reference_utils.dart';
 import 'android_navigation_delegate.dart';
 import 'android_proxy.dart';
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Specifies possible restrictions on automatic media playback.
+///
+/// This is typically used in [WebView.initialMediaPlaybackPolicy].
+// The method channel implementation is marshalling this enum to the value's index, so the order
+// is important.
+enum AutoMediaPlaybackPolicy {
+  /// Starting any kind of media playback requires a user action.
+  ///
+  /// For example: JavaScript code cannot start playing media unless the code was executed
+  /// as a result of a user action (like a touch event).
+  require_user_action_for_all_media_types,
+
+  /// Starting any kind of media playback is always allowed.
+  ///
+  /// For example: JavaScript code that's triggered when the page is loaded can start playing
+  /// video or audio.
+  always_allow,
+}
 
 /// Object specifying creation parameters for creating a [AndroidWebViewController].
 ///
@@ -258,6 +280,21 @@ class AndroidWebViewController extends PlatformWebViewController {
       _androidWebViewParams.androidWebViewProxy
           .setWebContentsDebuggingEnabled(enabled);
 
+  /// Sets whether the DOM storage API is enabled.
+  ///
+  /// The default value is false.
+  Future<void> enableDomStorage(bool enabled) =>
+      _webView.settings.setDomStorageEnabled(enabled);
+
+  /// Enables or disables file access within WebView.
+  ///
+  /// This enables or disables file system access only. Assets and resources are
+  /// still accessible using file:///android_asset and file:///android_res. The
+  /// default value is true for apps targeting Build.VERSION_CODES.Q and below,
+  /// and false when targeting Build.VERSION_CODES.R and above.
+  Future<void> enableFileAccess(bool enabled) =>
+      _webView.settings.setAllowFileAccess(enabled);
+
   @override
   Future<void> enableZoom(bool enabled) =>
       _webView.settings.setSupportZoom(enabled);
@@ -266,14 +303,79 @@ class AndroidWebViewController extends PlatformWebViewController {
   Future<void> setBackgroundColor(Color color) =>
       _webView.setBackgroundColor(color);
 
+  // TODO(bparrishMines): Update documentation when ZoomButtonsController is added.
+  /// Sets whether the WebView should display on-screen zoom controls when using the built-in zoom mechanisms.
+  ///
+  /// See [setBuiltInZoomControls]. The default is true. However, on-screen zoom
+  /// controls are deprecated in Android so it's recommended to set this to
+  /// false.
+  Future<void> setBuiltInZoomControls(bool enabled) =>
+      _webView.settings.setBuiltInZoomControls(enabled);
+
+  // TODO(bparrishMines): Update documentation when ZoomButtonsController is added.
+  /// Sets whether the WebView should use its built-in zoom mechanisms.
+  ///
+  /// The built-in zoom mechanisms comprise on-screen zoom controls, which are
+  /// displayed over the WebView's content, and the use of a pinch gesture to
+  /// control zooming. Whether or not these on-screen controls are displayed can
+  /// be set with [setDisplayZoomControls]. The default is false.
+  ///
+  /// The built-in mechanisms are the only currently supported zoom mechanisms,
+  /// so it is recommended that this setting is always enabled. However,
+  /// on-screen zoom controls are deprecated in Android so it's recommended to
+  /// disable [setDisplayZoomControls].
+  Future<void> setDisplayZoomControls(bool enabled) =>
+      _webView.settings.setDisplayZoomControls(enabled);
+
+  /// Sets whether the WebView loads pages in overview mode, that is, zooms out the content to fit on screen by width.
+  ///
+  /// This setting is taken into account when the content width is greater than
+  /// the width of the WebView control, for example, when [setUseWideViewPort]
+  /// is enabled.
+  ///
+  /// The default is false.
+  Future<void> setLoadWithOverviewMode(bool enabled) =>
+      _webView.settings.setLoadWithOverviewMode(enabled);
+
   @override
   Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) =>
       _webView.settings
           .setJavaScriptEnabled(javaScriptMode == JavaScriptMode.unrestricted);
 
+  /// Sets wether JavaScript is allowed to open windows automatically.
+  ///
+  /// This applies to the JavaScript function `window.open()`. The default is
+  /// false.
+  Future<void> setJavaScriptCanOpenWindowsAutomatically(bool enabled) =>
+      _webView.settings.setJavaScriptCanOpenWindowsAutomatically(enabled);
+
+  // TODO(bparrishMines): Update documentation when WebChromeClient.onCreateWindow is added.
+  /// Sets whether the WebView should supports multiple windows.
+  ///
+  /// The default is false.
+  Future<void> setSupportMultipleWindows(bool support) =>
+      _webView.settings.setSupportMultipleWindows(support);
+
+  /// Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport.
+  ///
+  /// When the value of the setting is false, the layout width is always set to
+  /// the width of the WebView control in device-independent (CSS) pixels. When
+  /// the value is true and the page contains the viewport meta tag, the value
+  /// of the width specified in the tag is used. If the page does not contain
+  /// the tag or does not provide a width, then a wide viewport will be used.
+  Future<void> setUseWideViewPort(bool enabled) =>
+      _webView.settings.setUseWideViewPort(enabled);
+
   @override
   Future<void> setUserAgent(String? userAgent) =>
       _webView.settings.setUserAgentString(userAgent);
+
+  /// Sets the restrictions that apply on automatic media playback.
+  Future<void> setAutoMediaPlaybackPolicy(
+      AutoMediaPlaybackPolicy autoMediaPlaybackPolicy) {
+    return _webView.settings.setMediaPlaybackRequiresUserGesture(
+        autoMediaPlaybackPolicy != AutoMediaPlaybackPolicy.always_allow);
+  }
 }
 
 /// An implementation of [JavaScriptChannelParams] with the Android WebView API.

--- a/packages/webview_flutter/webview_flutter_android/lib/src/v4/src/android_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_android/lib/src/v4/src/android_webview_controller.dart
@@ -19,29 +19,6 @@ import '../../weak_reference_utils.dart';
 import 'android_navigation_delegate.dart';
 import 'android_proxy.dart';
 
-// Copyright 2013 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-/// Specifies possible restrictions on automatic media playback.
-///
-/// This is typically used in [WebView.initialMediaPlaybackPolicy].
-// The method channel implementation is marshalling this enum to the value's index, so the order
-// is important.
-enum AutoMediaPlaybackPolicy {
-  /// Starting any kind of media playback requires a user action.
-  ///
-  /// For example: JavaScript code cannot start playing media unless the code was executed
-  /// as a result of a user action (like a touch event).
-  require_user_action_for_all_media_types,
-
-  /// Starting any kind of media playback is always allowed.
-  ///
-  /// For example: JavaScript code that's triggered when the page is loaded can start playing
-  /// video or audio.
-  always_allow,
-}
-
 /// Object specifying creation parameters for creating a [AndroidWebViewController].
 ///
 /// When adding additional fields make sure they can be null or have a default
@@ -91,20 +68,29 @@ class AndroidWebViewController extends PlatformWebViewController {
       : super.implementation(params is AndroidWebViewControllerCreationParams
             ? params
             : AndroidWebViewControllerCreationParams
-                .fromPlatformWebViewControllerCreationParams(params));
+                .fromPlatformWebViewControllerCreationParams(params)) {
+    _webView = _androidWebViewParams.androidWebViewProxy.createAndroidWebView(
+      // Due to changes in Flutter 3.0 the `useHybridComposition` doesn't have
+      // any effect and is purposefully not exposed publicly by the
+      // [AndroidWebViewController]. More info here:
+      // https://github.com/flutter/flutter/issues/108106
+      useHybridComposition: true,
+    );
+
+    _webView.settings.setDomStorageEnabled(true);
+    _webView.settings.setJavaScriptCanOpenWindowsAutomatically(true);
+    _webView.settings.setSupportMultipleWindows(true);
+    _webView.settings.setLoadWithOverviewMode(true);
+    _webView.settings.setUseWideViewPort(true);
+    _webView.settings.setDisplayZoomControls(false);
+    _webView.settings.setBuiltInZoomControls(true);
+  }
 
   AndroidWebViewControllerCreationParams get _androidWebViewParams =>
       params as AndroidWebViewControllerCreationParams;
 
   /// The native [android_webview.WebView] being controlled.
-  late final android_webview.WebView _webView =
-      _androidWebViewParams.androidWebViewProxy.createAndroidWebView(
-    // Due to changes in Flutter 3.0 the `useHybridComposition` doesn't have
-    // any effect and is purposefully not exposed publicly by the
-    // [AndroidWebViewController]. More info here:
-    // https://github.com/flutter/flutter/issues/108106
-    useHybridComposition: true,
-  );
+  late final android_webview.WebView _webView;
 
   /// The native [android_webview.FlutterAssetManager] allows managing assets.
   late final android_webview.FlutterAssetManager _flutterAssetManager =
@@ -280,12 +266,6 @@ class AndroidWebViewController extends PlatformWebViewController {
       _androidWebViewParams.androidWebViewProxy
           .setWebContentsDebuggingEnabled(enabled);
 
-  /// Sets whether the DOM storage API is enabled.
-  ///
-  /// The default value is false.
-  Future<void> enableDomStorage(bool enabled) =>
-      _webView.settings.setDomStorageEnabled(enabled);
-
   /// Enables or disables file access within WebView.
   ///
   /// This enables or disables file system access only. Assets and resources are
@@ -303,78 +283,18 @@ class AndroidWebViewController extends PlatformWebViewController {
   Future<void> setBackgroundColor(Color color) =>
       _webView.setBackgroundColor(color);
 
-  // TODO(bparrishMines): Update documentation when ZoomButtonsController is added.
-  /// Sets whether the WebView should display on-screen zoom controls when using the built-in zoom mechanisms.
-  ///
-  /// See [setBuiltInZoomControls]. The default is true. However, on-screen zoom
-  /// controls are deprecated in Android so it's recommended to set this to
-  /// false.
-  Future<void> setBuiltInZoomControls(bool enabled) =>
-      _webView.settings.setBuiltInZoomControls(enabled);
-
-  // TODO(bparrishMines): Update documentation when ZoomButtonsController is added.
-  /// Sets whether the WebView should use its built-in zoom mechanisms.
-  ///
-  /// The built-in zoom mechanisms comprise on-screen zoom controls, which are
-  /// displayed over the WebView's content, and the use of a pinch gesture to
-  /// control zooming. Whether or not these on-screen controls are displayed can
-  /// be set with [setDisplayZoomControls]. The default is false.
-  ///
-  /// The built-in mechanisms are the only currently supported zoom mechanisms,
-  /// so it is recommended that this setting is always enabled. However,
-  /// on-screen zoom controls are deprecated in Android so it's recommended to
-  /// disable [setDisplayZoomControls].
-  Future<void> setDisplayZoomControls(bool enabled) =>
-      _webView.settings.setDisplayZoomControls(enabled);
-
-  /// Sets whether the WebView loads pages in overview mode, that is, zooms out the content to fit on screen by width.
-  ///
-  /// This setting is taken into account when the content width is greater than
-  /// the width of the WebView control, for example, when [setUseWideViewPort]
-  /// is enabled.
-  ///
-  /// The default is false.
-  Future<void> setLoadWithOverviewMode(bool enabled) =>
-      _webView.settings.setLoadWithOverviewMode(enabled);
-
   @override
   Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) =>
       _webView.settings
           .setJavaScriptEnabled(javaScriptMode == JavaScriptMode.unrestricted);
-
-  /// Sets wether JavaScript is allowed to open windows automatically.
-  ///
-  /// This applies to the JavaScript function `window.open()`. The default is
-  /// false.
-  Future<void> setJavaScriptCanOpenWindowsAutomatically(bool enabled) =>
-      _webView.settings.setJavaScriptCanOpenWindowsAutomatically(enabled);
-
-  // TODO(bparrishMines): Update documentation when WebChromeClient.onCreateWindow is added.
-  /// Sets whether the WebView should supports multiple windows.
-  ///
-  /// The default is false.
-  Future<void> setSupportMultipleWindows(bool support) =>
-      _webView.settings.setSupportMultipleWindows(support);
-
-  /// Sets whether the WebView should enable support for the "viewport" HTML meta tag or should use a wide viewport.
-  ///
-  /// When the value of the setting is false, the layout width is always set to
-  /// the width of the WebView control in device-independent (CSS) pixels. When
-  /// the value is true and the page contains the viewport meta tag, the value
-  /// of the width specified in the tag is used. If the page does not contain
-  /// the tag or does not provide a width, then a wide viewport will be used.
-  Future<void> setUseWideViewPort(bool enabled) =>
-      _webView.settings.setUseWideViewPort(enabled);
 
   @override
   Future<void> setUserAgent(String? userAgent) =>
       _webView.settings.setUserAgentString(userAgent);
 
   /// Sets the restrictions that apply on automatic media playback.
-  Future<void> setAutoMediaPlaybackPolicy(
-      AutoMediaPlaybackPolicy autoMediaPlaybackPolicy) {
-    return _webView.settings.setMediaPlaybackRequiresUserGesture(
-        autoMediaPlaybackPolicy != AutoMediaPlaybackPolicy.always_allow);
+  Future<void> setMediaPlaybackRequiresUserGesture(bool require) {
+    return _webView.settings.setMediaPlaybackRequiresUserGesture(require);
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
@@ -40,6 +40,7 @@ void main() {
       android_webview.WebView? mockWebView,
       android_webview.WebViewClient? mockWebViewClient,
       android_webview.WebStorage? mockWebStorage,
+      android_webview.WebSettings? mockSettings,
     }) {
       final android_webview.WebView nonNullMockWebView =
           mockWebView ?? MockWebView();
@@ -91,6 +92,9 @@ void main() {
                     mockJavaScriptChannel ?? MockJavaScriptChannel(),
               ));
 
+      when(nonNullMockWebView.settings)
+          .thenReturn(mockSettings ?? MockWebSettings());
+
       return AndroidWebViewController(creationParams);
     }
 
@@ -116,9 +120,8 @@ void main() {
       final MockWebSettings mockWebSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockWebSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockWebSettings);
 
       await controller.loadFile('/path/to/file.html');
 
@@ -134,9 +137,8 @@ void main() {
       final MockWebSettings mockWebSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockWebSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockWebSettings);
 
       await controller.loadFile('/path/to/?_<_>_.html');
 
@@ -152,9 +154,8 @@ void main() {
       final MockWebSettings mockWebSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockWebSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockWebSettings);
 
       await controller.loadFile('file:///path/to/file.html');
 
@@ -623,33 +624,23 @@ void main() {
     });
 
     test('enableDebugging', () async {
+      final MockWebView mockWebView = MockWebView();
       final MockAndroidWebViewProxy mockProxy = MockAndroidWebViewProxy();
       final AndroidWebViewControllerCreationParams creationParams =
           AndroidWebViewControllerCreationParams(
         androidWebViewProxy: mockProxy,
         androidWebStorage: MockWebStorage(),
       );
+      when(mockProxy.createAndroidWebView).thenReturn(
+        ({required bool useHybridComposition}) => mockWebView,
+      );
+      when(mockWebView.settings).thenReturn(MockWebSettings());
+
       final AndroidWebViewController controller =
           AndroidWebViewController(creationParams);
-
       await controller.enableDebugging(true);
 
       verify(mockProxy.setWebContentsDebuggingEnabled(true)).called(1);
-    });
-
-    test('enableDomStorage', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.enableDomStorage(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setDomStorageEnabled(true)).called(1);
     });
 
     test('enableFileAccess', () async {
@@ -657,13 +648,10 @@ void main() {
       final MockWebSettings mockSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockSettings,
       );
 
-      when(mockWebView.settings).thenReturn(mockSettings);
-
       await controller.enableFileAccess(true);
-
-      verify(mockWebView.settings).called(1);
       verify(mockSettings.setAllowFileAccess(true)).called(1);
     });
 
@@ -672,13 +660,11 @@ void main() {
       final MockWebSettings mockSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
 
       await controller.enableZoom(true);
 
-      verify(mockWebView.settings).called(1);
       verify(mockSettings.setSupportZoom(true)).called(1);
     });
 
@@ -693,131 +679,30 @@ void main() {
       verify(mockWebView.setBackgroundColor(Colors.blue)).called(1);
     });
 
-    test('setBuiltInZoomControls', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setBuiltInZoomControls(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setBuiltInZoomControls(true)).called(1);
-    });
-
-    test('setDisplayZoomControls', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setDisplayZoomControls(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setDisplayZoomControls(true)).called(1);
-    });
-
-    test('setJavaScriptCanOpenWindowsAutomatically', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setJavaScriptCanOpenWindowsAutomatically(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setJavaScriptCanOpenWindowsAutomatically(true))
-          .called(1);
-    });
-
     test('setJavaScriptMode', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
 
       await controller.setJavaScriptMode(JavaScriptMode.disabled);
 
-      verify(mockWebView.settings).called(1);
       verify(mockSettings.setJavaScriptEnabled(false)).called(1);
     });
 
-    test(
-        'setAutoMediaPlaybackPolicy should set Media Playback Requires User Gesture to false when policy is set to always_allow.',
-        () async {
+    test('setMediaPlaybackRequiresUserGesture', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockSettings,
       );
 
-      when(mockWebView.settings).thenReturn(mockSettings);
+      await controller.setMediaPlaybackRequiresUserGesture(true);
 
-      await controller
-          .setAutoMediaPlaybackPolicy(AutoMediaPlaybackPolicy.always_allow);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setMediaPlaybackRequiresUserGesture(false)).called(1);
-    });
-
-    test(
-        'setAutoMediaPlaybackPolicy should set Media Playback Requires User Gesture to true when policy is anything but always_allow.',
-        () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setAutoMediaPlaybackPolicy(
-          AutoMediaPlaybackPolicy.require_user_action_for_all_media_types);
-
-      verify(mockWebView.settings).called(1);
       verify(mockSettings.setMediaPlaybackRequiresUserGesture(true)).called(1);
-    });
-
-    test('setLoadWithOverviewMode', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setLoadWithOverviewMode(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setLoadWithOverviewMode(true)).called(1);
-    });
-
-    test('setSupportMultipleWindows', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setSupportMultipleWindows(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setSupportMultipleWindows(true)).called(1);
     });
 
     test('setUserAgent', () async {
@@ -825,29 +710,12 @@ void main() {
       final MockWebSettings mockSettings = MockWebSettings();
       final AndroidWebViewController controller = createControllerWithMocks(
         mockWebView: mockWebView,
+        mockSettings: mockSettings,
       );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
 
       await controller.setUserAgent('Test Framework');
 
-      verify(mockWebView.settings).called(1);
       verify(mockSettings.setUserAgentString('Test Framework')).called(1);
-    });
-
-    test('setUseWideViewPort', () async {
-      final MockWebView mockWebView = MockWebView();
-      final MockWebSettings mockSettings = MockWebSettings();
-      final AndroidWebViewController controller = createControllerWithMocks(
-        mockWebView: mockWebView,
-      );
-
-      when(mockWebView.settings).thenReturn(mockSettings);
-
-      await controller.setUseWideViewPort(true);
-
-      verify(mockWebView.settings).called(1);
-      verify(mockSettings.setUseWideViewPort(true)).called(1);
     });
   });
 }

--- a/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
@@ -637,6 +637,36 @@ void main() {
       verify(mockProxy.setWebContentsDebuggingEnabled(true)).called(1);
     });
 
+    test('enableDomStorage', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.enableDomStorage(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setDomStorageEnabled(true)).called(1);
+    });
+
+    test('enableFileAccess', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.enableFileAccess(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setAllowFileAccess(true)).called(1);
+    });
+
     test('enableZoom', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockSettings = MockWebSettings();
@@ -663,6 +693,52 @@ void main() {
       verify(mockWebView.setBackgroundColor(Colors.blue)).called(1);
     });
 
+    test('setBuiltInZoomControls', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setBuiltInZoomControls(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setBuiltInZoomControls(true)).called(1);
+    });
+
+    test('setDisplayZoomControls', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setDisplayZoomControls(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setDisplayZoomControls(true)).called(1);
+    });
+
+    test('setJavaScriptCanOpenWindowsAutomatically', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setJavaScriptCanOpenWindowsAutomatically(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setJavaScriptCanOpenWindowsAutomatically(true))
+          .called(1);
+    });
+
     test('setJavaScriptMode', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockSettings = MockWebSettings();
@@ -678,6 +754,72 @@ void main() {
       verify(mockSettings.setJavaScriptEnabled(false)).called(1);
     });
 
+    test(
+        'setAutoMediaPlaybackPolicy should set Media Playback Requires User Gesture to false when policy is set to always_allow.',
+        () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller
+          .setAutoMediaPlaybackPolicy(AutoMediaPlaybackPolicy.always_allow);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setMediaPlaybackRequiresUserGesture(false)).called(1);
+    });
+
+    test(
+        'setAutoMediaPlaybackPolicy should set Media Playback Requires User Gesture to true when policy is anything but always_allow.',
+        () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setAutoMediaPlaybackPolicy(
+          AutoMediaPlaybackPolicy.require_user_action_for_all_media_types);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setMediaPlaybackRequiresUserGesture(true)).called(1);
+    });
+
+    test('setLoadWithOverviewMode', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setLoadWithOverviewMode(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setLoadWithOverviewMode(true)).called(1);
+    });
+
+    test('setSupportMultipleWindows', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setSupportMultipleWindows(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setSupportMultipleWindows(true)).called(1);
+    });
+
     test('setUserAgent', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockSettings = MockWebSettings();
@@ -691,6 +833,21 @@ void main() {
 
       verify(mockWebView.settings).called(1);
       verify(mockSettings.setUserAgentString('Test Framework')).called(1);
+    });
+
+    test('setUseWideViewPort', () async {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+      );
+
+      when(mockWebView.settings).thenReturn(mockSettings);
+
+      await controller.setUseWideViewPort(true);
+
+      verify(mockWebView.settings).called(1);
+      verify(mockSettings.setUseWideViewPort(true)).called(1);
     });
   });
 }

--- a/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/test/v4/android_webview_controller_test.dart
@@ -115,6 +115,26 @@ void main() {
           ));
     }
 
+    test(
+        'AndroidWebViewController should initialize WebView with default settings',
+        () {
+      final MockWebView mockWebView = MockWebView();
+      final MockWebSettings mockWebSettings = MockWebSettings();
+      final AndroidWebViewController controller = createControllerWithMocks(
+        mockWebView: mockWebView,
+        mockSettings: mockWebSettings,
+      );
+
+      verify(mockWebSettings.setBuiltInZoomControls(true)).called(1);
+      verify(mockWebSettings.setDisplayZoomControls(false)).called(1);
+      verify(mockWebSettings.setDomStorageEnabled(true)).called(1);
+      verify(mockWebSettings.setJavaScriptCanOpenWindowsAutomatically(true))
+          .called(1);
+      verify(mockWebSettings.setLoadWithOverviewMode(true)).called(1);
+      verify(mockWebSettings.setSupportMultipleWindows(true)).called(1);
+      verify(mockWebSettings.setUseWideViewPort(true)).called(1);
+    });
+
     test('loadFile without file prefix', () async {
       final MockWebView mockWebView = MockWebView();
       final MockWebSettings mockWebSettings = MockWebSettings();


### PR DESCRIPTION
Added the following setters which I missed during initial development:

- `setBuiltInZoomControls`
- `setDisplayZoomControls`
- `setJavaScriptCanOpenWindowsAutomatically`
- `setLoadWithOverviewMode`
- `setSupportMultipleWindows`
- `setUseWideViewPort`

Part of issue https://github.com/flutter/flutter/issues/94051

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
