### PR TITLE
[google_maps_flutter_web] Allow marker position updates

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 0.4.0+4
 
+* Allows marker position updates. Issue [#83467](https://github.com/flutter/flutter/issues/83467).
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.
 
 ## 0.4.0+3

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/marker_test.dart
@@ -100,13 +100,16 @@ void main() {
     testWidgets('update', (WidgetTester tester) async {
       final MarkerController controller = MarkerController(marker: marker);
       final gmaps.MarkerOptions options = gmaps.MarkerOptions()
-        ..draggable = true;
+        ..draggable = true
+        ..position = gmaps.LatLng(42, 54);
 
       expect(marker.draggable, isNull);
 
       controller.update(options);
 
       expect(marker.draggable, isTrue);
+      expect(marker.position?.lat, equals(42));
+      expect(marker.position?.lng, equals(54));
     });
 
     testWidgets('infoWindow null, showInfoWindow.',

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/integration_test/markers_test.dart
@@ -55,15 +55,22 @@ void main() {
       expect(
           controller.markers[const MarkerId('1')]?.marker?.draggable, isFalse);
 
-      // Update the marker with radius 10
+      // Update the marker with draggability and position
       final Set<Marker> updatedMarkers = <Marker>{
-        const Marker(markerId: MarkerId('1'), draggable: true),
+        const Marker(
+          markerId: MarkerId('1'),
+          draggable: true,
+          position: LatLng(42, 54),
+        ),
       };
       controller.changeMarkers(updatedMarkers);
 
       expect(controller.markers.length, 1);
-      expect(
-          controller.markers[const MarkerId('1')]?.marker?.draggable, isTrue);
+      final gmaps.Marker? marker =
+          controller.markers[const MarkerId('1')]?.marker;
+      expect(marker?.draggable, isTrue);
+      expect(marker?.position?.lat, equals(42));
+      expect(marker?.position?.lng, equals(54));
     });
 
     testWidgets('removeMarkers', (WidgetTester tester) async {

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/convert.dart
@@ -284,17 +284,15 @@ gmaps.Icon? _gmIconFromBitmapDescriptor(BitmapDescriptor bitmapDescriptor) {
 
 // Computes the options for a new [gmaps.Marker] from an incoming set of options
 // [marker], and the existing marker registered with the map: [currentMarker].
-// Preserves the position from the [currentMarker], if set.
 gmaps.MarkerOptions _markerOptionsFromMarker(
   Marker marker,
   gmaps.Marker? currentMarker,
 ) {
   return gmaps.MarkerOptions()
-    ..position = currentMarker?.position ??
-        gmaps.LatLng(
-          marker.position.latitude,
-          marker.position.longitude,
-        )
+    ..position = gmaps.LatLng(
+      marker.position.latitude,
+      marker.position.longitude,
+    )
     ..title = sanitizeHtml(marker.infoWindow.title ?? '')
     ..zIndex = marker.zIndex
     ..visible = marker.visible

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_web
 description: Web platform implementation of google_maps_flutter
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 0.4.0+3
+version: 0.4.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Unconditionally convert the current marker position in `convert.dart:_markerOptionsFromMarker`, to allow for position updates.

Also adds position changes to `marker_test.dart/MarkerController/update` and `markers_test.dart/MarkersController/changeMarkers`. The `MarkersController` case is fixed by this patch.

Issue: flutter/flutter#83467

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
