### PR TITLE
[camera] Handle empty grantResults on permission request

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0+5
+
+* Fixes `ArrayIndexOutOfBoundsException` when the permission request is interrupted.
 ## 0.10.0+4
 
 * Upgrades `androidx.annotation` version to 1.5.0.

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.10.0+5
 
 * Fixes `ArrayIndexOutOfBoundsException` when the permission request is interrupted.
+
 ## 0.10.0+4
 
 * Upgrades `androidx.annotation` version to 1.5.0.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/CameraPermissions.java
@@ -105,7 +105,9 @@ final class CameraPermissions {
       }
 
       alreadyCalled = true;
-      if (grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+      // grantResults could be empty if the permissions request with the user is interrupted
+      // https://developer.android.com/reference/android/app/Activity#onRequestPermissionsResult(int,%20java.lang.String[],%20int[])
+      if (grantResults.length == 0 || grantResults[0] != PackageManager.PERMISSION_GRANTED) {
         callback.onResult(CAMERA_ACCESS_DENIED, CAMERA_ACCESS_DENIED_MESSAGE);
       } else if (grantResults.length > 1 && grantResults[1] != PackageManager.PERMISSION_GRANTED) {
         callback.onResult(AUDIO_ACCESS_DENIED, AUDIO_ACCESS_DENIED_MESSAGE);

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
@@ -76,13 +76,12 @@ public class CameraPermissionsTest {
   @Test
   public void callback_respondsWithCameraAccessDeniedWhenEmptyResult() {
     // Handles the case where the grantResults array is empty
-    
+
     ResultCallback fakeResultCallback = mock(ResultCallback.class);
     CameraRequestPermissionsListener permissionsListener =
         new CameraRequestPermissionsListener(fakeResultCallback);
 
-    permissionsListener.onRequestPermissionsResult(
-        9796, null, new int[] {});
+    permissionsListener.onRequestPermissionsResult(9796, null, new int[] {});
 
     verify(fakeResultCallback)
         .onResult("CameraAccessDenied", "Camera access permission was denied.");

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
@@ -75,7 +75,7 @@ public class CameraPermissionsTest {
 
   @Test
   public void callback_respondsWithCameraAccessDeniedWhenEmptyResult() {
-    // Handles the case where the grantReults array is empty
+    // Handles the case where the grantResults array is empty
     
     ResultCallback fakeResultCallback = mock(ResultCallback.class);
     CameraRequestPermissionsListener permissionsListener =

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/CameraPermissionsTest.java
@@ -72,4 +72,19 @@ public class CameraPermissionsTest {
     verify(fakeResultCallback, never())
         .onResult("AudioAccessDenied", "Audio access permission was denied.");
   }
+
+  @Test
+  public void callback_respondsWithCameraAccessDeniedWhenEmptyResult() {
+    // Handles the case where the grantReults array is empty
+    
+    ResultCallback fakeResultCallback = mock(ResultCallback.class);
+    CameraRequestPermissionsListener permissionsListener =
+        new CameraRequestPermissionsListener(fakeResultCallback);
+
+    permissionsListener.onRequestPermissionsResult(
+        9796, null, new int[] {});
+
+    verify(fakeResultCallback)
+        .onResult("CameraAccessDenied", "Camera access permission was denied.");
+  }
 }

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android
 description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.0+4
+version: 0.10.0+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This PR handles a special situation where the grantResults array could be empty when asking for permissions.
Fixes https://github.com/flutter/flutter/issues/116047

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
