### PR TITLE
Revert "[google_maps_flutter] ios: re-enable test with popup"

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
@@ -18,6 +18,8 @@
   self.app = [[XCUIApplication alloc] init];
   [self.app launch];
 
+  // The location permission interception is currently not working.
+  // See: https://github.com/flutter/flutter/issues/93325.
   [self
       addUIInterruptionMonitorWithDescription:@"Permission popups"
                                       handler:^BOOL(XCUIElement *_Nonnull interruptingElement) {
@@ -43,7 +45,8 @@
                                       }];
 }
 
-- (void)testUserInterface {
+// Temporarily disabled due to https://github.com/flutter/flutter/issues/93325
+- (void)skip_testUserInterface {
   XCUIApplication *app = self.app;
   XCUIElement *userInteface = app.staticTexts[@"User interface"];
   if (![userInteface waitForExistenceWithTimeout:30.0]) {
@@ -51,9 +54,6 @@
     XCTFail(@"Failed due to not able to find User interface");
   }
   [userInteface tap];
-  // There is a known bug where the permission popups interruption won't get fired until a tap
-  // happened in the app. We expect a permission popup so we do a tap here.
-  [app tap];
   XCUIElement *platformView = app.otherElements[@"platform_view[0]"];
   if (![platformView waitForExistenceWithTimeout:30.0]) {
     os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);


### PR DESCRIPTION
Reverts flutter/plugins#5312 to unblock the tree.
Failure: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_x64%20ios_platform_tests_1_of_4%20stable/17/overview