### PR TITLE
Reland "[google_maps_flutter] ios: re-enable test with popup #5312"

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
 * Updates code for new analysis options.
+* Re-enable XCUITests: testUserInterface.
+* Remove unnecessary `RunnerUITests` target from Podfile of the example app.
 
 ## 2.1.12
 

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/Podfile
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/Podfile
@@ -34,9 +34,6 @@ target 'Runner' do
 
     pod 'OCMock', '~> 3.9.1'
   end
-  target 'RunnerUITests' do
-    inherit! :search_paths
-  end
 end
 
 post_install do |installer|

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@import CoreLocation;
 @import XCTest;
 @import os.log;
-@import GoogleMaps;
 
 @interface GoogleMapsUITests : XCTestCase
 @property(nonatomic, strong) XCUIApplication *app;
@@ -18,8 +18,6 @@
   self.app = [[XCUIApplication alloc] init];
   [self.app launch];
 
-  // The location permission interception is currently not working.
-  // See: https://github.com/flutter/flutter/issues/93325.
   [self
       addUIInterruptionMonitorWithDescription:@"Permission popups"
                                       handler:^BOOL(XCUIElement *_Nonnull interruptingElement) {
@@ -45,8 +43,7 @@
                                       }];
 }
 
-// Temporarily disabled due to https://github.com/flutter/flutter/issues/93325
-- (void)skip_testUserInterface {
+- (void)testUserInterface {
   XCUIApplication *app = self.app;
   XCUIElement *userInteface = app.staticTexts[@"User interface"];
   if (![userInteface waitForExistenceWithTimeout:30.0]) {
@@ -54,17 +51,27 @@
     XCTFail(@"Failed due to not able to find User interface");
   }
   [userInteface tap];
+
   XCUIElement *platformView = app.otherElements[@"platform_view[0]"];
   if (![platformView waitForExistenceWithTimeout:30.0]) {
     os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
     XCTFail(@"Failed due to not able to find platform view");
   }
+
+
+  // There is a known bug where the permission popups interruption won't get fired until a tap
+  // happened in the app. We expect a permission popup so we do a tap here.
+  // iOS 16 has a bug where if the app itself is directly tapped: [app tap], the first button (disable compass)
+  // in the app is also tapped, so instead we tap a arbitrary location in the app instead.
+  XCUICoordinate *coordinate = [app coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+  [coordinate tap];
   XCUIElement *compass = app.buttons[@"disable compass"];
   if (![compass waitForExistenceWithTimeout:30.0]) {
     os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
-    XCTFail(@"Failed due to not able to find compass button");
+    XCTFail(@"Failed due to not able to find disable compass button");
   }
-  [compass tap];
+
+  [self forceTap:compass];
 }
 
 - (void)testMapCoordinatesPage {
@@ -188,6 +195,17 @@
     os_log_error(OS_LOG_DEFAULT, "%@", app.debugDescription);
     XCTFail(@"Failed due to not able to find 'longPressed''");
   }
+}
+
+- (void)forceTap:(XCUIElement *)button {
+  // iOS 16 introduced a bug where hittable is NO for buttons. We force hit the location of the button
+  // if that is the case. It is likely similar to https://github.com/flutter/flutter/issues/113377.
+  if (button.isHittable) {
+    [button tap];
+    return;
+  }
+  XCUICoordinate *coordinate = [button coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+  [coordinate tap];
 }
 
 @end

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/ios/RunnerUITests/GoogleMapsUITests.m
@@ -58,11 +58,11 @@
     XCTFail(@"Failed due to not able to find platform view");
   }
 
-
   // There is a known bug where the permission popups interruption won't get fired until a tap
   // happened in the app. We expect a permission popup so we do a tap here.
-  // iOS 16 has a bug where if the app itself is directly tapped: [app tap], the first button (disable compass)
-  // in the app is also tapped, so instead we tap a arbitrary location in the app instead.
+  // iOS 16 has a bug where if the app itself is directly tapped: [app tap], the first button
+  // (disable compass) in the app is also tapped, so instead we tap a arbitrary location in the app
+  // instead.
   XCUICoordinate *coordinate = [app coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
   [coordinate tap];
   XCUIElement *compass = app.buttons[@"disable compass"];
@@ -198,8 +198,9 @@
 }
 
 - (void)forceTap:(XCUIElement *)button {
-  // iOS 16 introduced a bug where hittable is NO for buttons. We force hit the location of the button
-  // if that is the case. It is likely similar to https://github.com/flutter/flutter/issues/113377.
+  // iOS 16 introduced a bug where hittable is NO for buttons. We force hit the location of the
+  // button if that is the case. It is likely similar to
+  // https://github.com/flutter/flutter/issues/113377.
   if (button.isHittable) {
     [button tap];
     return;


### PR DESCRIPTION
Reland https://github.com/flutter/plugins/pull/5312

The accessibility type for the flutter text buttons are changed from buttons to texts.
Fixes https://github.com/flutter/flutter/issues/93325

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
