### PR TITLE
[ci] Fix macOS LUCI merge base

### DIFF
--- a/.ci/targets/mac_ios_platform_tests.yaml
+++ b/.ci/targets/mac_ios_platform_tests.yaml
@@ -1,4 +1,6 @@
 tasks:
+  - name: prepare tool
+    script: .ci/scripts/prepare_tool.sh
   - name: create simulator
     script: .ci/scripts/create_simulator.sh
   - name: build examples


### PR DESCRIPTION
Currently the repo tooling relies on `FETCH_HEAD` being set to `origin/main` in CI, which is done in `prepare_tool.sh` for LUCI bots. Longer term we should restructure the CI scripts to be explicit about the base SHA instead of relying on `FETCH_HEAD`, but for now this adds the missing `prepare_tool.sh` step to the new iOS LUCI tests so that they compute diffs correctly.

Fixes https://github.com/flutter/flutter/issues/116448
