### PR TITLE
[tools] Recognize Pigeon tests in version-check

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 13.1
 
+* Updates `version-check` to recognize Pigeon's platform test structure.
 * Pins `package:git` dependency to `2.0.x` until `dart >=2.18.0` becomes our
   oldest legacy.
 * Updates test mocks.

--- a/script/tool/lib/src/common/package_state_utils.dart
+++ b/script/tool/lib/src/common/package_state_utils.dart
@@ -110,7 +110,9 @@ bool _isTestChange(List<String> pathComponents) {
       pathComponents.contains('integration_test') ||
       pathComponents.contains('androidTest') ||
       pathComponents.contains('RunnerTests') ||
-      pathComponents.contains('RunnerUITests');
+      pathComponents.contains('RunnerUITests') ||
+      // Pigeon's custom platform tests.
+      pathComponents.first == 'platform_tests';
 }
 
 // True if the given file is an example file other than the one that will be

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.13.0
+version: 0.13.1
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/common/package_state_utils_test.dart
+++ b/script/tool/test/common/package_state_utils_test.dart
@@ -80,6 +80,9 @@ void main() {
         'packages/a_plugin/example/macos/Runner.xcodeproj/project.pbxproj',
         'packages/a_plugin/example/windows/CMakeLists.txt',
         'packages/a_plugin/example/pubspec.yaml',
+        // Pigeon platform tests, which have an unusual structure.
+        'packages/a_plugin/platform_tests/shared_test_plugin_code/lib/integration_tests.dart',
+        'packages/a_plugin/platform_tests/test_plugin/windows/test_plugin.cpp',
       ];
 
       final PackageChangeState state = await checkPackageChangeState(package,


### PR DESCRIPTION
Pigeon has an usual test structure since it generates test code to run in a dummy plugin; add that structure to the list of recognized tests so that changes to its platform tests won't be flagged by `version-check`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
