### PR TITLE
add getEmbeddedSubtitles and setEmbeddedSubtitles

### DIFF
--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.0
+
+* Added support Embedded Close Caption with videos
+
 ## 6.0.0
 
 * **BREAKING CHANGE**: Removes `MethodChannelVideoPlayer`. The default

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -102,6 +102,21 @@ abstract class VideoPlayerPlatform extends PlatformInterface {
   Future<void> setMixWithOthers(bool mixWithOthers) {
     throw UnimplementedError('setMixWithOthers() has not been implemented.');
   }
+
+  /// Get all available embedded subtitles of the video.
+  Future<List<EmbeddedSubtitle>> getEmbeddedSubtitles(int textureId) async {
+    throw UnimplementedError(
+        'getEmbeddedSubtitles() has not been implemented.');
+  }
+
+  /// Select one of the embedded subtitles of the video.
+  Future<void> setEmbeddedSubtitles(
+    int textureId,
+    EmbeddedSubtitle? embeddedSubtitle,
+  ) async {
+    throw UnimplementedError(
+        'setEmbeddedSubtitles() has not been implemented.');
+  }
 }
 
 class _PlaceholderImplementation extends VideoPlayerPlatform {}
@@ -114,7 +129,7 @@ class DataSource {
   /// The [sourceType] is always required.
   ///
   /// The [uri] argument takes the form of `'https://example.com/video.mp4'` or
-  /// `'file://${file.path}'`.
+  /// `'file:///absolute/path/to/local/video.mp4`.
   ///
   /// The [formatHint] argument can be null.
   ///
@@ -212,6 +227,7 @@ class VideoEvent {
     this.size,
     this.rotationCorrection,
     this.buffered,
+    this.bufferedData,
   });
 
   /// The type of the event.
@@ -237,6 +253,9 @@ class VideoEvent {
   /// Only used if [eventType] is [VideoEventType.bufferingUpdate].
   final List<DurationRange>? buffered;
 
+  /// Data that will be used in the current buffer.
+  final String? bufferedData;
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -246,6 +265,7 @@ class VideoEvent {
             duration == other.duration &&
             size == other.size &&
             rotationCorrection == other.rotationCorrection &&
+            bufferedData == bufferedData &&
             listEquals(buffered, other.buffered);
   }
 
@@ -256,6 +276,7 @@ class VideoEvent {
         size,
         rotationCorrection,
         buffered,
+        bufferedData,
       );
 }
 
@@ -278,6 +299,9 @@ enum VideoEventType {
 
   /// The video stopped to buffer.
   bufferingEnd,
+
+  /// Updated information on the subtitle.
+  subtitleUpdate,
 
   /// An unknown event has been received.
   unknown,
@@ -371,4 +395,45 @@ class VideoPlayerOptions {
   /// Note: This option will be silently ignored in the web platform (there is
   /// currently no way to implement this feature in this platform).
   final bool mixWithOthers;
+}
+
+/// Subtitle option, which is embedded into the video.
+class EmbeddedSubtitle {
+  /// Subtitle option which embedded into video.
+  ///
+  /// * It's recommended not to create a direct instance with this constructor.
+  ///   Try to get it from the video player controller.
+  const EmbeddedSubtitle({
+    required this.language,
+    required this.label,
+    required this.trackIndex,
+    required this.groupIndex,
+    required this.renderIndex,
+  });
+
+  /// An instance of the embedded subtitle that is used to disable the subtitle stream.
+  const EmbeddedSubtitle.none()
+      : language = null,
+        label = null,
+        trackIndex = null,
+        groupIndex = null,
+        renderIndex = null;
+
+  /// Language of embedded subtitle
+  final String? language;
+
+  /// Label, associated with each option of the embedded subtitle
+  final String? label;
+
+  /// Subtitle track index, in the list of subtitles in the embedded subtitle
+  final int? trackIndex;
+
+  /// Subtitle group track index in the available tracks for the video.
+  final int? groupIndex;
+
+  /// Subtitle group track render index
+  final int? renderIndex;
+
+  /// Checks whether the embedded subtitle is selected or is for removing the subtitle.
+  bool get embeddedSubtitleSelected => trackIndex != null;
 }

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/video_player/v
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.0.0
+version: 6.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Some videos like HLS includes embedded subtitle in them self. Both mobile native players (Exoplayer and AVPlayer) supports this functionality. 
User now can get available subtitle option and set one of it. The video_player will stream subtitle from native to flutter video_player controller caption so we can show in flutter.
This functions will use in future PR to implement it in Native and Flutter side

Fixed issues:
- https://github.com/flutter/flutter/issues/109153
- https://github.com/flutter/flutter/issues/50595

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
