### PR TITLE
[local_auth] Make `localizedReason` optional

### DIFF
--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Allowing empty localizedReason for Android
+
 ## 1.0.15
 
 * Updates androidx.fragment version to 1.5.4.

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## NEXT
+## 1.0.16
 
 * Allowing empty localizedReason for Android
 

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -85,10 +85,9 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
 
     BiometricPrompt.PromptInfo.Builder promptBuilder =
         new BiometricPrompt.PromptInfo.Builder()
-            .setDescription((String) call.argument("localizedReason"))
+            .setDescription(((String) call.argument("localizedReason")).isEmpty() ? null : (String) call.argument("localizedReason"))
             .setTitle((String) call.argument("signInTitle"))
             .setSubtitle((String) call.argument("biometricHint"))
-            .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"))
             .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"));
 
     int allowedAuthenticators =

--- a/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
+++ b/packages/local_auth/local_auth_android/android/src/main/java/io/flutter/plugins/localauth/AuthenticationHelper.java
@@ -85,7 +85,10 @@ class AuthenticationHelper extends BiometricPrompt.AuthenticationCallback
 
     BiometricPrompt.PromptInfo.Builder promptBuilder =
         new BiometricPrompt.PromptInfo.Builder()
-            .setDescription(((String) call.argument("localizedReason")).isEmpty() ? null : (String) call.argument("localizedReason"))
+            .setDescription(
+                ((String) call.argument("localizedReason")).isEmpty()
+                    ? null
+                    : (String) call.argument("localizedReason"))
             .setTitle((String) call.argument("signInTitle"))
             .setSubtitle((String) call.argument("biometricHint"))
             .setConfirmationRequired((Boolean) call.argument("sensitiveTransaction"));

--- a/packages/local_auth/local_auth_android/lib/local_auth_android.dart
+++ b/packages/local_auth/local_auth_android/lib/local_auth_android.dart
@@ -28,7 +28,7 @@ class LocalAuthAndroid extends LocalAuthPlatform {
     required Iterable<AuthMessages> authMessages,
     AuthenticationOptions options = const AuthenticationOptions(),
   }) async {
-    assert(localizedReason.isNotEmpty);
+    /// no empty check assertion because [localizedReason] can be nullable for android
     final Map<String, Object> args = <String, Object>{
       'localizedReason': localizedReason,
       'useErrorDialogs': options.useErrorDialogs,

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: local_auth_android
 description: Android implementation of the local_auth plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/local_auth/local_auth_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+local_auth%22
-version: 1.0.15
+version: 1.0.16
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/local_auth/local_auth_android/test/local_auth_test.dart
+++ b/packages/local_auth/local_auth_android/test/local_auth_test.dart
@@ -172,5 +172,53 @@ void main() {
         );
       });
     });
+
+    group('With empty localisedReason', () {
+      test('authenticate with no args.', () async {
+        await localAuthentication.authenticate(
+          authMessages: <AuthMessages>[const AndroidAuthMessages()],
+          localizedReason: '',
+          options: const AuthenticationOptions(biometricOnly: true),
+        );
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('authenticate',
+                arguments: <String, dynamic>{
+                  'localizedReason': '',
+                  'useErrorDialogs': true,
+                  'stickyAuth': false,
+                  'sensitiveTransaction': true,
+                  'biometricOnly': true,
+                }..addAll(const AndroidAuthMessages().args)),
+          ],
+        );
+      });
+
+      test('authenticate with no sensitive transaction.', () async {
+        await localAuthentication.authenticate(
+          authMessages: <AuthMessages>[const AndroidAuthMessages()],
+          localizedReason: '',
+          options: const AuthenticationOptions(
+            sensitiveTransaction: false,
+            useErrorDialogs: false,
+            biometricOnly: true,
+          ),
+        );
+        expect(
+          log,
+          <Matcher>[
+            isMethodCall('authenticate',
+                arguments: <String, dynamic>{
+                  'localizedReason': '',
+                  'useErrorDialogs': false,
+                  'stickyAuth': false,
+                  'sensitiveTransaction': false,
+                  'biometricOnly': true,
+                }..addAll(const AndroidAuthMessages().args)),
+          ],
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
`localizedReason` should be optional for Android. There could be use case where we only want to show a single piece of text on the biometric prompt. Currently showing 2 pieces of texts is mandatory

## Proposal

Only set the `description` parameter to the `BiometricPrompt` if a non empty String is passed in the call.

code:

`AuthenticationHelper.java`

use

```java
.setDescription(((String) call.argument("localizedReason")).isEmpty() ? null : (String) call.argument("localizedReason"))
```

instead of

```java
.setDescription((String) call.argument("localizedReason"))
```

issue link: [#116885](https://github.com/flutter/flutter/issues/116885)

** screenshots attached in the original issue



## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [X] I signed the [CLA].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [X] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
