### PR TITLE
[camera][google_maps_flutter][path_provider] prepare for TestDefaultBinaryMessengerBinding.instance becoming non-nullable

### DIFF
--- a/packages/camera/camera_android/example/lib/main.dart
+++ b/packages/camera/camera_android/example/lib/main.dart
@@ -1091,5 +1091,4 @@ Future<void> main() async {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_android/test/android_camera_test.dart
+++ b/packages/camera/camera_android/test/android_camera_test.dart
@@ -32,14 +32,15 @@ void main() {
     // registerWith is called very early in initialization the bindings won't
     // have been initialized. While registerWith could intialize them, that
     // could slow down startup, so instead the handler should be set up lazily.
-    final ByteData? response = await TestDefaultBinaryMessengerBinding
-        .instance!.defaultBinaryMessenger
-        .handlePlatformMessage(
-            AndroidCamera.deviceEventChannelName,
-            const StandardMethodCodec().encodeMethodCall(const MethodCall(
-                'orientation_changed',
-                <String, Object>{'orientation': 'portraitDown'})),
-            (ByteData? data) {});
+    final ByteData? response =
+        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+            .defaultBinaryMessenger
+            .handlePlatformMessage(
+                AndroidCamera.deviceEventChannelName,
+                const StandardMethodCodec().encodeMethodCall(const MethodCall(
+                    'orientation_changed',
+                    <String, Object>{'orientation': 'portraitDown'})),
+                (ByteData? data) {});
     expect(response, null);
   });
 
@@ -421,7 +422,8 @@ void main() {
       const DeviceOrientationChangedEvent event =
           DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
       for (int i = 0; i < 3; i++) {
-        await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+            .defaultBinaryMessenger
             .handlePlatformMessage(
                 AndroidCamera.deviceEventChannelName,
                 const StandardMethodCodec().encodeMethodCall(
@@ -1121,3 +1123,9 @@ void main() {
     });
   });
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_avfoundation/example/lib/main.dart
+++ b/packages/camera/camera_avfoundation/example/lib/main.dart
@@ -1091,5 +1091,4 @@ Future<void> main() async {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
+++ b/packages/camera/camera_avfoundation/test/avfoundation_camera_test.dart
@@ -32,14 +32,15 @@ void main() {
     // registerWith is called very early in initialization the bindings won't
     // have been initialized. While registerWith could intialize them, that
     // could slow down startup, so instead the handler should be set up lazily.
-    final ByteData? response = await TestDefaultBinaryMessengerBinding
-        .instance!.defaultBinaryMessenger
-        .handlePlatformMessage(
-            AVFoundationCamera.deviceEventChannelName,
-            const StandardMethodCodec().encodeMethodCall(const MethodCall(
-                'orientation_changed',
-                <String, Object>{'orientation': 'portraitDown'})),
-            (ByteData? data) {});
+    final ByteData? response =
+        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+            .defaultBinaryMessenger
+            .handlePlatformMessage(
+                AVFoundationCamera.deviceEventChannelName,
+                const StandardMethodCodec().encodeMethodCall(const MethodCall(
+                    'orientation_changed',
+                    <String, Object>{'orientation': 'portraitDown'})),
+                (ByteData? data) {});
     expect(response, null);
   });
 
@@ -421,7 +422,8 @@ void main() {
       const DeviceOrientationChangedEvent event =
           DeviceOrientationChangedEvent(DeviceOrientation.portraitUp);
       for (int i = 0; i < 3; i++) {
-        await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+            .defaultBinaryMessenger
             .handlePlatformMessage(
                 AVFoundationCamera.deviceEventChannelName,
                 const StandardMethodCodec().encodeMethodCall(
@@ -1122,3 +1124,9 @@ void main() {
     });
   });
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_android/test/google_maps_flutter_android_test.dart
@@ -37,7 +37,8 @@ void main() {
       int mapId, String method, Map<dynamic, dynamic> data) async {
     final ByteData byteData =
         const StandardMethodCodec().encodeMethodCall(MethodCall(method, data));
-    await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+        .defaultBinaryMessenger
         .handlePlatformMessage('plugins.flutter.dev/google_maps_android_$mapId',
             byteData, (ByteData? data) {});
   }
@@ -164,3 +165,9 @@ void main() {
     expect(widget, isA<PlatformViewLink>());
   });
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -36,7 +36,8 @@ void main() {
       int mapId, String method, Map<dynamic, dynamic> data) async {
     final ByteData byteData =
         const StandardMethodCodec().encodeMethodCall(MethodCall(method, data));
-    await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+    await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+        .defaultBinaryMessenger
         .handlePlatformMessage('plugins.flutter.dev/google_maps_ios_$mapId',
             byteData, (ByteData? data) {});
   }
@@ -122,3 +123,9 @@ void main() {
         equals('drag-end-marker'));
   });
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+T? _ambiguate<T>(T? value) => value;

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/test/method_channel/method_channel_google_maps_flutter_test.dart
@@ -36,7 +36,8 @@ void main() {
         int mapId, String method, Map<dynamic, dynamic> data) async {
       final ByteData byteData = const StandardMethodCodec()
           .encodeMethodCall(MethodCall(method, data));
-      await TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+      await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+          .defaultBinaryMessenger
           .handlePlatformMessage('plugins.flutter.io/google_maps_$mapId',
               byteData, (ByteData? data) {});
     }
@@ -120,3 +121,9 @@ void main() {
     });
   });
 }
+
+/// This allows a value of type T or T? to be treated as a value of type T?.
+///
+/// We use this so that APIs that have become non-nullable can still be used
+/// with `!` and `?` on the stable branch.
+T? _ambiguate<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher/lib/src/legacy_api.dart
+++ b/packages/url_launcher/url_launcher/lib/src/legacy_api.dart
@@ -150,5 +150,4 @@ Future<void> closeWebView() async {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
+++ b/packages/url_launcher/url_launcher/test/src/legacy_api_test.dart
@@ -321,8 +321,6 @@ void main() {
 
 /// This removes the type information from a value so that it can be cast
 /// to another type even if that cast is redundant.
-///
 /// We use this so that APIs whose type have become more descriptive can still
 /// be used on the stable branch where they require a cast.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 Object? _anonymize<T>(T? value) => value;

--- a/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
+++ b/packages/url_launcher/url_launcher_platform_interface/lib/link.dart
@@ -109,5 +109,4 @@ Future<ByteData> pushRouteNameToFramework(Object? _, String routeName) {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -1100,5 +1100,4 @@ class ClosedCaption extends StatelessWidget {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -360,5 +360,4 @@ void main() {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -339,5 +339,4 @@ void main() {
 ///
 /// We use this so that APIs that have become non-nullable can still be used
 /// with `!` and `?` on the stable branch.
-// TODO(ianh): Remove this once we roll stable in late 2021.
 T? _ambiguate<T>(T? value) => value;


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
