### PR TITLE
[flutter_plugin_tools] If `clang-format` does not run, fall back to other executables in PATH

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 13.1
+## 0.13.2
+
+* Falls back to other executables in PATH when `clang-format` does not run.
+
+## 0.13.1
 
 * Updates `version-check` to recognize Pigeon's platform test structure.
 * Pins `package:git` dependency to `2.0.x` until `dart >=2.18.0` becomes our

--- a/script/tool/lib/src/create_all_packages_app_command.dart
+++ b/script/tool/lib/src/create_all_packages_app_command.dart
@@ -230,7 +230,7 @@ class CreateAllPackagesAppCommand extends PackageCommand {
 
   String _pubspecToString(Pubspec pubspec) {
     return '''
-### Generated file. Do not edit. Run `pub global run flutter_plugin_tools gen-pubspec` to update.
+### Generated file. Do not edit. Run `dart pub global run flutter_plugin_tools gen-pubspec` to update.
 name: ${pubspec.name}
 description: ${pubspec.description}
 publish_to: none

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -104,8 +104,8 @@ class FormatCommand extends PackageCommand {
     print('These files are not formatted correctly (see diff below):');
     LineSplitter.split(stdout).map((String line) => '  $line').forEach(print);
 
-    print('\nTo fix run "pub global activate flutter_plugin_tools && '
-        'pub global run flutter_plugin_tools format" or copy-paste '
+    print('\nTo fix run "dart pub global activate flutter_plugin_tools && '
+        'dart pub global run flutter_plugin_tools format" or copy-paste '
         'this command into your terminal:');
 
     final io.ProcessResult diff = await processRunner.run(
@@ -128,16 +128,11 @@ class FormatCommand extends PackageCommand {
     final Iterable<String> clangFiles = _getPathsWithExtensions(
         files, <String>{'.h', '.m', '.mm', '.cc', '.cpp'});
     if (clangFiles.isNotEmpty) {
-      final String clangFormat = getStringArg('clang-format');
-      if (!await _hasDependency(clangFormat)) {
-        printError('Unable to run "clang-format". Make sure that it is in your '
-            'path, or provide a full path with --clang-format.');
-        throw ToolExit(_exitDependencyMissing);
-      }
+      final String clangFormat = await _findValidClangFormat();
 
       print('Formatting .cc, .cpp, .h, .m, and .mm files...');
       final int exitCode = await _runBatched(
-          getStringArg('clang-format'), <String>['-i', '--style=file'],
+          clangFormat, <String>['-i', '--style=file'],
           files: clangFiles);
       if (exitCode != 0) {
         printError(
@@ -145,6 +140,26 @@ class FormatCommand extends PackageCommand {
         throw ToolExit(_exitClangFormatFailed);
       }
     }
+  }
+
+  Future<String> _findValidClangFormat() async {
+    final String clangFormatArg = getStringArg('clang-format');
+    if (await _hasDependency(clangFormatArg)) {
+      return clangFormatArg;
+    }
+
+    // There is a known issue where "chromium/depot_tools/clang-format"
+    // fails with "Problem while looking for clang-format in Chromium source tree".
+    // Loop through all "clang-format"s in PATH until a working one is found,
+    // for example "/usr/local/bin/clang-format" or a "brew" installed version.
+    for (final String clangFormatPath in await _whichAll('clang-format')) {
+      if (await _hasDependency(clangFormatPath)) {
+        return clangFormatPath;
+      }
+    }
+    printError('Unable to run "clang-format". Make sure that it is in your '
+        'path, or provide a full path with --clang-format.');
+    throw ToolExit(_exitDependencyMissing);
   }
 
   Future<void> _formatJava(
@@ -277,6 +292,26 @@ class FormatCommand extends PackageCommand {
       return false;
     }
     return true;
+  }
+
+  /// Returns all instances of [command] executable found on user path.
+  Future<List<String>> _whichAll(String command) async {
+    try {
+      final io.ProcessResult result =
+      await processRunner.run('which', <String>['-a', command]);
+
+      if (result.exitCode != 0) {
+        return <String>[];
+      }
+
+      final String stdout = result.stdout as String;
+      if (stdout.isEmpty) {
+        return <String>[];
+      }
+      return stdout.trim().split('\n').toList();
+    } on io.ProcessException {
+      return <String>[];
+    }
   }
 
   /// Runs [command] on [arguments] on all of the files in [files], batched as

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -304,11 +304,11 @@ class FormatCommand extends PackageCommand {
         return <String>[];
       }
 
-      final String stdout = result.stdout as String;
+      final String stdout = result.stdout.trim() as String;
       if (stdout.isEmpty) {
         return <String>[];
       }
-      return stdout.trim().split('\n').toList();
+      return LineSplitter.split(stdout).toList();
     } on io.ProcessException {
       return <String>[];
     }

--- a/script/tool/lib/src/main.dart
+++ b/script/tool/lib/src/main.dart
@@ -52,7 +52,7 @@ void main(List<String> args) {
   }
 
   final CommandRunner<void> commandRunner = CommandRunner<void>(
-      'pub global run flutter_plugin_tools',
+      'dart pub global run flutter_plugin_tools',
       'Productivity utils for hosting multiple plugins within one repository.')
     ..addCommand(AnalyzeCommand(packagesDir))
     ..addCommand(BuildExamplesCommand(packagesDir))

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.13.1
+version: 0.13.2
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -332,6 +332,48 @@ void main() {
         ]));
   });
 
+  test('falls back to working clang-format in the path', () async {
+    const List<String> files = <String>[
+      'linux/foo_plugin.cc',
+      'macos/Classes/Foo.h',
+    ];
+    final RepositoryPackage plugin = createFakePlugin(
+      'a_plugin',
+      packagesDir,
+      extraFiles: files,
+    );
+
+    processRunner.mockProcessesForExecutable['clang-format'] = <io.Process>[
+      MockProcess(exitCode: 1)
+    ];
+    processRunner.mockProcessesForExecutable['which'] = <io.Process>[
+      MockProcess(
+          stdout: '/usr/local/bin/clang-format\n/path/to/working-clang-format')
+    ];
+    processRunner.mockProcessesForExecutable['/usr/local/bin/clang-format'] =
+        <io.Process>[MockProcess(exitCode: 1)];
+    Error? commandError;
+    final List<String> output = await runCapturingPrint(
+        runner, <String>['format'], errorHandler: (Error e) {
+      commandError = e;
+    });
+
+    expect(
+        processRunner.recordedCalls,
+        containsAll(<ProcessCall>[
+          const ProcessCall(
+              '/path/to/working-clang-format', <String>['--version'], null),
+          ProcessCall(
+              '/path/to/working-clang-format',
+              <String>[
+                '-i',
+                '--style=file',
+                ...getPackagesDirRelativePaths(plugin, files)
+              ],
+              packagesDir.path),
+        ]));
+  });
+
   test('honors --clang-format flag', () async {
     const List<String> files = <String>[
       'windows/foo_plugin.cpp',

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -352,11 +352,7 @@ void main() {
     ];
     processRunner.mockProcessesForExecutable['/usr/local/bin/clang-format'] =
         <io.Process>[MockProcess(exitCode: 1)];
-    Error? commandError;
-    final List<String> output = await runCapturingPrint(
-        runner, <String>['format'], errorHandler: (Error e) {
-      commandError = e;
-    });
+    await runCapturingPrint(runner, <String>['format']);
 
     expect(
         processRunner.recordedCalls,


### PR DESCRIPTION
1. When `clang-format` does not run (i.e. failing `chromium/depot_tools/clang-format`, loop through all the `clang-format` executables in the PATH until a working one is found.  If none run then bail with the same error as before.

2. Running `pub global...` fails with `command not found: pub`.  Update `pub global` instructions to `dart pub global`.

Fixes https://github.com/flutter/flutter/issues/117195

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
