### PR TITLE
[video_player] Add compatibility with the current platform interface

### DIFF
--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.10
+
+* Adds compatibilty with version 6.0 of the platform interface.
+
 ## 2.4.9
 
 * Fixes file URI construction.

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.4.9
+version: 2.4.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   html: ^0.15.0
   video_player_android: ^2.3.5
   video_player_avfoundation: ^2.2.17
-  video_player_platform_interface: ^5.1.1
+  video_player_platform_interface: ">=5.1.1 <7.0.0"
   video_player_web: ^2.0.0
 
 dev_dependencies:

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -106,6 +106,13 @@ class _FakeClosedCaptionFile extends ClosedCaptionFile {
 }
 
 void main() {
+  late FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
+
+  setUp(() {
+    fakeVideoPlayerPlatform = FakeVideoPlayerPlatform();
+    VideoPlayerPlatform.instance = fakeVideoPlayerPlatform;
+  });
+
   void verifyPlayStateRespondsToLifecycle(
     VideoPlayerController controller, {
     required bool shouldPlayInBackground,
@@ -235,13 +242,6 @@ void main() {
   });
 
   group('VideoPlayerController', () {
-    late FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
-
-    setUp(() {
-      fakeVideoPlayerPlatform = FakeVideoPlayerPlatform();
-      VideoPlayerPlatform.instance = fakeVideoPlayerPlatform;
-    });
-
     group('initialize', () {
       test('started app lifecycle observing', () async {
         final VideoPlayerController controller = VideoPlayerController.network(
@@ -1015,13 +1015,6 @@ void main() {
   });
 
   group('VideoPlayerOptions', () {
-    late FakeVideoPlayerPlatform fakeVideoPlayerPlatform;
-
-    setUp(() {
-      fakeVideoPlayerPlatform = FakeVideoPlayerPlatform();
-      VideoPlayerPlatform.instance = fakeVideoPlayerPlatform;
-    });
-
     test('setMixWithOthers', () async {
       final VideoPlayerController controller = VideoPlayerController.network(
           'https://127.0.0.1',
@@ -1159,6 +1152,11 @@ class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
   @override
   Future<void> setMixWithOthers(bool mixWithOthers) async {
     calls.add('setMixWithOthers');
+  }
+
+  @override
+  Widget buildView(int textureId) {
+    return Texture(textureId: textureId);
   }
 }
 

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.3.10
 
+* Adds compatibilty with version 6.0 of the platform interface.
 * Fixes file URI construction in example.
 * Updates code for new analysis options.
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
+  video_player_platform_interface: ">=5.1.1 <7.0.0"
 
 dev_dependencies:
   flutter_driver:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.9
+version: 2.3.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -20,7 +20,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ^5.1.1
+  video_player_platform_interface: ">=5.1.1 <7.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.3.8
 
+* Adds compatibilty with version 6.0 of the platform interface.
 * Fixes file URI construction in example.
 * Updates code for new analysis options.
 * Adds an integration test for a bug where the aspect ratios of some HLS videos are incorrectly inverted.

--- a/packages/video_player/video_player_avfoundation/example/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/example/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
     path: ../
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
+  video_player_platform_interface: ">=4.2.0 <7.0.0"
 
 dev_dependencies:
   flutter_driver:

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.7
+version: 2.3.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
+  video_player_platform_interface: ">=4.2.0 <7.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 2.0.13
 
+* Adds compatibilty with version 6.0 of the platform interface.
 * Updates minimum Flutter version to 2.10.
 
 ## 2.0.12

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   js: ^0.6.0
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
+  video_player_platform_interface: ">=4.2.0 <7.0.0"
   video_player_web:
     path: ../
 

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  video_player_platform_interface: ">=4.2.0 <6.0.0"
+  video_player_platform_interface: ">=4.2.0 <7.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.12
+version: 2.0.13
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
#6341 did a major version bump of the platform interface to delete the default method channel implementation, but I never updated the other packages in the plugin to allow using it. For the implementation packages, it's a pure no-op. The app-facing package had tests that relied on the `buildView` implementation of the default implementation; this updates the tests to use a fake instead so that those tests pass even without a real default implementation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
