### PR TITLE
[webview_flutter_android] Fix timeouts in the integration tests

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -682,7 +682,7 @@ Future<void> main() async {
         '${base64Encode(const Utf8Encoder().convert(blankPage))}';
 
     testWidgets('can allow requests', (WidgetTester tester) async {
-      final StreamController<String> pageLoads = StreamController<String>();
+      Completer<void> pageLoaded = Completer<void>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -692,7 +692,7 @@ Future<void> main() async {
           PlatformNavigationDelegate(
             const PlatformNavigationDelegateCreationParams(),
           )
-            ..setOnPageFinished((String url) => pageLoads.add(url))
+            ..setOnPageFinished((_) => pageLoaded.complete())
             ..setOnNavigationRequest((NavigationRequest navigationRequest) {
               return (navigationRequest.url.contains('youtube.com'))
                   ? NavigationDecision.prevent
@@ -711,10 +711,12 @@ Future<void> main() async {
         },
       ));
 
-      await pageLoads.stream.first; // Wait for initial page load.
-      await controller.runJavaScript('location.href = "$secondaryUrl"');
+      await pageLoaded.future; // Wait for initial page load.
 
-      await pageLoads.stream.first; // Wait for the next page load.
+      pageLoaded = Completer<void>();
+      await controller.runJavaScript('location.href = "$secondaryUrl"');
+      await pageLoaded.future; // Wait for the next page load.
+
       final String? currentUrl = await controller.currentUrl();
       expect(currentUrl, secondaryUrl);
     });
@@ -798,7 +800,7 @@ Future<void> main() async {
     });
 
     testWidgets('can block requests', (WidgetTester tester) async {
-      final StreamController<String> pageLoads = StreamController<String>();
+      Completer<void> pageLoaded = Completer<void>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -808,7 +810,7 @@ Future<void> main() async {
           PlatformNavigationDelegate(
             const PlatformNavigationDelegateCreationParams(),
           )
-            ..setOnPageFinished((String url) => pageLoads.add(url))
+            ..setOnPageFinished((_) => pageLoaded.complete())
             ..setOnNavigationRequest((NavigationRequest navigationRequest) {
               return (navigationRequest.url.contains('youtube.com'))
                   ? NavigationDecision.prevent
@@ -825,21 +827,23 @@ Future<void> main() async {
         },
       ));
 
-      await pageLoads.stream.first; // Wait for initial page load.
+      await pageLoaded.future; // Wait for initial page load.
+
+      pageLoaded = Completer<void>();
       await controller
           .runJavaScript('location.href = "https://www.youtube.com/"');
 
       // There should never be any second page load, since our new URL is
       // blocked. Still wait for a potential page change for some time in order
       // to give the test a chance to fail.
-      await pageLoads.stream.first
-          .timeout(const Duration(milliseconds: 500), onTimeout: () => '');
+      await pageLoaded.future
+          .timeout(const Duration(milliseconds: 500), onTimeout: () => false);
       final String? currentUrl = await controller.currentUrl();
       expect(currentUrl, isNot(contains('youtube.com')));
     });
 
     testWidgets('supports asynchronous decisions', (WidgetTester tester) async {
-      final StreamController<String> pageLoads = StreamController<String>();
+      Completer<void> pageLoaded = Completer<void>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -849,7 +853,7 @@ Future<void> main() async {
           PlatformNavigationDelegate(
             const PlatformNavigationDelegateCreationParams(),
           )
-            ..setOnPageFinished((String url) => pageLoads.add(url))
+            ..setOnPageFinished((_) => pageLoaded.complete())
             ..setOnNavigationRequest(
                 (NavigationRequest navigationRequest) async {
               NavigationDecision decision = NavigationDecision.prevent;
@@ -869,10 +873,12 @@ Future<void> main() async {
         },
       ));
 
-      await pageLoads.stream.first; // Wait for initial page load.
-      await controller.runJavaScript('location.href = "$secondaryUrl"');
+      await pageLoaded.future; // Wait for initial page load.
 
-      await pageLoads.stream.first; // Wait for second page to load.
+      pageLoaded = Completer<void>();
+      await controller.runJavaScript('location.href = "$secondaryUrl"');
+      await pageLoaded.future; // Wait for second page to load.
+
       final String? currentUrl = await controller.currentUrl();
       expect(currentUrl, secondaryUrl);
     });

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -144,12 +144,6 @@ Future<void> main() async {
         PlatformNavigationDelegate(
           const PlatformNavigationDelegateCreationParams(),
         )..setOnPageFinished((String url) => pageLoads.add(url)),
-      )
-      ..loadRequest(
-        LoadRequestParams(
-          uri: Uri.parse(headersUrl),
-          headers: headers,
-        ),
       );
 
     await tester.pumpWidget(
@@ -160,6 +154,10 @@ Future<void> main() async {
           ).build(context);
         },
       ),
+    );
+
+    controller.loadRequest(
+      LoadRequestParams(uri: Uri.parse(headersUrl), headers: headers),
     );
 
     await pageLoads.stream.firstWhere((String url) => url == headersUrl);
@@ -699,9 +697,6 @@ Future<void> main() async {
                   ? NavigationDecision.prevent
                   : NavigationDecision.navigate;
             }),
-        )
-        ..loadRequest(
-          LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
         );
 
       await tester.pumpWidget(Builder(
@@ -711,6 +706,10 @@ Future<void> main() async {
           ).build(context);
         },
       ));
+
+      controller.loadRequest(
+        LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
+      );
 
       await pageLoads.stream.first; // Wait for initial page load.
       await controller.runJavaScript('location.href = "$secondaryUrl"');
@@ -816,8 +815,7 @@ Future<void> main() async {
                   ? NavigationDecision.prevent
                   : NavigationDecision.navigate;
             }),
-        )
-        ..loadRequest(LoadRequestParams(uri: Uri.parse(blankPageEncoded)));
+        );
 
       await tester.pumpWidget(Builder(
         builder: (BuildContext context) {
@@ -826,6 +824,10 @@ Future<void> main() async {
           ).build(context);
         },
       ));
+
+      controller.loadRequest(
+        LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
+      );
 
       await pageLoads.stream.first; // Wait for initial page load.
       await controller
@@ -861,8 +863,7 @@ Future<void> main() async {
                   () => NavigationDecision.navigate);
               return decision;
             }),
-        )
-        ..loadRequest(LoadRequestParams(uri: Uri.parse(blankPageEncoded)));
+        );
 
       await tester.pumpWidget(Builder(
         builder: (BuildContext context) {
@@ -870,6 +871,10 @@ Future<void> main() async {
             PlatformWebViewWidgetCreationParams(controller: controller),
           ).build(context);
         },
+      ));
+
+      controller.loadRequest(LoadRequestParams(
+        uri: Uri.parse(blankPageEncoded),
       ));
 
       await pageLoads.stream.first; // Wait for initial page load.

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -144,6 +144,12 @@ Future<void> main() async {
         PlatformNavigationDelegate(
           const PlatformNavigationDelegateCreationParams(),
         )..setOnPageFinished((String url) => pageLoads.add(url)),
+      )
+      ..loadRequest(
+        LoadRequestParams(
+          uri: Uri.parse(headersUrl),
+          headers: headers,
+        ),
       );
 
     await tester.pumpWidget(
@@ -154,10 +160,6 @@ Future<void> main() async {
           ).build(context);
         },
       ),
-    );
-
-    controller.loadRequest(
-      LoadRequestParams(uri: Uri.parse(headersUrl), headers: headers),
     );
 
     await pageLoads.stream.firstWhere((String url) => url == headersUrl);
@@ -680,8 +682,7 @@ Future<void> main() async {
         '${base64Encode(const Utf8Encoder().convert(blankPage))}';
 
     testWidgets('can allow requests', (WidgetTester tester) async {
-      final StreamController<String> pageLoads =
-          StreamController<String>.broadcast();
+      final StreamController<String> pageLoads = StreamController<String>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -697,6 +698,9 @@ Future<void> main() async {
                   ? NavigationDecision.prevent
                   : NavigationDecision.navigate;
             }),
+        )
+        ..loadRequest(
+          LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
         );
 
       await tester.pumpWidget(Builder(
@@ -706,10 +710,6 @@ Future<void> main() async {
           ).build(context);
         },
       ));
-
-      controller.loadRequest(
-        LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
-      );
 
       await pageLoads.stream.first; // Wait for initial page load.
       await controller.runJavaScript('location.href = "$secondaryUrl"');
@@ -798,8 +798,7 @@ Future<void> main() async {
     });
 
     testWidgets('can block requests', (WidgetTester tester) async {
-      final StreamController<String> pageLoads =
-          StreamController<String>.broadcast();
+      final StreamController<String> pageLoads = StreamController<String>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -815,7 +814,8 @@ Future<void> main() async {
                   ? NavigationDecision.prevent
                   : NavigationDecision.navigate;
             }),
-        );
+        )
+        ..loadRequest(LoadRequestParams(uri: Uri.parse(blankPageEncoded)));
 
       await tester.pumpWidget(Builder(
         builder: (BuildContext context) {
@@ -824,10 +824,6 @@ Future<void> main() async {
           ).build(context);
         },
       ));
-
-      controller.loadRequest(
-        LoadRequestParams(uri: Uri.parse(blankPageEncoded)),
-      );
 
       await pageLoads.stream.first; // Wait for initial page load.
       await controller
@@ -843,8 +839,7 @@ Future<void> main() async {
     });
 
     testWidgets('supports asynchronous decisions', (WidgetTester tester) async {
-      final StreamController<String> pageLoads =
-          StreamController<String>.broadcast();
+      final StreamController<String> pageLoads = StreamController<String>();
 
       final PlatformWebViewController controller = PlatformWebViewController(
         const PlatformWebViewControllerCreationParams(),
@@ -863,7 +858,8 @@ Future<void> main() async {
                   () => NavigationDecision.navigate);
               return decision;
             }),
-        );
+        )
+        ..loadRequest(LoadRequestParams(uri: Uri.parse(blankPageEncoded)));
 
       await tester.pumpWidget(Builder(
         builder: (BuildContext context) {
@@ -871,10 +867,6 @@ Future<void> main() async {
             PlatformWebViewWidgetCreationParams(controller: controller),
           ).build(context);
         },
-      ));
-
-      controller.loadRequest(LoadRequestParams(
-        uri: Uri.parse(blankPageEncoded),
       ));
 
       await pageLoads.stream.first; // Wait for initial page load.


### PR DESCRIPTION
Fixes timeouts caused by a race condition when loading a page. In pre-4.0 webview_flutter, the widget was passed the initial url, so we were able to call `await pageLoads.stream.first;` before the page was loaded. 

However, these tests would load the url before we could call `await pageLoads.stream.first;`, leading to a timeout.

This could also be responsible for the test crashes, but I'll keep an eye on the CI to make sure.

Edit: Tests passed first time, so this could be the only fixed needed!

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
