### PR TITLE
[image_picker_ios] Pass through error message from image saving

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.6+3
+
+* Returns error on image load failure.
+
 ## 0.8.6+2
 
 * Fixes issue where selectable images of certain types (such as ProRAW images) could not be loaded.

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -6,7 +6,9 @@
 
 @import image_picker_ios;
 @import image_picker_ios.Test;
+@import UniformTypeIdentifiers;
 @import XCTest;
+
 #import <OCMock/OCMock.h>
 
 @interface MockViewController : UIViewController
@@ -269,37 +271,130 @@
 - (void)testPluginMultiImagePathHasNullItem {
   FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
 
-  dispatch_semaphore_t resultSemaphore = dispatch_semaphore_create(0);
-  __block FlutterError *pickImageResult = nil;
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
   plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
       initWithResult:^(NSArray<NSString *> *_Nullable result, FlutterError *_Nullable error) {
-        pickImageResult = error;
-        dispatch_semaphore_signal(resultSemaphore);
+        XCTAssertEqualObjects(error.code, @"create_error");
+        [resultExpectation fulfill];
       }];
   [plugin sendCallResultWithSavedPathList:@[ [NSNull null] ]];
 
-  dispatch_semaphore_wait(resultSemaphore, DISPATCH_TIME_FOREVER);
-
-  XCTAssertEqualObjects(pickImageResult.code, @"create_error");
+  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 - (void)testPluginMultiImagePathHasItem {
   FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
   NSArray *pathList = @[ @"test" ];
 
-  dispatch_semaphore_t resultSemaphore = dispatch_semaphore_create(0);
-  __block id pickImageResult = nil;
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
 
   plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
       initWithResult:^(NSArray<NSString *> *_Nullable result, FlutterError *_Nullable error) {
-        pickImageResult = result;
-        dispatch_semaphore_signal(resultSemaphore);
+        XCTAssertEqualObjects(result, pathList);
+        [resultExpectation fulfill];
       }];
   [plugin sendCallResultWithSavedPathList:pathList];
 
-  dispatch_semaphore_wait(resultSemaphore, DISPATCH_TIME_FOREVER);
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
 
-  XCTAssertEqual(pickImageResult, pathList);
+- (void)testSendsImageInvalidSourceError API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+
+  id mockItemProvider = OCMClassMock([NSItemProvider class]);
+  // Does not conform to image, invalid source.
+  OCMStub([mockItemProvider hasItemConformingToTypeIdentifier:OCMOCK_ANY]).andReturn(NO);
+
+  PHPickerResult *failResult1 = OCMClassMock([PHPickerResult class]);
+  OCMStub([failResult1 itemProvider]).andReturn(mockItemProvider);
+
+  PHPickerResult *failResult2 = OCMClassMock([PHPickerResult class]);
+  OCMStub([failResult2 itemProvider]).andReturn(mockItemProvider);
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
+
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertTrue(NSThread.isMainThread);
+        XCTAssertNil(result);
+        XCTAssertEqualObjects(error.code, @"invalid_source");
+        [resultExpectation fulfill];
+      }];
+
+  [plugin picker:mockPickerViewController didFinishPicking:@[ failResult1, failResult2 ]];
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testSendsImageInvalidErrorWhenOneFails API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+  NSError *loadDataError = [NSError errorWithDomain:@"PHPickerDomain" code:1234 userInfo:nil];
+
+  id mockFailItemProvider = OCMClassMock([NSItemProvider class]);
+  OCMStub([mockFailItemProvider hasItemConformingToTypeIdentifier:OCMOCK_ANY]).andReturn(YES);
+  [[mockFailItemProvider stub]
+      loadDataRepresentationForTypeIdentifier:OCMOCK_ANY
+                            completionHandler:[OCMArg invokeBlockWithArgs:[NSNull null],
+                                                                          loadDataError, nil]];
+
+  PHPickerResult *failResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([failResult itemProvider]).andReturn(mockFailItemProvider);
+
+  NSURL *tiffURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"tiffImage"
+                                                            withExtension:@"tiff"];
+  NSItemProvider *tiffItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:tiffURL];
+  PHPickerResult *tiffResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([tiffResult itemProvider]).andReturn(tiffItemProvider);
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
+
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertTrue(NSThread.isMainThread);
+        XCTAssertNil(result);
+        XCTAssertEqualObjects(error.code, @"invalid_image");
+        [resultExpectation fulfill];
+      }];
+
+  [plugin picker:mockPickerViewController didFinishPicking:@[ failResult, tiffResult ]];
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
+}
+
+- (void)testSavesImages API_AVAILABLE(ios(14)) {
+  id mockPickerViewController = OCMClassMock([PHPickerViewController class]);
+
+  NSURL *tiffURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"tiffImage"
+                                                            withExtension:@"tiff"];
+  NSItemProvider *tiffItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:tiffURL];
+  PHPickerResult *tiffResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([tiffResult itemProvider]).andReturn(tiffItemProvider);
+
+  NSURL *pngURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"pngImage"
+                                                           withExtension:@"png"];
+  NSItemProvider *pngItemProvider = [[NSItemProvider alloc] initWithContentsOfURL:pngURL];
+  PHPickerResult *pngResult = OCMClassMock([PHPickerResult class]);
+  OCMStub([pngResult itemProvider]).andReturn(pngItemProvider);
+
+  FLTImagePickerPlugin *plugin = [[FLTImagePickerPlugin alloc] init];
+
+  XCTestExpectation *resultExpectation = [self expectationWithDescription:@"result"];
+
+  plugin.callContext = [[FLTImagePickerMethodCallContext alloc]
+      initWithResult:^(NSArray<NSString *> *result, FlutterError *error) {
+        XCTAssertTrue(NSThread.isMainThread);
+        XCTAssertEqual(result.count, 2);
+        XCTAssertNil(error);
+        [resultExpectation fulfill];
+      }];
+
+  [plugin picker:mockPickerViewController didFinishPicking:@[ tiffResult, pngResult ]];
+
+  [self waitForExpectationsWithTimeout:30 handler:nil];
 }
 
 @end

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PhotoAssetUtilTests.m
@@ -39,8 +39,7 @@
                                                                                maxWidth:nil
                                                                               maxHeight:nil
                                                                            imageQuality:nil];
-  XCTAssertNotNil(savedPathJPG);
-  XCTAssertEqualObjects([savedPathJPG substringFromIndex:savedPathJPG.length - 4], @".jpg");
+  XCTAssertEqualObjects([NSURL URLWithString:savedPathJPG].pathExtension, @"jpg");
 
   NSDictionary *originalMetaDataJPG = [FLTImagePickerMetaDataUtil getMetaDataFromImageData:dataJPG];
   NSData *newDataJPG = [NSData dataWithContentsOfFile:savedPathJPG];
@@ -55,8 +54,7 @@
                                                                                maxWidth:nil
                                                                               maxHeight:nil
                                                                            imageQuality:nil];
-  XCTAssertNotNil(savedPathPNG);
-  XCTAssertEqualObjects([savedPathPNG substringFromIndex:savedPathPNG.length - 4], @".png");
+  XCTAssertEqualObjects([NSURL URLWithString:savedPathPNG].pathExtension, @"png");
 
   NSDictionary *originalMetaDataPNG = [FLTImagePickerMetaDataUtil getMetaDataFromImageData:dataPNG];
   NSData *newDataPNG = [NSData dataWithContentsOfFile:savedPathPNG];
@@ -69,8 +67,6 @@
   NSString *savedPathJPG = [FLTImagePickerPhotoAssetUtil saveImageWithPickerInfo:nil
                                                                            image:imageJPG
                                                                     imageQuality:nil];
-
-  XCTAssertNotNil(savedPathJPG);
   // should be saved as
   XCTAssertEqualObjects([savedPathJPG substringFromIndex:savedPathJPG.length - 4],
                         kFLTImagePickerDefaultSuffix);
@@ -98,7 +94,7 @@
   // test gif
   NSData *dataGIF = ImagePickerTestImages.GIFTestData;
   UIImage *imageGIF = [UIImage imageWithData:dataGIF];
-  CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)dataGIF, nil);
+  CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)dataGIF, nil);
 
   size_t numberOfFrames = CGImageSourceGetCount(imageSource);
 
@@ -107,12 +103,12 @@
                                                                                maxWidth:nil
                                                                               maxHeight:nil
                                                                            imageQuality:nil];
-  XCTAssertNotNil(savedPathGIF);
-  XCTAssertEqualObjects([savedPathGIF substringFromIndex:savedPathGIF.length - 4], @".gif");
+  XCTAssertEqualObjects([NSURL URLWithString:savedPathGIF].pathExtension, @"gif");
 
   NSData *newDataGIF = [NSData dataWithContentsOfFile:savedPathGIF];
 
-  CGImageSourceRef newImageSource = CGImageSourceCreateWithData((CFDataRef)newDataGIF, nil);
+  CGImageSourceRef newImageSource =
+      CGImageSourceCreateWithData((__bridge CFDataRef)newDataGIF, nil);
 
   size_t newNumberOfFrames = CGImageSourceGetCount(newImageSource);
 
@@ -124,7 +120,7 @@
   NSData *dataGIF = ImagePickerTestImages.GIFTestData;
   UIImage *imageGIF = [UIImage imageWithData:dataGIF];
 
-  CGImageSourceRef imageSource = CGImageSourceCreateWithData((CFDataRef)dataGIF, nil);
+  CGImageSourceRef imageSource = CGImageSourceCreateWithData((__bridge CFDataRef)dataGIF, nil);
 
   size_t numberOfFrames = CGImageSourceGetCount(imageSource);
 
@@ -139,7 +135,8 @@
   XCTAssertEqual(newImage.size.width, 3);
   XCTAssertEqual(newImage.size.height, 2);
 
-  CGImageSourceRef newImageSource = CGImageSourceCreateWithData((CFDataRef)newDataGIF, nil);
+  CGImageSourceRef newImageSource =
+      CGImageSourceCreateWithData((__bridge CFDataRef)newDataGIF, nil);
 
   size_t newNumberOfFrames = CGImageSourceGetCount(newImageSource);
 

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
@@ -120,7 +120,7 @@
   options[(NSString *)kCGImageSourceTypeIdentifierHint] = (NSString *)kUTTypeGIF;
 
   CGImageSourceRef imageSource =
-      CGImageSourceCreateWithData((__bridge CFDataRef)data, (CFDictionaryRef)options);
+      CGImageSourceCreateWithData((__bridge CFDataRef)data, (__bridge CFDictionaryRef)options);
 
   size_t numberOfFrames = CGImageSourceGetCount(imageSource);
   NSMutableArray<UIImage *> *images = [NSMutableArray arrayWithCapacity:numberOfFrames];
@@ -128,7 +128,7 @@
   NSTimeInterval interval = 0.0;
   for (size_t index = 0; index < numberOfFrames; index++) {
     CGImageRef imageRef =
-        CGImageSourceCreateImageAtIndex(imageSource, index, (CFDictionaryRef)options);
+        CGImageSourceCreateImageAtIndex(imageSource, index, (__bridge CFDictionaryRef)options);
 
     NSDictionary *properties = (NSDictionary *)CFBridgingRelease(
         CGImageSourceCopyPropertiesAtIndex(imageSource, index, NULL));

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
@@ -120,7 +120,7 @@
   options[(NSString *)kCGImageSourceTypeIdentifierHint] = (NSString *)kUTTypeGIF;
 
   CGImageSourceRef imageSource =
-      CGImageSourceCreateWithData((CFDataRef)data, (CFDictionaryRef)options);
+      CGImageSourceCreateWithData((__bridge CFDataRef)data, (CFDictionaryRef)options);
 
   size_t numberOfFrames = CGImageSourceGetCount(imageSource);
   NSMutableArray<UIImage *> *images = [NSMutableArray arrayWithCapacity:numberOfFrames];

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerMetaDataUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerMetaDataUtil.m
@@ -42,7 +42,7 @@ const FLTImagePickerMIMEType kFLTImagePickerMIMETypeDefault = FLTImagePickerMIME
 }
 
 + (NSDictionary *)getMetaDataFromImageData:(NSData *)imageData {
-  CGImageSourceRef source = CGImageSourceCreateWithData((CFDataRef)imageData, NULL);
+  CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef)imageData, NULL);
   NSDictionary *metadata =
       (NSDictionary *)CFBridgingRelease(CGImageSourceCopyPropertiesAtIndex(source, 0, NULL));
   CFRelease(source);

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -124,7 +124,8 @@
 
   for (NSInteger index = 0; index < gifInfo.images.count; index++) {
     UIImage *image = (UIImage *)[gifInfo.images objectAtIndex:index];
-    CGImageDestinationAddImage(destination, image.CGImage, (__bridge CFDictionaryRef)frameProperties);
+    CGImageDestinationAddImage(destination, image.CGImage,
+                               (__bridge CFDictionaryRef)frameProperties);
   }
 
   CGImageDestinationFinalize(destination);

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPhotoAssetUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPhotoAssetUtil.m
@@ -103,7 +103,7 @@
                             gifInfo:(GIFInfo *)gifInfo
                                path:(NSString *)path {
   CGImageDestinationRef destination = CGImageDestinationCreateWithURL(
-      (CFURLRef)[NSURL fileURLWithPath:path], kUTTypeGIF, gifInfo.images.count, NULL);
+      (__bridge CFURLRef)[NSURL fileURLWithPath:path], kUTTypeGIF, gifInfo.images.count, NULL);
 
   NSDictionary *frameProperties = @{
     (__bridge NSString *)kCGImagePropertyGIFDictionary : @{
@@ -120,11 +120,11 @@
 
   gifProperties[(__bridge NSString *)kCGImagePropertyGIFLoopCount] = @0;
 
-  CGImageDestinationSetProperties(destination, (CFDictionaryRef)gifMetaProperties);
+  CGImageDestinationSetProperties(destination, (__bridge CFDictionaryRef)gifMetaProperties);
 
   for (NSInteger index = 0; index < gifInfo.images.count; index++) {
     UIImage *image = (UIImage *)[gifInfo.images objectAtIndex:index];
-    CGImageDestinationAddImage(destination, image.CGImage, (CFDictionaryRef)frameProperties);
+    CGImageDestinationAddImage(destination, image.CGImage, (__bridge CFDictionaryRef)frameProperties);
   }
 
   CGImageDestinationFinalize(destination);

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.h
@@ -5,9 +5,9 @@
 #import <Flutter/Flutter.h>
 #import <PhotosUI/PhotosUI.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FLTImagePickerPlugin : NSObject <FlutterPlugin>
-
-// For testing only.
-- (UIViewController *)viewControllerWithWindow:(UIWindow *)window;
-
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -29,10 +29,7 @@
 
 #pragma mark -
 
-@interface FLTImagePickerPlugin () <UINavigationControllerDelegate,
-                                    UIImagePickerControllerDelegate,
-                                    PHPickerViewControllerDelegate,
-                                    UIAdaptivePresentationControllerDelegate>
+@interface FLTImagePickerPlugin ()
 
 /**
  * The PHPickerViewController instance used to pick multiple
@@ -478,52 +475,55 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
     [self sendCallResultWithSavedPathList:nil];
     return;
   }
-  dispatch_queue_t backgroundQueue =
-      dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
-  dispatch_async(backgroundQueue, ^{
-    NSNumber *maxWidth = self.callContext.maxSize.width;
-    NSNumber *maxHeight = self.callContext.maxSize.height;
-    NSNumber *imageQuality = self.callContext.imageQuality;
-    NSNumber *desiredImageQuality = [self getDesiredImageQuality:imageQuality];
-    NSOperationQueue *operationQueue = [NSOperationQueue new];
-    NSMutableArray *pathList = [self createNSMutableArrayWithSize:results.count];
+  __block NSOperationQueue *saveQueue = [[NSOperationQueue alloc] init];
+  saveQueue.name = @"Flutter Save Image Queue";
+  saveQueue.qualityOfService = NSQualityOfServiceUserInitiated;
 
-    for (int i = 0; i < results.count; i++) {
-      PHPickerResult *result = results[i];
-      FLTPHPickerSaveImageToPathOperation *operation = [[FLTPHPickerSaveImageToPathOperation alloc]
-               initWithResult:result
-                    maxHeight:maxHeight
-                     maxWidth:maxWidth
-          desiredImageQuality:desiredImageQuality
-                 fullMetadata:self.callContext.requestFullMetadata
-               savedPathBlock:^(NSString *savedPath) {
-                 pathList[i] = savedPath;
-               }];
-      [operationQueue addOperation:operation];
-    }
-    [operationQueue waitUntilAllOperationsAreFinished];
-    dispatch_async(dispatch_get_main_queue(), ^{
+  FLTImagePickerMethodCallContext *currentCallContext = self.callContext;
+  NSNumber *maxWidth = currentCallContext.maxSize.width;
+  NSNumber *maxHeight = currentCallContext.maxSize.height;
+  NSNumber *imageQuality = currentCallContext.imageQuality;
+  NSNumber *desiredImageQuality = [self getDesiredImageQuality:imageQuality];
+  BOOL requestFullMetadata = currentCallContext.requestFullMetadata;
+  NSMutableArray *pathList = [[NSMutableArray alloc] initWithCapacity:results.count];
+  __block FlutterError *saveError = nil;
+
+  // This operation will be executed on the main queue after
+  // all selected files have been saved.
+  NSBlockOperation *sendListOperation = [NSBlockOperation blockOperationWithBlock:^{
+    if (saveError != nil) {
+      [self sendCallResultWithError:saveError];
+    } else {
       [self sendCallResultWithSavedPathList:pathList];
-    });
-  });
-}
+    }
+    // Retain queue until here.
+    saveQueue = nil;
+  }];
 
-#pragma mark -
+  [results enumerateObjectsUsingBlock:^(PHPickerResult *result, NSUInteger index, BOOL *stop) {
+    // NSNull means it hasn't saved yet.
+    pathList[index] = [NSNull null];
+    FLTPHPickerSaveImageToPathOperation *saveOperation =
+        [[FLTPHPickerSaveImageToPathOperation alloc]
+                 initWithResult:result
+                      maxHeight:maxHeight
+                       maxWidth:maxWidth
+            desiredImageQuality:desiredImageQuality
+                   fullMetadata:requestFullMetadata
+                 savedPathBlock:^(NSString *savedPath, FlutterError *error) {
+                   if (savedPath != nil) {
+                     pathList[index] = savedPath;
+                   } else {
+                     saveError = error;
+                   }
+                 }];
+    [sendListOperation addDependency:saveOperation];
+    [saveQueue addOperation:saveOperation];
+  }];
 
-/**
- * Creates an NSMutableArray of a certain size filled with NSNull objects.
- *
- * The difference with initWithCapacity is that initWithCapacity still gives an empty array making
- * it impossible to add objects on an index larger than the size.
- *
- * @param size The length of the required array
- * @return NSMutableArray An array of a specified size
- */
-- (NSMutableArray *)createNSMutableArrayWithSize:(NSUInteger)size {
-  NSMutableArray *mutableArray = [[NSMutableArray alloc] initWithCapacity:size];
-  for (int i = 0; i < size; [mutableArray addObject:[NSNull null]], i++)
-    ;
-  return mutableArray;
+  // Schedule the final Flutter callback on the main queue
+  // to be run after all images have been saved.
+  [NSOperationQueue.mainQueue addOperation:sendListOperation];
 }
 
 #pragma mark - UIImagePickerControllerDelegate

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -487,14 +487,14 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
   BOOL requestFullMetadata = currentCallContext.requestFullMetadata;
   NSMutableArray *pathList = [[NSMutableArray alloc] initWithCapacity:results.count];
   __block FlutterError *saveError = nil;
-
+  __weak typeof(self) weakSelf = self;
   // This operation will be executed on the main queue after
   // all selected files have been saved.
   NSBlockOperation *sendListOperation = [NSBlockOperation blockOperationWithBlock:^{
     if (saveError != nil) {
-      [self sendCallResultWithError:saveError];
+      [weakSelf sendCallResultWithError:saveError];
     } else {
-      [self sendCallResultWithSavedPathList:pathList];
+      [weakSelf sendCallResultWithSavedPathList:pathList];
     }
     // Retain queue until here.
     saveQueue = nil;

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m
@@ -502,7 +502,7 @@ typedef NS_ENUM(NSInteger, ImagePickerClassType) { UIImagePickerClassType, PHPic
 
   [results enumerateObjectsUsingBlock:^(PHPickerResult *result, NSUInteger index, BOOL *stop) {
     // NSNull means it hasn't saved yet.
-    pathList[index] = [NSNull null];
+    [pathList addObject:[NSNull null]];
     FLTPHPickerSaveImageToPathOperation *saveOperation =
         [[FLTPHPickerSaveImageToPathOperation alloc]
                  initWithResult:result

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin_Test.h
@@ -54,12 +54,18 @@ typedef void (^FlutterResultAdapter)(NSArray<NSString *> *_Nullable, FlutterErro
 #pragma mark -
 
 /** Methods exposed for unit testing. */
-@interface FLTImagePickerPlugin () <FLTImagePickerApi>
+@interface FLTImagePickerPlugin () <FLTImagePickerApi,
+                                    UINavigationControllerDelegate,
+                                    UIImagePickerControllerDelegate,
+                                    PHPickerViewControllerDelegate,
+                                    UIAdaptivePresentationControllerDelegate>
 
 /**
  * The context of the Flutter method call that is currently being handled, if any.
  */
 @property(strong, nonatomic, nullable) FLTImagePickerMethodCallContext *callContext;
+
+- (UIViewController *)viewControllerWithWindow:(nullable UIWindow *)window;
 
 /**
  * Validates the provided paths list, then sends it via `callContext.result` as the result of the

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.h
@@ -9,6 +9,11 @@
 #import "FLTImagePickerMetaDataUtil.h"
 #import "FLTImagePickerPhotoAssetUtil.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
+/// Returns either the saved path, or an error. Both cannot be set.
+typedef void (^FLTGetSavedPath)(NSString *_Nullable savedPath, FlutterError *_Nullable error);
+
 /*!
  @class FLTPHPickerSaveImageToPathOperation
 
@@ -27,6 +32,8 @@
                       maxWidth:(NSNumber *)maxWidth
            desiredImageQuality:(NSNumber *)desiredImageQuality
                   fullMetadata:(BOOL)fullMetadata
-                savedPathBlock:(void (^)(NSString *))savedPathBlock API_AVAILABLE(ios(14));
+                savedPathBlock:(FLTGetSavedPath)savedPathBlock API_AVAILABLE(ios(14));
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.6+2
+version: 0.8.6+3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Previously, if there was an error loading the image, the result callback would never be called, and the `callContext` would not be nil'd out.  When the next request happened, the user would get a confusing `multiple_request` error because the last state wasn't cleared out.
https://github.com/flutter/plugins/blob/2cbb314d99d800cb4e1229ce6b304755303bbd64/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m#L273-L277

Now, when there is an error loading an image, pipe an error back to the flutter result instead of silently failing and never calling the result callback.  This also `nil`s out the `callContext` so the next request has a chance of succeeding.
https://github.com/flutter/plugins/blob/2cbb314d99d800cb4e1229ce6b304755303bbd64/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerPlugin.m#L683-L684

As before, save all the picked images on a background thread, and when complete call the callback with either all the saved images, or with the image error.  Use the `NSOperationQueue` API instead of GCD to take advantage of dependency operations (the final main callback is dependent on the image save operations completing).

If _any_ of the picked images fail to load, return an error back to the dart side.  Ideally there would be a mapping between successfully picked images and the images that failed to load, but I believe that would require an API change like https://github.com/flutter/flutter/issues/95268.

Also
- Minor `__bridge` cleanup
- Use XCTest expectations instead of semaphores.

Fixes https://github.com/flutter/flutter/issues/98569
Fixes https://github.com/flutter/flutter/issues/82602
Will make https://github.com/flutter/flutter/issues/49780 actually show the underlying error.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
