### PR TITLE
[video_player] allow attaching VideoPlayerController to multi VideoPlayers in web

### DIFF
--- a/packages/video_player/video_player/example/lib/main.dart
+++ b/packages/video_player/video_player/example/lib/main.dart
@@ -398,7 +398,7 @@ class _PlayerVideoAndPopPageState extends State<_PlayerVideoAndPopPage> {
         VideoPlayerController.asset('assets/Butterfly-209.mp4');
     _videoPlayerController.addListener(() {
       if (startedPlaying && !_videoPlayerController.value.isPlaying) {
-        Navigator.pop(context);
+        Navigator.maybePop(context);
       }
     });
   }

--- a/packages/video_player/video_player_web/lib/src/media_stream_view.dart
+++ b/packages/video_player/video_player_web/lib/src/media_stream_view.dart
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:flutter/widgets.dart';
+
+import 'shims/dart_ui.dart' as ui;
+import 'video_player.dart';
+
+/// Wraps a [HtmlElementView] which can render [html.MediaStream].
+class MediaStreamView extends StatefulWidget {
+  /// Create a [MediaStreamView] from a [VideoPlayer] instance.
+  const MediaStreamView({
+    Key? key,
+    required this.mediaStream,
+  }) : super(key: key);
+
+  /// The [html.MediaStream] content to render into a [html.VideoElement].
+  final html.MediaStream mediaStream;
+
+  @override
+  MediaStreamViewState createState() => MediaStreamViewState();
+}
+
+/// The state of [MediaStreamView].
+class MediaStreamViewState extends State<MediaStreamView> {
+  late final html.VideoElement _videoElement;
+
+  String get _viewType => 'videoPlayer-${identityHashCode(this)}';
+
+  @override
+  void initState() {
+    super.initState();
+    _videoElement = html.VideoElement()
+      ..id = 'videoElement-${identityHashCode(this)}'
+      ..style.border = 'none'
+      ..style.height = '100%'
+      ..style.width = '100%'
+      ..muted = true
+      ..autoplay = true
+      ..controls = false
+      ..srcObject = widget.mediaStream;
+    // TODO(hterkelsen): Use initialization parameters once they are available
+    ui.platformViewRegistry.registerViewFactory(
+      _viewType,
+      (int viewId) => _videoElement,
+    );
+  }
+
+  @override
+  void didUpdateWidget(MediaStreamView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mediaStream != oldWidget.mediaStream) {
+      _videoElement.srcObject = widget.mediaStream;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HtmlElementView(viewType: _viewType);
+  }
+
+  @override
+  void dispose() {
+    _videoElement.srcObject = null;
+    super.dispose();
+  }
+}

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -52,6 +52,9 @@ class VideoPlayer {
   /// Returns the [Stream] of [VideoEvent]s from the inner [html.VideoElement].
   Stream<VideoEvent> get events => _eventController.stream;
 
+  /// Returns the captured [html.MediaStream] from the inner [html.VideoElement].
+  late final html.MediaStream capturedStream = _videoElement.captureStream();
+
   /// Initializes the wrapped [html.VideoElement].
   ///
   /// This method sets the required DOM attributes so videos can [play] programmatically,

--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
 
+import 'src/media_stream_view.dart';
 import 'src/shims/dart_ui.dart' as ui;
 import 'src/video_player.dart';
 
@@ -76,13 +77,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
     final VideoElement videoElement = VideoElement()
       ..id = 'videoElement-$textureId'
       ..src = uri
-      ..style.border = 'none'
-      ..style.height = '100%'
-      ..style.width = '100%';
-
-    // TODO(hterkelsen): Use initialization parameters once they are available
-    ui.platformViewRegistry.registerViewFactory(
-        'videoPlayer-$textureId', (int viewId) => videoElement);
+      ..crossOrigin = 'anonymous';
 
     final VideoPlayer player = VideoPlayer(videoElement: videoElement)
       ..initialize();
@@ -140,7 +135,7 @@ class VideoPlayerPlugin extends VideoPlayerPlatform {
 
   @override
   Widget buildView(int textureId) {
-    return HtmlElementView(viewType: 'videoPlayer-$textureId');
+    return MediaStreamView(mediaStream: _player(textureId).capturedStream);
   }
 
   /// Sets the audio mode to mix with other sources (ignored)


### PR DESCRIPTION
This PR Allows attaching VideoPlayerController to multi VideoPlayers in web platforms.
Fix: https://github.com/flutter/flutter/issues/117432

The existing `VideoElement` serves as a primary node and won't render directly.
For each VideoPlayer, it will be backed up with a new replica `VideoElement`.
The content rendered to the replica is the `MediaStream` get from primary node via `captureStream()`.

This is useful for creating in-app picture-in-picture mode or fullscreen mode UI.

Also, fullscreen mode example is added.

Before:

https://user-images.githubusercontent.com/13031690/209276854-f7acc48a-e6df-41a9-820a-f9e4c94bf47f.mov

After:

https://user-images.githubusercontent.com/13031690/209276869-c953ce02-2622-4ac3-8d05-57d60efbe8ee.mov




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [ ] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
