### PR TITLE
[image_picker_ios] Fix FLTPHPickerSaveImageToPathOperation property attributes

### DIFF
--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,6 +1,10 @@
+## 0.8.6+5
+
+* Fixes crash when `imageQuality` is set.
+
 ## 0.8.6+4
 
-* Fix authorization status check for iOS14+ so it includes `PHAuthorizationStatusLimited`.
+* Fixes authorization status check for iOS14+ so it includes `PHAuthorizationStatusLimited`.
 
 ## 0.8.6+3
 

--- a/packages/image_picker/image_picker_ios/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/image_picker/image_picker_ios/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -51,16 +51,6 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "BE7AEE6B26403C46006181AA"
-               BuildableName = "RunnerUITestiOS14.xctest"
-               BlueprintName = "RunnerUITestiOS14"
-               ReferencedContainer = "container:Runner.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "334733F12668136400DCC49E"
                BuildableName = "RunnerTests.xctest"
                BlueprintName = "RunnerTests"

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/ImagePickerPluginTests.m
@@ -56,7 +56,7 @@
                                                             camera:FLTSourceCameraRear]
                       maxSize:[[FLTMaxSize alloc] init]
                       quality:nil
-                 fullMetadata:@(YES)
+                 fullMetadata:@YES
                    completion:^(NSString *_Nullable result, FlutterError *_Nullable error){
                    }];
 
@@ -89,7 +89,7 @@
                                                             camera:FLTSourceCameraFront]
                       maxSize:[[FLTMaxSize alloc] init]
                       quality:nil
-                 fullMetadata:@(YES)
+                 fullMetadata:@YES
                    completion:^(NSString *_Nullable result, FlutterError *_Nullable error){
                    }];
 
@@ -174,7 +174,7 @@
 
   [plugin pickMultiImageWithMaxSize:[FLTMaxSize makeWithWidth:@(100) height:@(200)]
                             quality:@(50)
-                       fullMetadata:@(YES)
+                       fullMetadata:@YES
                          completion:^(NSArray<NSString *> *_Nullable result,
                                       FlutterError *_Nullable error){
                          }];
@@ -193,7 +193,7 @@
                                                             camera:FLTSourceCameraFront]
                       maxSize:[[FLTMaxSize alloc] init]
                       quality:nil
-                 fullMetadata:@(NO)
+                 fullMetadata:@NO
                    completion:^(NSString *_Nullable result, FlutterError *_Nullable error){
                    }];
 
@@ -209,7 +209,7 @@
 
   [plugin pickMultiImageWithMaxSize:[[FLTMaxSize alloc] init]
                             quality:nil
-                       fullMetadata:@(NO)
+                       fullMetadata:@NO
                          completion:^(NSArray<NSString *> *_Nullable result,
                                       FlutterError *_Nullable error){
                          }];
@@ -231,7 +231,7 @@
                                                             camera:FLTSourceCameraRear]
                       maxSize:[[FLTMaxSize alloc] init]
                       quality:nil
-                 fullMetadata:@(YES)
+                 fullMetadata:@YES
                    completion:^(NSString *_Nullable result, FlutterError *_Nullable error){
                    }];
 

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerTests/PickerSaveImageToPathOperationTests.m
@@ -184,7 +184,6 @@
  * Creates a mock picker result using NSItemProvider.
  *
  * @param itemProvider an item provider that will be used as picker result
- * @param identifier local identifier of the asset
  */
 - (PHPickerResult *)createPickerResultWithProvider:(NSItemProvider *)itemProvider
     API_AVAILABLE(ios(14)) {

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromGalleryUITests.m
@@ -59,41 +59,25 @@ const int kElementWaitingTime = 30;
   [self.app terminate];
 }
 
-- (void)testPickingFromGallery {
-  [self launchPickerAndPick];
-}
-
 - (void)testCancel {
-  [self launchPickerAndCancel];
-}
-
-- (void)launchPickerAndCancel {
   // Find and tap on the pick from gallery button.
-  NSPredicate *predicateToFindImageFromGalleryButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"image_picker_example_from_gallery"];
-
   XCUIElement *imageFromGalleryButton =
-      [self.app.otherElements elementMatchingPredicate:predicateToFindImageFromGalleryButton];
+      self.app.otherElements[@"image_picker_example_from_gallery"].firstMatch;
   if (![imageFromGalleryButton waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find image from gallery button with %@ seconds",
             @(kElementWaitingTime));
   }
 
-  XCTAssertTrue(imageFromGalleryButton.exists);
   [imageFromGalleryButton tap];
 
   // Find and tap on the `pick` button.
-  NSPredicate *predicateToFindPickButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"PICK"];
-
-  XCUIElement *pickButton = [self.app.buttons elementMatchingPredicate:predicateToFindPickButton];
+  XCUIElement *pickButton = self.app.buttons[@"PICK"].firstMatch;
   if (![pickButton waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find pick button with %@ seconds", @(kElementWaitingTime));
   }
 
-  XCTAssertTrue(pickButton.exists);
   [pickButton tap];
 
   // There is a known bug where the permission popups interruption won't get fired until a tap
@@ -101,61 +85,69 @@ const int kElementWaitingTime = 30;
   [self.app tap];
 
   // Find and tap on the `Cancel` button.
-  NSPredicate *predicateToFindCancelButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"Cancel"];
-
   XCUIElement *cancelButton =
-      [self.app.buttons elementMatchingPredicate:predicateToFindCancelButton];
+      self.app.buttons[@"Cancel"].firstMatch;
   if (![cancelButton waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find Cancel button with %@ seconds",
             @(kElementWaitingTime));
   }
 
-  XCTAssertTrue(cancelButton.exists);
   [cancelButton tap];
 
   // Find the "not picked image text".
-  XCUIElement *imageNotPickedText = [self.app.staticTexts
-      elementMatchingPredicate:[NSPredicate
-                                   predicateWithFormat:@"label == %@",
-                                                       @"You have not yet picked an image."]];
+  XCUIElement *imageNotPickedText = self.app.staticTexts[@"You have not yet picked an image."].firstMatch;
   if (![imageNotPickedText waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find imageNotPickedText with %@ seconds",
             @(kElementWaitingTime));
   }
-
-  XCTAssertTrue(imageNotPickedText.exists);
 }
 
-- (void)launchPickerAndPick {
-  // Find and tap on the pick from gallery button.
-  NSPredicate *predicateToFindImageFromGalleryButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"image_picker_example_from_gallery"];
+- (void)testPickingFromGallery {
+  [self launchPickerAndPickWithMaxWidth:nil maxHeight:nil quality:nil];
+}
 
+
+- (void)testPickingWithContraintsFromGallery {
+  [self launchPickerAndPickWithMaxWidth:@200 maxHeight:@100 quality:@50];
+}
+
+- (void)launchPickerAndPickWithMaxWidth:(NSNumber *)maxWidth maxHeight:(NSNumber *)maxHeight quality:(NSNumber *)quality {
+  // Find and tap on the pick from gallery button.
   XCUIElement *imageFromGalleryButton =
-      [self.app.otherElements elementMatchingPredicate:predicateToFindImageFromGalleryButton];
+      self.app.otherElements[@"image_picker_example_from_gallery"].firstMatch;
   if (![imageFromGalleryButton waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find image from gallery button with %@ seconds",
             @(kElementWaitingTime));
   }
-
-  XCTAssertTrue(imageFromGalleryButton.exists);
   [imageFromGalleryButton tap];
 
-  // Find and tap on the `pick` button.
-  NSPredicate *predicateToFindPickButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"PICK"];
+  if (maxWidth != nil) {
+    XCUIElement *field = self.app.textFields[@"Enter maxWidth if desired"].firstMatch;
+    [field tap];
+    [field typeText:maxWidth.stringValue];
+  }
 
-  XCUIElement *pickButton = [self.app.buttons elementMatchingPredicate:predicateToFindPickButton];
+  if (maxHeight != nil) {
+    XCUIElement *field = self.app.textFields[@"Enter maxHeight if desired"].firstMatch;
+    [field tap];
+    [field typeText:maxHeight.stringValue];
+  }
+
+  if (quality != nil) {
+    XCUIElement *field = self.app.textFields[@"Enter quality if desired"].firstMatch;
+    [field tap];
+    [field typeText:quality.stringValue];
+  }
+
+  // Find and tap on the `pick` button.
+  XCUIElement *pickButton = self.app.buttons[@"PICK"].firstMatch;
   if (![pickButton waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find pick button with %@ seconds", @(kElementWaitingTime));
   }
-
-  XCTAssertTrue(pickButton.exists);
   [pickButton tap];
 
   // There is a known bug where the permission popups interruption won't get fired until a tap
@@ -167,8 +159,7 @@ const int kElementWaitingTime = 30;
   if (@available(iOS 14, *)) {
     aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
   } else {
-    XCUIElement *allPhotosCell = [self.app.cells
-        elementMatchingPredicate:[NSPredicate predicateWithFormat:@"label == %@", @"All Photos"]];
+    XCUIElement *allPhotosCell = self.app.cells[@"All Photos"].firstMatch;
     if (![allPhotosCell waitForExistenceWithTimeout:kElementWaitingTime]) {
       os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
       XCTFail(@"Failed due to not able to find \"All Photos\" cell with %@ seconds",
@@ -184,20 +175,14 @@ const int kElementWaitingTime = 30;
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find an image with %@ seconds", @(kElementWaitingTime));
   }
-  XCTAssertTrue(aImage.exists);
   [aImage tap];
 
   // Find the picked image.
-  NSPredicate *predicateToFindPickedImage =
-      [NSPredicate predicateWithFormat:@"label == %@", @"image_picker_example_picked_image"];
-
-  XCUIElement *pickedImage = [self.app.images elementMatchingPredicate:predicateToFindPickedImage];
+  XCUIElement *pickedImage = self.app.images[@"image_picker_example_picked_image"].firstMatch;
   if (![pickedImage waitForExistenceWithTimeout:kElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find pickedImage with %@ seconds", @(kElementWaitingTime));
   }
-
-  XCTAssertTrue(pickedImage.exists);
 }
 
 @end

--- a/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
+++ b/packages/image_picker/image_picker_ios/example/ios/RunnerUITests/ImagePickerFromLimitedGalleryUITests.m
@@ -46,126 +46,59 @@ const int kLimitedElementWaitingTime = 30;
   [self.app terminate];
 }
 
-- (void)testSelectingFromGallery {
-  // Test the `Select Photos` button which is available after iOS 14.
-  if (@available(iOS 14, *)) {
-    [self launchPickerAndSelect];
-  } else {
-    return;
-  }
-}
-
-- (void)launchPickerAndSelect {
+// Test the `Select Photos` button which is available after iOS 14.
+- (void)testSelectingFromGallery API_AVAILABLE(ios(14)) {
   // Find and tap on the pick from gallery button.
-  NSPredicate *predicateToFindImageFromGalleryButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"image_picker_example_from_gallery"];
-
-  XCUIElement *imageFromGalleryButton =
-      [self.app.otherElements elementMatchingPredicate:predicateToFindImageFromGalleryButton];
+  XCUIElement *imageFromGalleryButton = self.app.otherElements[@"image_picker_example_from_gallery"].firstMatch;
   if (![imageFromGalleryButton waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find image from gallery button with %@ seconds",
             @(kLimitedElementWaitingTime));
   }
-
-  XCTAssertTrue(imageFromGalleryButton.exists);
   [imageFromGalleryButton tap];
 
   // Find and tap on the `pick` button.
-  NSPredicate *predicateToFindPickButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"PICK"];
-
-  XCUIElement *pickButton = [self.app.buttons elementMatchingPredicate:predicateToFindPickButton];
+  XCUIElement *pickButton = self.app.buttons[@"PICK"].firstMatch;
   if (![pickButton waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTSkip(@"Pick button isn't found so the test is skipped...");
   }
-
-  XCTAssertTrue(pickButton.exists);
   [pickButton tap];
 
   // There is a known bug where the permission popups interruption won't get fired until a tap
   // happened in the app. We expect a permission popup so we do a tap here.
   [self.app tap];
 
-  // Find an image and tap on it. (IOS 14 UI, images are showing directly)
-  XCUIElement *aImage;
-  if (@available(iOS 14, *)) {
-    aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
-  } else {
-    XCUIElement *selectedPhotosCell = [self.app.cells
-        elementMatchingPredicate:[NSPredicate
-                                     predicateWithFormat:@"label == %@", @"Selected Photos"]];
-    if (![selectedPhotosCell waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
-      os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-      XCTFail(@"Failed due to not able to find \"Selected Photos\" cell with %@ seconds",
-              @(kLimitedElementWaitingTime));
-    }
-    [selectedPhotosCell tap];
-    aImage = [self.app.collectionViews elementMatchingType:XCUIElementTypeCollectionView
-                                                identifier:@"PhotosGridView"]
-                 .cells.firstMatch;
-  }
-  os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
-  if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
-    os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-    XCTFail(@"Failed due to not able to find an image with %@ seconds",
-            @(kLimitedElementWaitingTime));
-  }
-  XCTAssertTrue(aImage.exists);
+  // Find an image and tap on it.
+  XCUIElement *aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
   [aImage tap];
 
   // Find and tap on the `Done` button.
-  NSPredicate *predicateToFindDoneButton =
-      [NSPredicate predicateWithFormat:@"label == %@", @"Done"];
-
-  XCUIElement *doneButton = [self.app.buttons elementMatchingPredicate:predicateToFindDoneButton];
+  XCUIElement *doneButton = self.app.buttons[@"Done"].firstMatch;
   if (![doneButton waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTSkip(@"Permissions popup could not fired so the test is skipped...");
   }
-
-  XCTAssertTrue(doneButton.exists);
   [doneButton tap];
 
   // Find an image and tap on it to have access to selected photos.
-  if (@available(iOS 14, *)) {
-    aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
-  } else {
-    XCUIElement *selectedPhotosCell = [self.app.cells
-        elementMatchingPredicate:[NSPredicate
-                                     predicateWithFormat:@"label == %@", @"Selected Photos"]];
-    if (![selectedPhotosCell waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
-      os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
-      XCTFail(@"Failed due to not able to find \"Selected Photos\" cell with %@ seconds",
-              @(kLimitedElementWaitingTime));
-    }
-    [selectedPhotosCell tap];
-    aImage = [self.app.collectionViews elementMatchingType:XCUIElementTypeCollectionView
-                                                identifier:@"PhotosGridView"]
-                 .cells.firstMatch;
-  }
+  aImage = [self.app.scrollViews.firstMatch.images elementBoundByIndex:1];
+
   os_log_error(OS_LOG_DEFAULT, "description before picking image %@", self.app.debugDescription);
   if (![aImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find an image with %@ seconds",
             @(kLimitedElementWaitingTime));
   }
-  XCTAssertTrue(aImage.exists);
   [aImage tap];
 
   // Find the picked image.
-  NSPredicate *predicateToFindPickedImage =
-      [NSPredicate predicateWithFormat:@"label == %@", @"image_picker_example_picked_image"];
-
-  XCUIElement *pickedImage = [self.app.images elementMatchingPredicate:predicateToFindPickedImage];
+  XCUIElement *pickedImage = self.app.images[@"image_picker_example_picked_image"].firstMatch;
   if (![pickedImage waitForExistenceWithTimeout:kLimitedElementWaitingTime]) {
     os_log_error(OS_LOG_DEFAULT, "%@", self.app.debugDescription);
     XCTFail(@"Failed due to not able to find pickedImage with %@ seconds",
             @(kLimitedElementWaitingTime));
   }
-
-  XCTAssertTrue(pickedImage.exists);
 }
 
 @end

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTImagePickerImageUtil.m
@@ -116,7 +116,7 @@
                    maxWidth:(NSNumber *)maxWidth
                   maxHeight:(NSNumber *)maxHeight {
   NSMutableDictionary<NSString *, id> *options = [NSMutableDictionary dictionary];
-  options[(NSString *)kCGImageSourceShouldCache] = @(YES);
+  options[(NSString *)kCGImageSourceShouldCache] = @YES;
   options[(NSString *)kCGImageSourceTypeIdentifierHint] = (NSString *)kUTTypeGIF;
 
   CGImageSourceRef imageSource =

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -13,9 +13,9 @@ API_AVAILABLE(ios(14))
 @interface FLTPHPickerSaveImageToPathOperation ()
 
 @property(strong, nonatomic) PHPickerResult *result;
-@property(assign, nonatomic) NSNumber *maxHeight;
-@property(assign, nonatomic) NSNumber *maxWidth;
-@property(assign, nonatomic) NSNumber *desiredImageQuality;
+@property(strong, nonatomic) NSNumber *maxHeight;
+@property(strong, nonatomic) NSNumber *maxWidth;
+@property(strong, nonatomic) NSNumber *desiredImageQuality;
 @property(assign, nonatomic) BOOL requestFullMetadata;
 
 @end

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.6+4
+version: 0.8.6+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
- Fix memory attributes of `FLTPHPickerSaveImageToPathOperation` `NSNumber` properties to `strong`, not `assign`
- Add UI tests that exercises the quality setting, confirm in crashes without this fix.
- Use `XCUIElementQuery` subscripting to find elements instead of label predicates.
- Minor cleanup of NSNumber boxing.

Fixes https://github.com/flutter/flutter/issues/117670

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
