### PR TITLE
[android_webview_controller] Fixes bug where an `AndroidController` couldn't be reused

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+* Fixes bug where an `AndroidWebViewController` couldn't be reused with a new `WebViewWidget`.
+
 ## 3.1.1
 
 * Fixes bug where a `AndroidNavigationDelegate` was required to load a request.

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/JavaObjectHostApiImpl.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/JavaObjectHostApiImpl.java
@@ -27,6 +27,10 @@ public class JavaObjectHostApiImpl implements GeneratedAndroidWebView.JavaObject
 
   @Override
   public void dispose(@NonNull Long identifier) {
+    final Object instance = instanceManager.getInstance(identifier);
+    if (instance instanceof WebViewHostApiImpl.WebViewPlatformView) {
+      ((WebViewHostApiImpl.WebViewPlatformView) instance).destroy();
+    }
     instanceManager.remove(identifier);
   }
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewHostApiImpl.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/WebViewHostApiImpl.java
@@ -102,9 +102,7 @@ public class WebViewHostApiImpl implements WebViewHostApi {
     }
 
     @Override
-    public void dispose() {
-      destroy();
-    }
+    public void dispose() {}
 
     @Override
     public void setWebViewClient(WebViewClient webViewClient) {

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
@@ -296,4 +296,22 @@ public class WebViewTest {
 
     assertFalse(destroyCalled[0]);
   }
+
+  @Test
+  public void destroyWebViewWhenDisposedFromJavaObjectHostApi() {
+    final boolean[] destroyCalled = {false};
+    final WebViewPlatformView webView =
+        new WebViewPlatformView(mockContext, null, null) {
+          @Override
+          public void destroy() {
+            destroyCalled[0] = true;
+          }
+        };
+
+    testInstanceManager.addDartCreatedInstance(webView, 0);
+    final JavaObjectHostApiImpl javaObjectHostApi = new JavaObjectHostApiImpl(testInstanceManager);
+    javaObjectHostApi.dispose(0L);
+
+    assertTrue(destroyCalled[0]);
+  }
 }

--- a/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/test/java/io/flutter/plugins/webviewflutter/WebViewTest.java
@@ -281,4 +281,19 @@ public class WebViewTest {
     // This shouldn't throw an Exception.
     Objects.requireNonNull(webView.getWebChromeClient()).onProgressChanged(webView, 0);
   }
+
+  @Test
+  public void disposeDoesNotCallDestroy() {
+    final boolean[] destroyCalled = {false};
+    final WebViewPlatformView webView =
+        new WebViewPlatformView(mockContext, null, null) {
+          @Override
+          public void destroy() {
+            destroyCalled[0] = true;
+          }
+        };
+    webView.dispose();
+
+    assertFalse(destroyCalled[0]);
+  }
 }

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -1018,6 +1018,51 @@ Future<void> main() async {
       expect(elementText, 'null');
     },
   );
+
+  testWidgets(
+    '`AndroidWebViewController` can be reused with a new `AndroidWebViewWidget`',
+    (WidgetTester tester) async {
+      Completer<void> pageLoaded = Completer<void>();
+
+      final PlatformWebViewController controller = PlatformWebViewController(
+        const PlatformWebViewControllerCreationParams(),
+      )
+        ..setPlatformNavigationDelegate(PlatformNavigationDelegate(
+          const PlatformNavigationDelegateCreationParams(),
+        )..setOnPageFinished((_) => pageLoaded.complete()))
+        ..loadRequest(LoadRequestParams(uri: Uri.parse(primaryUrl)));
+
+      await tester.pumpWidget(Builder(
+        builder: (BuildContext context) {
+          return PlatformWebViewWidget(
+            PlatformWebViewWidgetCreationParams(controller: controller),
+          ).build(context);
+        },
+      ));
+
+      await pageLoaded.future;
+      pageLoaded = Completer<void>();
+
+      await tester.pumpWidget(Container());
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(Builder(
+        builder: (BuildContext context) {
+          return PlatformWebViewWidget(
+            PlatformWebViewWidgetCreationParams(controller: controller),
+          ).build(context);
+        },
+      ));
+
+      await controller.loadRequest(
+        LoadRequestParams(uri: Uri.parse(primaryUrl)),
+      );
+      await expectLater(
+        pageLoaded.future,
+        completes,
+      );
+    },
+  );
 }
 
 /// Returns the value used for the HTTP User-Agent: request header in subsequent HTTP requests.

--- a/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_android/example/integration_test/webview_flutter_test.dart
@@ -1041,7 +1041,6 @@ Future<void> main() async {
       ));
 
       await pageLoaded.future;
-      pageLoaded = Completer<void>();
 
       await tester.pumpWidget(Container());
       await tester.pumpAndSettle();
@@ -1054,6 +1053,7 @@ Future<void> main() async {
         },
       ));
 
+      pageLoaded = Completer<void>();
       await controller.loadRequest(
         LoadRequestParams(uri: Uri.parse(primaryUrl)),
       );

--- a/packages/webview_flutter/webview_flutter_android/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_android
 description: A Flutter plugin that provides a WebView widget on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 3.1.1
+version: 3.1.2
 
 environment:
   sdk: ">=2.17.0 <3.0.0"


### PR DESCRIPTION
Bug is fixed by not calling `destroy()` when the widget is disposed.

This shouldn't cause a regression since we were calling it incorrectly in 4.0 and pre 4.0 anyways. We could consider offering a `AndroidWebViewController.destoryWebView()` if the community shows interest in using this method.

Fixes the issue https://github.com/flutter/flutter/issues/117887 for WebView

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
