### PR TITLE
[webview_flutter_platform_interface] Improves error message when `WebViewPlatform.instance` is null

### DIFF
--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+* Improves error message when a platform interface class is used before `WebViewPlatform.instance` has been set.
+
 ## 2.0.0
 
 * **Breaking Change**: Releases new interface. See [documentation](https://pub.dev/documentation/webview_flutter_platform_interface/2.0.0/) and [design doc](https://flutter.dev/go/webview_flutter_4_interface)

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -31,6 +31,13 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
   /// Creates a new [PlatformNavigationDelegate]
   factory PlatformNavigationDelegate(
       PlatformNavigationDelegateCreationParams params) {
+    assert(
+      WebViewPlatform.instance != null,
+      'A platform implementation for `webview_flutter` has not been set. Please '
+      'ensure that an implementation of `WebViewPlatform` has been set to '
+      '`WebViewPlatform.instance` before use. For unit testing, '
+      '`WebViewPlatform.instance` can be set with your own test implementation.'
+    );
     final PlatformNavigationDelegate callbackDelegate =
         WebViewPlatform.instance!.createPlatformNavigationDelegate(params);
     PlatformInterface.verify(callbackDelegate, _token);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_navigation_delegate.dart
@@ -36,7 +36,7 @@ abstract class PlatformNavigationDelegate extends PlatformInterface {
       'A platform implementation for `webview_flutter` has not been set. Please '
       'ensure that an implementation of `WebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
-      '`WebViewPlatform.instance` can be set with your own test implementation.'
+      '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
     final PlatformNavigationDelegate callbackDelegate =
         WebViewPlatform.instance!.createPlatformNavigationDelegate(params);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
@@ -21,6 +21,13 @@ abstract class PlatformWebViewController extends PlatformInterface {
   /// Creates a new [PlatformWebViewController]
   factory PlatformWebViewController(
       PlatformWebViewControllerCreationParams params) {
+    assert(
+      WebViewPlatform.instance != null,
+      'A platform implementation for `webview_flutter` has not been set. Please '
+      'ensure that an implementation of `WebViewPlatform` has been set to '
+      '`WebViewPlatform.instance` before use. For unit testing, '
+      '`WebViewPlatform.instance` can be set with your own test implementation.'
+    );
     final PlatformWebViewController webViewControllerDelegate =
         WebViewPlatform.instance!.createPlatformWebViewController(params);
     PlatformInterface.verify(webViewControllerDelegate, _token);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_controller.dart
@@ -26,7 +26,7 @@ abstract class PlatformWebViewController extends PlatformInterface {
       'A platform implementation for `webview_flutter` has not been set. Please '
       'ensure that an implementation of `WebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
-      '`WebViewPlatform.instance` can be set with your own test implementation.'
+      '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
     final PlatformWebViewController webViewControllerDelegate =
         WebViewPlatform.instance!.createPlatformWebViewController(params);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_cookie_manager.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_cookie_manager.dart
@@ -19,6 +19,13 @@ abstract class PlatformWebViewCookieManager extends PlatformInterface {
   /// Creates a new [PlatformWebViewCookieManager]
   factory PlatformWebViewCookieManager(
       PlatformWebViewCookieManagerCreationParams params) {
+    assert(
+      WebViewPlatform.instance != null,
+      'A platform implementation for `webview_flutter` has not been set. Please '
+      'ensure that an implementation of `WebViewPlatform` has been set to '
+      '`WebViewPlatform.instance` before use. For unit testing, '
+      '`WebViewPlatform.instance` can be set with your own test implementation.'
+    );
     final PlatformWebViewCookieManager cookieManagerDelegate =
         WebViewPlatform.instance!.createPlatformCookieManager(params);
     PlatformInterface.verify(cookieManagerDelegate, _token);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_cookie_manager.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_cookie_manager.dart
@@ -24,7 +24,7 @@ abstract class PlatformWebViewCookieManager extends PlatformInterface {
       'A platform implementation for `webview_flutter` has not been set. Please '
       'ensure that an implementation of `WebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
-      '`WebViewPlatform.instance` can be set with your own test implementation.'
+      '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
     final PlatformWebViewCookieManager cookieManagerDelegate =
         WebViewPlatform.instance!.createPlatformCookieManager(params);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_widget.dart
@@ -16,7 +16,7 @@ abstract class PlatformWebViewWidget extends PlatformInterface {
       'A platform implementation for `webview_flutter` has not been set. Please '
       'ensure that an implementation of `WebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
-      '`WebViewPlatform.instance` can be set with your own test implementation.'
+      '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
     final PlatformWebViewWidget webViewWidgetDelegate =
         WebViewPlatform.instance!.createPlatformWebViewWidget(params);

--- a/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_widget.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/lib/src/platform_webview_widget.dart
@@ -11,6 +11,13 @@ import 'webview_platform.dart';
 abstract class PlatformWebViewWidget extends PlatformInterface {
   /// Creates a new [PlatformWebViewWidget]
   factory PlatformWebViewWidget(PlatformWebViewWidgetCreationParams params) {
+    assert(
+      WebViewPlatform.instance != null,
+      'A platform implementation for `webview_flutter` has not been set. Please '
+      'ensure that an implementation of `WebViewPlatform` has been set to '
+      '`WebViewPlatform.instance` before use. For unit testing, '
+      '`WebViewPlatform.instance` can be set with your own test implementation.'
+    );
     final PlatformWebViewWidget webViewWidgetDelegate =
         WebViewPlatform.instance!.createPlatformWebViewWidget(params);
     PlatformInterface.verify(webViewWidgetDelegate, _token);

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutte
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview_flutter%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_platform_interface/test/webview_platform_test.dart
+++ b/packages/webview_flutter/webview_flutter_platform_interface/test/webview_platform_test.dart
@@ -18,6 +18,69 @@ void main() {
     expect(WebViewPlatform.instance, isNull);
   });
 
+  // This test can only run while `WebViewPlatform.instance` is still null.
+  test(
+      'Interface classes throw assertion error when `WebViewPlatform.instance` is null',
+      () {
+    expect(
+      () => PlatformNavigationDelegate(
+        const PlatformNavigationDelegateCreationParams(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        'A platform implementation for `webview_flutter` has not been set. Please '
+            'ensure that an implementation of `WebViewPlatform` has been set to '
+            '`WebViewPlatform.instance` before use. For unit testing, '
+            '`WebViewPlatform.instance` can be set with your own test implementation.',
+      )),
+    );
+
+    expect(
+      () => PlatformWebViewController(
+        const PlatformWebViewControllerCreationParams(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        'A platform implementation for `webview_flutter` has not been set. Please '
+            'ensure that an implementation of `WebViewPlatform` has been set to '
+            '`WebViewPlatform.instance` before use. For unit testing, '
+            '`WebViewPlatform.instance` can be set with your own test implementation.',
+      )),
+    );
+
+    expect(
+      () => PlatformWebViewCookieManager(
+        const PlatformWebViewCookieManagerCreationParams(),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        'A platform implementation for `webview_flutter` has not been set. Please '
+            'ensure that an implementation of `WebViewPlatform` has been set to '
+            '`WebViewPlatform.instance` before use. For unit testing, '
+            '`WebViewPlatform.instance` can be set with your own test implementation.',
+      )),
+    );
+
+    expect(
+      () => PlatformWebViewWidget(
+        PlatformWebViewWidgetCreationParams(
+          controller: MockWebViewControllerDelegate(),
+        ),
+      ),
+      throwsA(isA<AssertionError>().having(
+        (AssertionError error) => error.message,
+        'message',
+        'A platform implementation for `webview_flutter` has not been set. Please '
+            'ensure that an implementation of `WebViewPlatform` has been set to '
+            '`WebViewPlatform.instance` before use. For unit testing, '
+            '`WebViewPlatform.instance` can be set with your own test implementation.',
+      )),
+    );
+  });
+
   test('Cannot be implemented with `implements`', () {
     expect(() {
       WebViewPlatform.instance = ImplementsWebViewPlatform();


### PR DESCRIPTION
In light of https://github.com/flutter/flutter/issues/117422, the error message when using `webview_flutter` with unit tests is not very helpful. This creates a more actionable error message.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
