### PR TITLE
[tool] Replace `flutter format`

### DIFF
--- a/script/tool/CHANGELOG.md
+++ b/script/tool/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.2+1
+
+* Replaces deprecated `flutter format` with `dart format` in `format`
+  implementation.
+
 ## 0.13.2
 
 * Falls back to other executables in PATH when `clang-format` does not run.

--- a/script/tool/lib/src/format_command.dart
+++ b/script/tool/lib/src/format_command.dart
@@ -191,10 +191,8 @@ class FormatCommand extends PackageCommand {
         _getPathsWithExtensions(files, <String>{'.dart'});
     if (dartFiles.isNotEmpty) {
       print('Formatting .dart files...');
-      // `flutter format` doesn't require the project to actually be a Flutter
-      // project.
-      final int exitCode = await _runBatched(flutterCommand, <String>['format'],
-          files: dartFiles);
+      final int exitCode =
+          await _runBatched('dart', <String>['format'], files: dartFiles);
       if (exitCode != 0) {
         printError('Failed to format Dart files: exit code $exitCode.');
         throw ToolExit(_exitFlutterFormatFailed);

--- a/script/tool/pubspec.yaml
+++ b/script/tool/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_plugin_tools
 description: Productivity utils for flutter/plugins and flutter/packages
 repository: https://github.com/flutter/plugins/tree/main/script/tool
-version: 0.13.2
+version: 0.13.2+1
 
 dependencies:
   args: ^2.1.0

--- a/script/tool/test/format_command_test.dart
+++ b/script/tool/test/format_command_test.dart
@@ -98,7 +98,7 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(
-              getFlutterCommand(mockPlatform),
+              'dart',
               <String>['format', ...getPackagesDirRelativePaths(plugin, files)],
               packagesDir.path),
         ]));
@@ -132,7 +132,7 @@ void main() {
         processRunner.recordedCalls,
         orderedEquals(<ProcessCall>[
           ProcessCall(
-              getFlutterCommand(mockPlatform),
+              'dart',
               <String>[
                 'format',
                 ...getPackagesDirRelativePaths(plugin, formattedFiles)
@@ -141,7 +141,7 @@ void main() {
         ]));
   });
 
-  test('fails if flutter format fails', () async {
+  test('fails if dart format fails', () async {
     const List<String> files = <String>[
       'lib/a.dart',
       'lib/src/b.dart',
@@ -149,8 +149,9 @@ void main() {
     ];
     createFakePlugin('a_plugin', packagesDir, extraFiles: files);
 
-    processRunner.mockProcessesForExecutable[getFlutterCommand(mockPlatform)] =
-        <io.Process>[MockProcess(exitCode: 1)];
+    processRunner.mockProcessesForExecutable['dart'] = <io.Process>[
+      MockProcess(exitCode: 1)
+    ];
     Error? commandError;
     final List<String> output = await runCapturingPrint(
         runner, <String>['format'], errorHandler: (Error e) {
@@ -465,7 +466,7 @@ void main() {
               ],
               packagesDir.path),
           ProcessCall(
-              getFlutterCommand(mockPlatform),
+              'dart',
               <String>[
                 'format',
                 ...getPackagesDirRelativePaths(plugin, dartFiles)
@@ -594,7 +595,7 @@ void main() {
         processRunner.recordedCalls,
         contains(
           ProcessCall(
-              getFlutterCommand(mockPlatform),
+              'dart',
               <String>[
                 'format',
                 '$pluginName\\$extraFile',
@@ -651,7 +652,7 @@ void main() {
         processRunner.recordedCalls,
         contains(
           ProcessCall(
-              getFlutterCommand(mockPlatform),
+              'dart',
               <String>[
                 'format',
                 '$pluginName/$extraFile',


### PR DESCRIPTION
`flutter format` is deprecated on `master`, and prints a warning saying to switch to `dart format` instead. This updates `format` to make that switch. `flutter format` is essentially just a passthrough, so no usage changes are needed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
