### PR TITLE
[tool] Fix false positives in update-exceprts

### DIFF
--- a/script/tool/lib/src/update_excerpts_command.dart
+++ b/script/tool/lib/src/update_excerpts_command.dart
@@ -206,20 +206,28 @@ class UpdateExcerptsCommand extends PackageLoopingCommand {
         .renameSync(package.pubspecFile.path);
   }
 
-  /// Checks the git state, returning an error string unless nothing has
+  /// Checks the git state, returning an error string if any .md files have
   /// changed.
   Future<String?> _validateRepositoryState() async {
-    final io.ProcessResult modifiedFiles = await processRunner.run(
+    final io.ProcessResult checkFiles = await processRunner.run(
       'git',
       <String>['ls-files', '--modified'],
       workingDir: packagesDir,
       logOnError: true,
     );
-    if (modifiedFiles.exitCode != 0) {
+    if (checkFiles.exitCode != 0) {
       return 'Unable to determine local file state';
     }
 
-    final String stdout = modifiedFiles.stdout as String;
-    return stdout.trim().isEmpty ? null : 'Snippets are out of sync';
+    final String stdout = checkFiles.stdout as String;
+    final List<String> changedFiles = stdout.trim().split('\n');
+    final Iterable<String> changedMDFiles =
+        changedFiles.where((String filePath) => filePath.endsWith('.md'));
+    if (changedMDFiles.isNotEmpty) {
+      return 'Snippets are out of sync in the following files: '
+          '${changedMDFiles.join(', ')}';
+    }
+
+    return null;
   }
 }

--- a/script/tool/test/update_excerpts_command_test.dart
+++ b/script/tool/test/update_excerpts_command_test.dart
@@ -232,11 +232,11 @@ void main() {
         ]));
   });
 
-  test('fails if files are changed with --fail-on-change', () async {
+  test('fails if READMEs are changed with --fail-on-change', () async {
     createFakePlugin('a_plugin', packagesDir,
         extraFiles: <String>[kReadmeExcerptConfigPath]);
 
-    const String changedFilePath = 'packages/a_plugin/linux/foo_plugin.cc';
+    const String changedFilePath = 'packages/a_plugin/README.md';
     processRunner.mockProcessesForExecutable['git'] = <io.Process>[
       MockProcess(stdout: changedFilePath),
     ];
@@ -253,6 +253,27 @@ void main() {
         output,
         containsAllInOrder(<Matcher>[
           contains('README.md is out of sync with its source excerpts'),
+          contains('Snippets are out of sync in the following files: '
+              'packages/a_plugin/README.md'),
+        ]));
+  });
+
+  test('passes if unrelated files are changed with --fail-on-change', () async {
+    createFakePlugin('a_plugin', packagesDir,
+        extraFiles: <String>[kReadmeExcerptConfigPath]);
+
+    const String changedFilePath = 'packages/a_plugin/linux/CMakeLists.txt';
+    processRunner.mockProcessesForExecutable['git'] = <io.Process>[
+      MockProcess(stdout: changedFilePath),
+    ];
+
+    final List<String> output = await runCapturingPrint(
+        runner, <String>['update-excerpts', '--fail-on-change']);
+
+    expect(
+        output,
+        containsAllInOrder(<Matcher>[
+          contains('Ran for 1 package(s)'),
         ]));
   });
 


### PR DESCRIPTION
When determining whether or not to fail with `--fail-on-change`, only look at .md files. In some cases, running the necessary commands (e.g., `flutter pub get`) may change unrelated files, causing fales positive failures. Only changed documentation files should be flagged.

Also log the specific files that were detected as changed, to aid in debugging any future false positives.

Fixes https://github.com/flutter/flutter/issues/111592
Fixes https://github.com/flutter/flutter/issues/111590

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
