### PR TITLE
[image_picker] 'NSInvalidArgumentException', reason: '-[__NSConcreteUUID floatValue]: unrecognized selector sent to instance 0x2804ef400'

### DIFF
--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   image_picker_android: ^0.8.4+11
   image_picker_for_web: ^2.1.0
-  image_picker_ios: ^0.8.6+1
+  image_picker_ios: ^0.8.6+6
   image_picker_platform_interface: ^2.6.1
 
 dev_dependencies:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   image_picker_android: ^0.8.4+11
   image_picker_for_web: ^2.1.0
-  image_picker_ios: ^0.8.6+6
+  image_picker_ios: ^0.8.6+5
   image_picker_platform_interface: ^2.6.1
 
 dev_dependencies:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   image_picker_android: ^0.8.4+11
   image_picker_for_web: ^2.1.0
-  image_picker_ios: ^0.8.6+5
+  image_picker_ios: ./image_picker_ios
   image_picker_platform_interface: ^2.6.1
 
 dev_dependencies:

--- a/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
+++ b/packages/image_picker/image_picker_ios/ios/Classes/FLTPHPickerSaveImageToPathOperation.m
@@ -13,9 +13,9 @@ API_AVAILABLE(ios(14))
 @interface FLTPHPickerSaveImageToPathOperation ()
 
 @property(strong, nonatomic) PHPickerResult *result;
-@property(strong, nonatomic) NSNumber *maxHeight;
-@property(strong, nonatomic) NSNumber *maxWidth;
-@property(strong, nonatomic) NSNumber *desiredImageQuality;
+@property(assign, nonatomic) NSNumber *maxHeight;
+@property(assign, nonatomic) NSNumber *maxWidth;
+@property(assign, nonatomic) NSNumber *desiredImageQuality;
 @property(assign, nonatomic) BOOL requestFullMetadata;
 
 @end
@@ -175,7 +175,7 @@ API_AVAILABLE(ios(14))
     NSString *savedPath =
         [FLTImagePickerPhotoAssetUtil saveImageWithPickerInfo:nil
                                                         image:localImage
-                                                 imageQuality:self.desiredImageQuality];
+                                                 imageQuality: @0.5];
     [self completeOperationWithPath:savedPath error:nil];
   }
 }

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_ios
 description: iOS implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.6+5
+version: 0.8.6+6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
<!-- Thank you for using Flutter!

     If you are looking for support, please check out our documentation
     or consider asking a question on Stack Overflow:
      * https://flutter.dev/
      * https://api.flutter.dev/
      * https://stackoverflow.com/questions/tagged/flutter?sort=frequent

     If you have found a bug or if our documentation doesn't have an answer
     to what you're looking for, then fill out the template below. Please read
     our guide to filing a bug first: https://flutter.dev/docs/resources/bug-reports
-->

## Use case

Using pick library to pick images and got crash with error

## Proposal

for me error was with wrong selector(variable access) `imageQuality`, when I've hardcode it it's start working
<img width="693" alt="image" src="https://user-images.githubusercontent.com/8526612/212744588-4cee03fd-8aba-43f1-8ef9-a68fed50d89d.png">

Error stack trace below:
```
[+3617 ms] -[__NSConcreteUUID floatValue]: unrecognized selector sent to instance 0x2804ef400
[   +2 ms] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[__NSConcreteUUID floatValue]: unrecognized selector sent to instance 0x2804ef400'
[        ] *** First throw call stack:
[        ] (0x181953c80 0x199177ee4 0x181a24708 0x1818ed56c 0x1818ec77c 0x10eab56fc 0x10eab5c0c 0x10eab5adc 0x10eab93a0 0x10eab90f4 0x1969b336c 0x1969b3ddc 0x183155a14 0x181613094 0x181614094 0x1815ba73c 0x1815bb1f4 0x1815c4ec8 0x1dcd60e10 0x1dcd6093c)
[ +257 ms] Process 2234 stopped
[        ] * thread #47, queue = 'com.apple.Foundation.NSItemProvider-callback-queue', stop reason = signal SIGABRT
[        ]     frame #0: 0x00000001bc204bbc libsystem_kernel.dylib`__pthread_kill + 8
[        ] libsystem_kernel.dylib`:
[        ] ->  0x1bc204bbc <+8>:  b.lo   0x1bc204bd8               ; <+36>
[        ]     0x1bc204bc0 <+12>: stp    x29, x30, [sp, #-0x10]!
[        ]     0x1bc204bc4 <+16>: mov    x29, sp
[        ]     0x1bc204bc8 <+20>: bl     0x1bc20060c               ; cerror_nocancel
[        ] Target 0: (Runner) stopped.
[        ] thread backtrace all
[        ] process detach
[+10205 ms]   thread #1, queue = 'com.apple.main-thread'
[        ]     frame #0: 0x0000000199165d10 libobjc.A.dylib`objc_release
[        ]     frame #1: 0x0000000183d8c060 UIKitCore`-[UIGestureEnvironment _cancelGestureRecognizers:] + 2936
[        ]     frame #2: 0x00000001840787a0 UIKitCore`-[UIApplication _cancelGestureRecognizersForView:] + 64
[        ]     frame #3: 0x000000018408c7c8 UIKitCore`-[UIView(Hierarchy) _willMoveToWindow:] + 128
[        ]     frame #4: 0x0000000183d6cfe0 UIKitCore`__UIViewWillBeRemovedFromSuperview + 740
[        ]     frame #5: 0x0000000183d9a3cc UIKitCore`-[UIView(Hierarchy) removeFromSuperview] + 92
[        ]     frame #6: 0x0000000183f37668 UIKitCore`-[UIDropShadowView setContentView:] + 184
[        ]     frame #7: 0x00000001840fa458 UIKitCore`-[UISheetPresentationController dismissalTransitionDidEnd:] + 144
[        ]     frame #8: 0x000000018448d2f4 UIKitCore`__80-[UIPresentationController _initViewHierarchyForPresentationSuperview:inWindow:]_block_invoke_2.615 + 320
[        ]     frame #9: 0x0000000183f80848 UIKitCore`-[UIPresentationController transitionDidFinish:] + 144
[        ]     frame #10: 0x000000018448c99c UIKitCore`__56-[UIPresentationController runTransitionForCurrentState]_block_invoke.437 + 208
[        ]     frame #11: 0x0000000183e26d8c UIKitCore`-[_UIViewControllerTransitionContext completeTransition:] + 112
[        ]     frame #12: 0x00000001840250ec UIKitCore`-[UITransitionView notifyDidCompleteTransition:] + 240
[        ]     frame #13: 0x0000000183e8c518 UIKitCore`-[UITransitionView _didCompleteTransition:] + 1120
[        ]     frame #14: 0x0000000184db0428 UIKitCore`__UIVIEW_IS_EXECUTING_ANIMATION_COMPLETION_BLOCK__ + 28
[        ]     frame #15: 0x0000000183ea64e4 UIKitCore`-[UIViewAnimationBlockDelegate _didEndBlockAnimation:finished:context:] + 696
[        ]     frame #16: 0x0000000183d7acf0 UIKitCore`-[UIViewAnimationState sendDelegateAnimationDidStop:finished:] + 244
[        ]     frame #17: 0x0000000183d8e6b8 UIKitCore`-[UIViewAnimationState animationDidStop:finished:] + 240
[        ]     frame #18: 0x0000000183d8e80c UIKitCore`-[UIViewAnimationState animationDidStop:finished:] + 580
[        ]     frame #19: 0x000000018547c730 QuartzCore`CA::Layer::run_animation_callbacks(void*) + 276
[        ]     frame #20: 0x0000000181614094 libdispatch.dylib`_dispatch_client_callout + 16
[        ]     frame #21: 0x00000001815c0d44 libdispatch.dylib`_dispatch_main_queue_drain + 928
[        ]     frame #22: 0x00000001815c0994 libdispatch.dylib`_dispatch_main_queue_callback_4CF$VARIANT$mp + 36
[        ]     frame #23: 0x000000018190f034 CoreFoundation`__CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__ + 12
[        ]     frame #24: 0x00000001818cc538 CoreFoundation`__CFRunLoopRun + 2544
[        ]     frame #25: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #26: 0x00000001a23ee988 GraphicsServices`GSEventRunModal + 160
[        ]     frame #27: 0x00000001840e1a88 UIKitCore`-[UIApplication _run] + 1080
[        ]     frame #28: 0x0000000183e7afc8 UIKitCore`UIApplicationMain + 336
[        ]     frame #29: 0x0000000102ec244c Runner`main at AppDelegate.swift:8:13
[        ]     frame #30: 0x00000001045884d0 dyld`start + 444
[        ]   thread #3
[        ]     frame #0: 0x00000001bc1ff014 libsystem_kernel.dylib`__workq_kernreturn + 8
[        ]   thread #5, name = 'com.apple.uikit.eventfetch-thread'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x0000000182feceac Foundation`-[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 232
[        ]     frame #6: 0x000000018302bfd0 Foundation`-[NSRunLoop(NSRunLoop) runUntilDate:] + 88
[        ]     frame #7: 0x0000000184060ef4 UIKitCore`-[UIEventFetcher threadMain] + 512
[        ]     frame #8: 0x0000000183039bdc Foundation`__NSThread__start__ + 792
[        ]     frame #9: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #13, name = 'io.worker.1'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68bd4 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1240
[        ]     frame #2: 0x000000019920f8f0 libc++.1.dylib`std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 24
[        ]     frame #3: 0x000000011eacf0c0 Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 304
[        ]     frame #4: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #14, name = 'io.worker.2'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68bd4 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1240
[        ]     frame #2: 0x000000019920f8f0 libc++.1.dylib`std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 24
[        ]     frame #3: 0x000000011eacf0c0 Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::ConcurrentMessageLoop::ConcurrentMessageLoop(unsigned long)::$_0> >(void*) + 304
[        ]     frame #4: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #15, name = 'dart:io EventHandler'
[        ]     frame #0: 0x00000001bc200294 libsystem_kernel.dylib`kevent + 8
[        ]     frame #1: 0x000000011ecb88f4 Flutter`dart::bin::EventHandlerImplementation::EventHandlerEntry(unsigned long) + 448
[        ]     frame #2: 0x000000011ecea0d0 Flutter`dart::bin::ThreadStart(void*) + 44
[        ]     frame #3: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #16, name = 'Dart Profiler ThreadInterrupter'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef44b88 Flutter`dart::ThreadInterrupter::ThreadMain(unsigned long) + 432
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #17, name = 'Dart Profiler SampleBlockProcessor'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011eea32bc Flutter`dart::SampleBlockProcessor::ThreadMain(unsigned long) + 264
[        ]     frame #3: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #4: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #21, name = 'io.flutter.2.ui'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x000000011ead53ac Flutter`fml::MessageLoopDarwin::Run() + 88
[        ]     frame #6: 0x000000011ead442c Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
[        ]     frame #7: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #22, name = 'io.flutter.2.raster'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x000000011ead53ac Flutter`fml::MessageLoopDarwin::Run() + 88
[        ]     frame #6: 0x000000011ead442c Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
[        ]     frame #7: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #23, name = 'io.flutter.2.io'
[        ]     frame #0: 0x000000011e872368 Flutter`void downsample_3_3<ColorTypeFilter_8888>(void*, void const*, unsigned long, int) + 80
[        ]     frame #1: 0x000000011e87203c Flutter`SkMipmap::Build(SkPixmap const&, SkDiscardableMemory* (*)(unsigned long), bool) + 1980
[        ]     frame #2: 0x000000011e9d27b0 Flutter`make_bmp_proxy(GrProxyProvider*, SkBitmap const&, GrColorType, GrMipmapped, SkBackingFit, SkBudgeted) + 1352
[        ]     frame #3: 0x000000011e9d29d4 Flutter`GrMakeUncachedBitmapProxyView(GrRecordingContext*, SkBitmap const&, GrMipmapped, SkBackingFit, SkBudgeted) + 180
[        ]     frame #4: 0x000000011e9d5c1c Flutter`SkImage::MakeCrossContextFromPixmap(GrDirectContext*, SkPixmap const&, bool, bool) + 416
[        ]     frame #5: 0x000000011ec98684 Flutter`std::__1::__function::__func<flutter::UploadRasterImage(sk_sp<SkImage>, fml::WeakPtr<flutter::IOManager>, fml::tracing::TraceFlow const&)::$_3, std::__1::allocator<flutter::UploadRasterImage(sk_sp<SkImage>, fml::WeakPtr<flutter::IOManager>, fml::tracing::TraceFlow const&)::$_3>, void ()>::operator()() + 120
[        ]     frame #6: 0x000000011ead30a4 Flutter`fml::SyncSwitch::Execute(fml::SyncSwitch::Handlers const&) const + 72
[        ]     frame #7: 0x000000011ec97fa4 Flutter`std::__1::__function::__func<fml::internal::CopyableLambda<flutter::ImageDecoderSkia::Decode(fml::RefPtr<flutter::ImageDescriptor>, unsigned int, unsigned int, std::__1::function<void (sk_sp<flutter::DlImage>)> const&)::$_1::operator()()::'lambda'()>, std::__1::allocator<fml::internal::CopyableLambda<flutter::ImageDecoderSkia::Decode(fml::RefPtr<flutter::ImageDescriptor>, unsigned int, unsigned int, std::__1::function<void (sk_sp<flutter::DlImage>)> const&)::$_1::operator()()::'lambda'()> >, void ()>::operator()() + 720
[        ]     frame #8: 0x000000011ead19f0 Flutter`fml::MessageLoopImpl::FlushTasks(fml::FlushType) + 1636
[        ]     frame #9: 0x000000011ead54dc Flutter`fml::MessageLoopDarwin::OnTimerFire(__CFRunLoopTimer*, fml::MessageLoopDarwin*) + 32
[        ]     frame #10: 0x00000001819681d4 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 28
[        ]     frame #11: 0x00000001818f1a58 CoreFoundation`__CFRunLoopDoTimer + 1008
[        ]     frame #12: 0x00000001818ec608 CoreFoundation`__CFRunLoopDoTimers + 316
[        ]     frame #13: 0x00000001818cc2f4 CoreFoundation`__CFRunLoopRun + 1964
[        ]     frame #14: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #15: 0x000000011ead53ac Flutter`fml::MessageLoopDarwin::Run() + 88
[        ]     frame #16: 0x000000011ead442c Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
[        ]     frame #17: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #24, name = 'io.flutter.2.profiler'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x000000011ead53ac Flutter`fml::MessageLoopDarwin::Run() + 88
[        ]     frame #6: 0x000000011ead442c Flutter`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, fml::Thread::Thread(std::__1::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0> >(void*) + 208
[        ]     frame #7: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #26
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68bd4 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1240
[        ]     frame #2: 0x000000019920f988 libc++.1.dylib`std::__1::condition_variable::__do_timed_wait(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::system_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >) + 96
[        ]     frame #3: 0x000000010a5850ec AgoraRtcWrapper`std::__1::cv_status std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) [inlined] std::__1::cv_status std::__1::condition_variable::wait_for<long long, std::__1::ratio<1l, 1000000000l> >(this=0x0000000282a148d0, __lk=0x000000016e072f58, __d=<unavailable>) at __mutex_base:0 [opt]
[        ]     frame #4: 0x000000010a58508c AgoraRtcWrapper`std::__1::cv_status std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >(std::__1::unique_lock<std::__1::mutex>&, std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > > const&) [inlined] void std::__1::condition_variable::__do_timed_wait<std::__1::chrono::steady_clock>(this=0x0000000282a148d0, __lk=0x000000016e072f58, __tp=<unavailable>) at __mutex_base:523:5 [opt]
[        ]     frame #5: 0x000000010a58508c AgoraRtcWrapper`std::__1::cv_status std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >(this=0x0000000282a148d0, __lk=0x000000016e072f58, __t=0x000000016e072f68) at __mutex_base:426:5 [opt]
[        ]     frame #6: 0x000000010a584f68 AgoraRtcWrapper`spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const [inlined] bool std::__1::condition_variable::wait_until<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> >, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const::'lambda'()>(this=0x0000000282a148d0, __lk=0x000000016e072f58, __t=0x000000016e072f68, __pred=(unnamed class) @ x22)> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const::'lambda'()) at __mutex_base:438:13 [opt]
[        ]     frame #7: 0x000000010a584f50 AgoraRtcWrapper`spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const [inlined] bool std::__1::condition_variable::wait_for<long long, std::__1::ratio<1l, 1l>, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const::'lambda'()>(this=0x0000000282a148d0, __lk=0x000000016e072f58, __d=0x0000000281136170, __pred=(unnamed class) @ x22)> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const::'lambda'()) at __mutex_base:482:12 [opt]
[        ]     frame #8: 0x000000010a584f40 AgoraRtcWrapper`spdlog::details::periodic_worker::periodic_worker(this=0x0000000281136148)> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()::operator()() const at periodic_worker-inl.h:25:27 [opt]
[        ]     frame #9: 0x000000010a584e80 AgoraRtcWrapper`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()> >(void*) [inlined] decltype(__f=<unavailable>)> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()>(fp)()) std::__1::__invoke<spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()>(spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()&&) at type_traits:3747:1 [opt]
[        ]     frame #10: 0x000000010a584e7c AgoraRtcWrapper`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()> >(void*) [inlined] void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()>(__t=size=2, (null)=<unavailable>)> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()>&, std::__1::__tuple_indices<>) at thread:280:5 [opt]
[        ]     frame #11: 0x000000010a584e78 AgoraRtcWrapper`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, spdlog::details::periodic_worker::periodic_worker(std::__1::function<void ()> const&, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1l> >)::'lambda'()> >(__vp=0x0000000281136140) at thread:291:5 [opt]
[        ]     frame #12: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #30, name = 'com.apple.NSURLConnectionLoader'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x00000001822e4aa8 CFNetwork`___lldb_unnamed_symbol14214 + 428
[        ]     frame #6: 0x0000000183039bdc Foundation`__NSThread__start__ + 792
[        ]     frame #7: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #31, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011edcb7f4 Flutter`dart::MutatorThreadPool::OnEnterIdleLocked(dart::MonitorLocker*) + 384
[        ]     frame #4: 0x000000011ef45d2c Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 720
[        ]     frame #5: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #6: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #32, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #33, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #38, name = 'com.apple.CFSocket.private'
[        ]     frame #0: 0x00000001bc1ff6b0 libsystem_kernel.dylib`__select + 8
[        ]     frame #1: 0x00000001819648e8 CoreFoundation`__CFSocketManager + 628
[        ]     frame #2: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #39, name = 'com.apple.CoreMotion.MotionThread'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001818c7cc8 CoreFoundation`__CFRunLoopServiceMachPort + 368
[        ]     frame #3: 0x00000001818cbfd0 CoreFoundation`__CFRunLoopRun + 1160
[        ]     frame #4: 0x00000001818df194 CoreFoundation`CFRunLoopRunSpecific + 572
[        ]     frame #5: 0x000000018195a340 CoreFoundation`CFRunLoopRun + 60
[        ]     frame #6: 0x000000018e1a8ab0 CoreMotion`___lldb_unnamed_symbol1528 + 1340
[        ]     frame #7: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #40, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #41, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011edcb7f4 Flutter`dart::MutatorThreadPool::OnEnterIdleLocked(dart::MonitorLocker*) + 384
[        ]     frame #4: 0x000000011ef45d2c Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 720
[        ]     frame #5: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #6: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #42, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011edcb7f4 Flutter`dart::MutatorThreadPool::OnEnterIdleLocked(dart::MonitorLocker*) + 384
[        ]     frame #4: 0x000000011ef45d2c Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 720
[        ]     frame #5: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #6: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #43, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #44, queue = 'com.datadoghq.ios-sdk-logging-upload'
[        ]     frame #0: 0x00000001bc1feae8 libsystem_kernel.dylib`semaphore_wait_trap + 8
[        ]     frame #1: 0x00000001815b4960 libdispatch.dylib`_dispatch_sema4_wait$VARIANT$mp + 24
[        ]     frame #2: 0x00000001815b4fb0 libdispatch.dylib`_dispatch_semaphore_wait_slow + 148
[        ]     frame #3: 0x0000000199f178a4 libswiftDispatch.dylib`__C.OS_dispatch_semaphore.wait(wallTimeout: Dispatch.DispatchWallTime) -> Dispatch.DispatchTimeoutResult + 20
[        ]     frame #4: 0x000000010c6382cc Datadog`DataUploader.upload(data=<unavailable>, self=<unavailable>) at DataUploader.swift:46:23 [opt]
[        ]     frame #5: 0x000000010c6397cc Datadog`closure #1 in DataUploadWorker.init(queue:fileReader:dataUploader:uploadConditions:delay:featureName:) [inlined] protocol witness for Datadog.DataUploaderType.upload(data: Foundation.Data) -> Datadog.DataUploadStatus in conformance Datadog.DataUploader : Datadog.DataUploaderType in Datadog at <compiler-generated>:0 [opt]
[        ]     frame #6: 0x000000010c6397bc Datadog`closure #1 in DataUploadWorker.init(self=<unavailable>) at DataUploadWorker.swift:60:54 [opt]
[        ]     frame #7: 0x000000010c6f3a60 Datadog`thunk for @escaping @callee_guaranteed () -> () at <compiler-generated>:0 [opt]
[        ]     frame #8: 0x00000001815c1544 libdispatch.dylib`_dispatch_block_async_invoke2 + 104
[        ]     frame #9: 0x0000000181614094 libdispatch.dylib`_dispatch_client_callout + 16
[        ]     frame #10: 0x00000001815b6bb8 libdispatch.dylib`_dispatch_continuation_pop$VARIANT$mp + 440
[        ]     frame #11: 0x00000001815c88dc libdispatch.dylib`_dispatch_source_invoke$VARIANT$mp + 1668
[        ]     frame #12: 0x00000001815ba610 libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$mp + 344
[        ]     frame #13: 0x00000001815bb1f4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$mp + 408
[        ]     frame #14: 0x00000001815c4ec8 libdispatch.dylib`_dispatch_workloop_worker_thread + 632
[        ]     frame #15: 0x00000001dcd60e10 libsystem_pthread.dylib`_pthread_wqthread + 284
[        ]   thread #45, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #46, queue = 'APMDefaultIdentitySupport'
[        ]     frame #0: 0x00000001bc1feaac libsystem_kernel.dylib`mach_msg_trap + 8
[        ]     frame #1: 0x00000001bc1ff07c libsystem_kernel.dylib`mach_msg + 72
[        ]     frame #2: 0x00000001815caf7c libdispatch.dylib`_dispatch_mach_send_and_wait_for_reply + 524
[        ]     frame #3: 0x00000001815cb30c libdispatch.dylib`dispatch_mach_send_with_result_and_wait_for_reply$VARIANT$mp + 56
[        ]     frame #4: 0x00000001dcd8a9bc libxpc.dylib`xpc_connection_send_message_with_reply_sync + 236
[        ]     frame #5: 0x0000000183012164 Foundation`__NSXPCCONNECTION_IS_WAITING_FOR_A_SYNCHRONOUS_REPLY__ + 12
[        ]     frame #6: 0x0000000183017bb0 Foundation`-[NSXPCConnection _sendInvocation:orArguments:count:methodSignature:selector:withProxy:] + 2404
[        ]     frame #7: 0x00000001818ed258 CoreFoundation`___forwarding___ + 684
[        ]     frame #8: 0x00000001818ec77c CoreFoundation`_CF_forwarding_prep_0 + 92
[        ]     frame #9: 0x0000000181d8d970 CoreServices`-[LSApplicationWorkspace deviceIdentifierForAdvertising] + 156
[        ]     frame #10: 0x00000001c0809c14 AdSupport`-[ASIdentifierManager advertisingIdentifier] + 168
[        ]     frame #11: 0x0000000102fcd6a8 Runner`-[APMPlatformIdentitySupport resettableDeviceID] + 72
[        ]     frame #12: 0x0000000102f421d4 Runner`__47-[APMDefaultIdentitySupport resettableDeviceID]_block_invoke + 48
[        ]     frame #13: 0x00000001815c1544 libdispatch.dylib`_dispatch_block_async_invoke2 + 104
[        ]     frame #14: 0x0000000181614094 libdispatch.dylib`_dispatch_client_callout + 16
[        ]     frame #15: 0x00000001815ba73c libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$mp + 644
[        ]     frame #16: 0x00000001815bb1f4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$mp + 408
[        ]     frame #17: 0x00000001815c4ec8 libdispatch.dylib`_dispatch_workloop_worker_thread + 632
[        ]     frame #18: 0x00000001dcd60e10 libsystem_pthread.dylib`_pthread_wqthread + 284
[        ] * thread #47, queue = 'com.apple.Foundation.NSItemProvider-callback-queue', stop reason = signal SIGABRT
[        ]   * frame #0: 0x00000001bc204bbc libsystem_kernel.dylib`__pthread_kill + 8
[        ]     frame #1: 0x00000001dcd6c854 libsystem_pthread.dylib`pthread_kill + 208
[        ]     frame #2: 0x000000018c03f6ac libsystem_c.dylib`abort + 124
[        ]     frame #3: 0x00000001036ecec8 Runner`uncaught_exception_handler.cold.1 at PLCrashReporter.m:369:5 [opt]
[        ]     frame #4: 0x0000000102ef6d08 Runner`uncaught_exception_handler(exception=<unavailable>) at PLCrashReporter.m:366:5 [opt]
[        ]     frame #5: 0x00000001819ce458 CoreFoundation`__handleUncaughtException + 708
[        ]     frame #6: 0x000000019917d8ec libobjc.A.dylib`_objc_terminate() + 112
[        ]     frame #7: 0x000000019926f280 libc++abi.dylib`std::__terminate(void (*)()) + 16
[        ]     frame #8: 0x000000019926f228 libc++abi.dylib`std::terminate() + 60
[        ]     frame #9: 0x000000019918b46c libobjc.A.dylib`objc_terminate + 12
[        ]     frame #10: 0x00000001816140a8 libdispatch.dylib`_dispatch_client_callout + 36
[        ]     frame #11: 0x00000001815ba73c libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$mp + 644
[        ]     frame #12: 0x00000001815bb1f4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$mp + 408
[        ]     frame #13: 0x00000001815c4ec8 libdispatch.dylib`_dispatch_workloop_worker_thread + 632
[        ]     frame #14: 0x00000001dcd60e10 libsystem_pthread.dylib`_pthread_wqthread + 284
[        ]   thread #48, queue = 'com.datadoghq.ios-sdk-RUM-upload'
[        ]     frame #0: 0x00000001bc1feae8 libsystem_kernel.dylib`semaphore_wait_trap + 8
[        ]     frame #1: 0x00000001815b4960 libdispatch.dylib`_dispatch_sema4_wait$VARIANT$mp + 24
[        ]     frame #2: 0x00000001815b4fb0 libdispatch.dylib`_dispatch_semaphore_wait_slow + 148
[        ]     frame #3: 0x0000000199f178a4 libswiftDispatch.dylib`__C.OS_dispatch_semaphore.wait(wallTimeout: Dispatch.DispatchWallTime) -> Dispatch.DispatchTimeoutResult + 20
[        ]     frame #4: 0x000000010c6382cc Datadog`DataUploader.upload(data=<unavailable>, self=<unavailable>) at DataUploader.swift:46:23 [opt]
[        ]     frame #5: 0x000000010c6397cc Datadog`closure #1 in DataUploadWorker.init(queue:fileReader:dataUploader:uploadConditions:delay:featureName:) [inlined] protocol witness for Datadog.DataUploaderType.upload(data: Foundation.Data) -> Datadog.DataUploadStatus in conformance Datadog.DataUploader : Datadog.DataUploaderType in Datadog at <compiler-generated>:0 [opt]
[        ]     frame #6: 0x000000010c6397bc Datadog`closure #1 in DataUploadWorker.init(self=<unavailable>) at DataUploadWorker.swift:60:54 [opt]
[        ]     frame #7: 0x000000010c6f3a60 Datadog`thunk for @escaping @callee_guaranteed () -> () at <compiler-generated>:0 [opt]
[        ]     frame #8: 0x00000001815c1544 libdispatch.dylib`_dispatch_block_async_invoke2 + 104
[        ]     frame #9: 0x0000000181614094 libdispatch.dylib`_dispatch_client_callout + 16
[        ]     frame #10: 0x00000001815b6bb8 libdispatch.dylib`_dispatch_continuation_pop$VARIANT$mp + 440
[        ]     frame #11: 0x00000001815c88dc libdispatch.dylib`_dispatch_source_invoke$VARIANT$mp + 1668
[        ]     frame #12: 0x00000001815ba610 libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$mp + 344
[        ]     frame #13: 0x00000001815bb1f4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$mp + 408
[        ]     frame #14: 0x00000001815c4ec8 libdispatch.dylib`_dispatch_workloop_worker_thread + 632
[        ]     frame #15: 0x00000001dcd60e10 libsystem_pthread.dylib`_pthread_wqthread + 284
[        ]   thread #49, queue = 'com.google.fira.worker'
[        ]     frame #0: 0x00000001bc1ff134 libsystem_kernel.dylib`kevent_id + 8
[        ]     frame #1: 0x00000001815d24b4 libdispatch.dylib`_dispatch_kq_poll + 228
[        ]     frame #2: 0x00000001815d2ebc libdispatch.dylib`_dispatch_event_loop_wait_for_ownership$VARIANT$mp + 440
[        ]     frame #3: 0x00000001815c1bdc libdispatch.dylib`__DISPATCH_WAIT_FOR_QUEUE__ + 288
[        ]     frame #4: 0x00000001815c1820 libdispatch.dylib`_dispatch_sync_f_slow + 136
[        ]     frame #5: 0x0000000102f559ec Runner`-[APMIdentity hasLimitedAdTracking] + 112
[        ]     frame #6: 0x0000000102f6f270 Runner`APMUpdateConsentSignalsAndIdentifiers + 852
[        ]     frame #7: 0x0000000102f75178 Runner`-[APMMeasurement(Event) createRawEventMetadataWithUserAttributes:] + 1596
[        ]     frame #8: 0x0000000102f773a4 Runner`-[APMMeasurement(Event) writeEvent:isPublicEvent:isRealtime:] + 768
[        ]     frame #9: 0x0000000102f74af8 Runner`__57-[APMMeasurement(Event) writeFilteredEventOnWorkerQueue:]_block_invoke + 604
[        ]     frame #10: 0x0000000102fc6254 Runner`-[APMSqliteStore performTransactionWithError:block:] + 176
[        ]     frame #11: 0x0000000102f33dd8 Runner`-[APMDatabase performTransaction:] + 48
[        ]     frame #12: 0x0000000102f74870 Runner`-[APMMeasurement(Event) writeFilteredEventOnWorkerQueue:] + 264
[        ]     frame #13: 0x0000000102f744b8 Runner`-[APMMeasurement(Event) writeEventOnWorkerQueue:] + 1444
[        ]     frame #14: 0x0000000102f73da4 Runner`-[APMMeasurement(Event) handleEventOnWorkerQueue:] + 540
[        ]     frame #15: 0x0000000102f67f48 Runner`-[APMMeasurement logEventOnWorkerQueue:notifyEventListeners:] + 76
[        ]     frame #16: 0x0000000102f67ef8 Runner`-[APMMeasurement logEventOnWorkerQueueWithOrigin:isPublicEvent:name:parameters:timestamp:enabled:ignoreEnabled:ignoreInterceptor:interceptor:addedScreenParameters:] + 708
[        ]     frame #17: 0x0000000102f67bd4 Runner`__151-[APMMeasurement logEventWithOrigin:isPublicEvent:name:parameters:timestamp:enabled:ignoreEnabled:ignoreInterceptor:interceptor:addedScreenParameters:]_block_invoke + 68
[        ]     frame #18: 0x0000000102fbb984 Runner`__51-[APMScheduler scheduleOnWorkerQueueBlockID:block:]_block_invoke + 44
[        ]     frame #19: 0x0000000181613094 libdispatch.dylib`_dispatch_call_block_and_release + 24
[        ]     frame #20: 0x0000000181614094 libdispatch.dylib`_dispatch_client_callout + 16
[        ]     frame #21: 0x00000001815ba73c libdispatch.dylib`_dispatch_lane_serial_drain$VARIANT$mp + 644
[        ]     frame #22: 0x00000001815bb1f4 libdispatch.dylib`_dispatch_lane_invoke$VARIANT$mp + 408
[        ]     frame #23: 0x00000001815c4ec8 libdispatch.dylib`_dispatch_workloop_worker_thread + 632
[        ]     frame #24: 0x00000001dcd60e10 libsystem_pthread.dylib`_pthread_wqthread + 284
[        ]   thread #50
[        ]     frame #0: 0x00000001dcd60934 libsystem_pthread.dylib`start_wqthread
[        ]   thread #51, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #52, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #53, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #54, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #55, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #56, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #57, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #58, name = 'DartWorker'
[        ]     frame #0: 0x00000001bc1ff484 libsystem_kernel.dylib`__psynch_cvwait + 8
[        ]     frame #1: 0x00000001dcd68c00 libsystem_pthread.dylib`_pthread_cond_wait$VARIANT$mp + 1284
[        ]     frame #2: 0x000000011ee9e4dc Flutter`dart::Monitor::WaitMicros(long long) + 128
[        ]     frame #3: 0x000000011ef45cf8 Flutter`dart::ThreadPool::Worker::Main(unsigned long) + 668
[        ]     frame #4: 0x000000011ee9de64 Flutter`dart::ThreadStart(void*) + 288
[        ]     frame #5: 0x00000001dcd62348 libsystem_pthread.dylib`_pthread_start + 116
[        ]   thread #59
[        ]     frame #0: 0x00000001dcd60934 libsystem_pthread.dylib`start_wqthread
[        ]   thread #60
[        ]     frame #0: 0x00000001dcd60934 libsystem_pthread.dylib`start_wqthread
[  +68 ms] (lldb) 
[        ] ios-deploy exited with code 0
[   +8 ms] Service protocol connection closed.
[        ] Lost connection to device.
[        ] DevFS: Deleting filesystem on the device (file:///private/var/mobile/Containers/Data/Application/8B7DD4C3-F128-4E58-97E2-8156409183EC/tmp/mobiles0FPle/mobile/)
[{"id":14,"result":true}]

```

