### PR TITLE
[google_sign_in] Slight cleanup in GoogleSignInPlugin

### DIFF
--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,5 +1,6 @@
-## NEXT
+## 6.1.6
 
+* Minor implementation cleanup
 * Updates minimum Flutter version to 3.0.
 
 ## 6.1.5

--- a/packages/google_sign_in/google_sign_in_android/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -404,9 +404,9 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
     public void signInSilently(Result result) {
       checkAndSetPendingOperation(METHOD_SIGN_IN_SILENTLY, result);
       Task<GoogleSignInAccount> task = signInClient.silentSignIn();
-      if (task.isSuccessful()) {
+      if (task.isComplete()) {
         // There's immediate result available.
-        onSignInAccount(task.getResult());
+        onSignInResult(task);
       } else {
         task.addOnCompleteListener(
             new OnCompleteListener<GoogleSignInAccount>() {
@@ -516,7 +516,7 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
         GoogleSignInAccount account = completedTask.getResult(ApiException.class);
         onSignInAccount(account);
       } catch (ApiException e) {
-        // Forward all errors and let Dart side decide how to handle.
+        // Forward all errors and let Dart decide how to handle.
         String errorCode = errorCodeForStatus(e.getStatusCode());
         finishWithError(errorCode, e.toString());
       } catch (RuntimeExecutionException e) {
@@ -538,14 +538,20 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
     }
 
     private String errorCodeForStatus(int statusCode) {
-      if (statusCode == GoogleSignInStatusCodes.SIGN_IN_CANCELLED) {
-        return ERROR_REASON_SIGN_IN_CANCELED;
-      } else if (statusCode == CommonStatusCodes.SIGN_IN_REQUIRED) {
-        return ERROR_REASON_SIGN_IN_REQUIRED;
-      } else if (statusCode == CommonStatusCodes.NETWORK_ERROR) {
-        return ERROR_REASON_NETWORK_ERROR;
-      } else {
-        return ERROR_REASON_SIGN_IN_FAILED;
+      switch (statusCode) {
+        case GoogleSignInStatusCodes.SIGN_IN_CANCELLED:
+            return ERROR_REASON_SIGN_IN_CANCELED;
+        case CommonStatusCodes.SIGN_IN_REQUIRED:
+            return ERROR_REASON_SIGN_IN_REQUIRED;
+        case CommonStatusCodes.NETWORK_ERROR:
+            return ERROR_REASON_NETWORK_ERROR;
+        case GoogleSignInStatusCodes.SIGN_IN_CURRENTLY_IN_PROGRESS:
+        case GoogleSignInStatusCodes.SIGN_IN_FAILED:
+        case CommonStatusCodes.INVALID_ACCOUNT:
+        case CommonStatusCodes.INTERNAL_ERROR:
+            return ERROR_REASON_SIGN_IN_FAILED;
+        default:
+            return ERROR_REASON_SIGN_IN_FAILED;
       }
     }
 

--- a/packages/google_sign_in/google_sign_in_android/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/main/java/io/flutter/plugins/googlesignin/GoogleSignInPlugin.java
@@ -540,18 +540,18 @@ public class GoogleSignInPlugin implements MethodCallHandler, FlutterPlugin, Act
     private String errorCodeForStatus(int statusCode) {
       switch (statusCode) {
         case GoogleSignInStatusCodes.SIGN_IN_CANCELLED:
-            return ERROR_REASON_SIGN_IN_CANCELED;
+          return ERROR_REASON_SIGN_IN_CANCELED;
         case CommonStatusCodes.SIGN_IN_REQUIRED:
-            return ERROR_REASON_SIGN_IN_REQUIRED;
+          return ERROR_REASON_SIGN_IN_REQUIRED;
         case CommonStatusCodes.NETWORK_ERROR:
-            return ERROR_REASON_NETWORK_ERROR;
+          return ERROR_REASON_NETWORK_ERROR;
         case GoogleSignInStatusCodes.SIGN_IN_CURRENTLY_IN_PROGRESS:
         case GoogleSignInStatusCodes.SIGN_IN_FAILED:
         case CommonStatusCodes.INVALID_ACCOUNT:
         case CommonStatusCodes.INTERNAL_ERROR:
-            return ERROR_REASON_SIGN_IN_FAILED;
+          return ERROR_REASON_SIGN_IN_FAILED;
         default:
-            return ERROR_REASON_SIGN_IN_FAILED;
+          return ERROR_REASON_SIGN_IN_FAILED;
       }
     }
 

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -18,6 +18,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
 import com.google.android.gms.auth.api.signin.GoogleSignInClient;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions;
 import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.common.api.Status;
 import com.google.android.gms.tasks.Task;
@@ -214,13 +215,13 @@ public class GoogleSignInTest {
     MethodCall methodCall = buildInitMethodCall(clientId, null);
     initAndAssertServerClientId(methodCall, clientId);
 
-    ApiException exception = new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));
+    ApiException exception =
+        new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));
     when(mockClient.silentSignIn()).thenReturn(mockSignInTask);
     when(mockSignInTask.isComplete()).thenReturn(true);
     when(mockSignInTask.getResult(ApiException.class)).thenThrow(exception);
 
-    MethodCall methodCall = new MethodCall("signInSilently", null);
-    plugin.onMethodCall(methodCall, result);
+    plugin.onMethodCall(new MethodCall("signInSilently", null), result);
     verify(result).error("sign_in_required", "Error text", null);
   }
 

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -219,7 +219,6 @@ public class GoogleSignInTest {
 
     ArgumentCaptor<String> code = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
-    verify(mockResult).error(code.capture(), message.capture(), any());
 
     ApiException exception =
         new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));
@@ -228,6 +227,7 @@ public class GoogleSignInTest {
     when(mockSignInTask.getResult(ApiException.class)).thenThrow(exception);
 
     plugin.onMethodCall(new MethodCall("signInSilently", null), mockResult);
+    verify(mockResult).error(code.capture(), message.capture(), any());
     System.out.println("~!@ :: " + code.getValue());
     System.out.println("~!@ :: " + message.getValue());
     Assert.assertEquals(CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", message.getValue());

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -219,7 +219,7 @@ public class GoogleSignInTest {
 
     ArgumentCaptor<String> code = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
-    verify(mockResult).error(code.capture(), message.capture(), null);
+    verify(mockResult).error(code.capture(), message.capture(), any());
 
     ApiException exception =
         new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -223,7 +223,8 @@ public class GoogleSignInTest {
     when(mockSignInTask.getResult(ApiException.class)).thenThrow(exception);
 
     plugin.onMethodCall(new MethodCall("signInSilently", null), result);
-    verify(result).error("sign_in_required", "Error text", null);
+    verify(result)
+        .error("sign_in_required", CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", null);
   }
 
   @Test

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -44,6 +44,7 @@ public class GoogleSignInTest {
   @Mock PluginRegistry.Registrar mockRegistrar;
   @Mock BinaryMessenger mockMessenger;
   @Spy MethodChannel.Result result;
+  @Mock MethodChannel.Result mockResult;
   @Mock GoogleSignInWrapper mockGoogleSignIn;
   @Mock GoogleSignInAccount account;
   @Mock GoogleSignInClient mockClient;
@@ -216,15 +217,24 @@ public class GoogleSignInTest {
     MethodCall methodCall = buildInitMethodCall(clientId, null);
     initAndAssertServerClientId(methodCall, clientId);
 
+    ArgumentCaptor<String> code = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
+    verify(mockResult).error(code.capture(), message.capture(), null);
+
     ApiException exception =
         new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));
     when(mockClient.silentSignIn()).thenReturn(mockSignInTask);
     when(mockSignInTask.isComplete()).thenReturn(true);
     when(mockSignInTask.getResult(ApiException.class)).thenThrow(exception);
 
-    plugin.onMethodCall(new MethodCall("signInSilently", null), result);
+    plugin.onMethodCall(new MethodCall("signInSilently", null), mockResult);
+    System.out.println("~!@ :: " + code.getValue());
+    System.out.println("~!@ :: " + message.getValue());
+    Assert.assertEquals(CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", message.getValue());
+    /*
     verify(result)
         .error("sign_in_required", CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", null);
+    */
   }
 
   @Test

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -44,7 +44,6 @@ public class GoogleSignInTest {
   @Mock PluginRegistry.Registrar mockRegistrar;
   @Mock BinaryMessenger mockMessenger;
   @Spy MethodChannel.Result result;
-  @Mock MethodChannel.Result mockResult;
   @Mock GoogleSignInWrapper mockGoogleSignIn;
   @Mock GoogleSignInAccount account;
   @Mock GoogleSignInClient mockClient;
@@ -217,24 +216,18 @@ public class GoogleSignInTest {
     MethodCall methodCall = buildInitMethodCall(clientId, null);
     initAndAssertServerClientId(methodCall, clientId);
 
-    ArgumentCaptor<String> code = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<String> message = ArgumentCaptor.forClass(String.class);
-
     ApiException exception =
         new ApiException(new Status(CommonStatusCodes.SIGN_IN_REQUIRED, "Error text"));
     when(mockClient.silentSignIn()).thenReturn(mockSignInTask);
     when(mockSignInTask.isComplete()).thenReturn(true);
     when(mockSignInTask.getResult(ApiException.class)).thenThrow(exception);
 
-    plugin.onMethodCall(new MethodCall("signInSilently", null), mockResult);
-    verify(mockResult).error(code.capture(), message.capture(), any());
-    System.out.println("~!@ :: " + code.getValue());
-    System.out.println("~!@ :: " + message.getValue());
-    Assert.assertEquals(CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", message.getValue());
-    /*
+    plugin.onMethodCall(new MethodCall("signInSilently", null), result);
     verify(result)
-        .error("sign_in_required", CommonStatusCodes.SIGN_IN_REQUIRED + ": Error text", null);
-    */
+        .error(
+            "sign_in_required",
+            "com.google.android.gms.common.api.ApiException: 4: Error text",
+            null);
   }
 
   @Test

--- a/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
+++ b/packages/google_sign_in/google_sign_in_android/android/src/test/java/io/flutter/plugins/googlesignin/GoogleSignInTest.java
@@ -210,7 +210,8 @@ public class GoogleSignInTest {
   }
 
   @Test
-  public void signInSilentlyThatImmediatelyCompletesWithoutResultFinishesWithError() {
+  public void signInSilentlyThatImmediatelyCompletesWithoutResultFinishesWithError()
+      throws ApiException {
     final String clientId = "fakeClientId";
     MethodCall methodCall = buildInitMethodCall(clientId, null);
     initAndAssertServerClientId(methodCall, clientId);

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_sign_in_android
 description: Android implementation of the google_sign_in plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_sign_in/google_sign_in_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+google_sign_in%22
-version: 6.1.5
+version: 6.1.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
1) Use switch instead of if/else and show all possible states
2) Handle the case of synchronous failure in signInSilently()
   by checking isComplete() instead of isSuccessful()

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
