### PR TITLE
Ignore deprecated member use on DecoderBufferCallback

### DIFF
--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,6 +1,6 @@
-## NEXT
+## 0.2.1+1
 
-* Updates minimum Flutter version to 3.0.
+* Add lint ignore comments
 
 ## 0.2.1
 

--- a/packages/ios_platform_images/lib/ios_platform_images.dart
+++ b/packages/ios_platform_images/lib/ios_platform_images.dart
@@ -63,7 +63,9 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
 
   @override
   ImageStreamCompleter loadBuffer(
-      _FutureMemoryImage key, DecoderBufferCallback decode) {
+    _FutureMemoryImage key,
+    DecoderBufferCallback decode, // ignore: deprecated_member_use
+  ) {
     return _FutureImageStreamCompleter(
       codec: _loadAsync(key, decode),
       futureScale: _futureScale,
@@ -72,7 +74,7 @@ class _FutureMemoryImage extends ImageProvider<_FutureMemoryImage> {
 
   Future<ui.Codec> _loadAsync(
     _FutureMemoryImage key,
-    DecoderBufferCallback decode,
+    DecoderBufferCallback decode, // ignore: deprecated_member_use
   ) {
     assert(key == this);
     return _futureBytes.then(ui.ImmutableBuffer.fromUint8List).then(decode);

--- a/packages/ios_platform_images/pubspec.yaml
+++ b/packages/ios_platform_images/pubspec.yaml
@@ -2,7 +2,7 @@ name: ios_platform_images
 description: A plugin to share images between Flutter and iOS in add-to-app setups.
 repository: https://github.com/flutter/plugins/tree/main/packages/ios_platform_images
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+ios_platform_images%22
-version: 0.2.1
+version: 0.2.1+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
In preparation for flutter/flutter#118966
