### PR TITLE
[ci] Update legacy Flutter version tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -175,8 +175,8 @@ task:
           CHANNEL: "3.0.5"
           DART_VERSION: "2.17.6"
         env:
-          CHANNEL: "2.10.5"
-          DART_VERSION: "2.16.2"
+          CHANNEL: "3.3.10"
+          DART_VERSION: "2.18.6"
       package_prep_script:
         # Allow analyzing packages that use a dev dependency with a higher
         # minimum Flutter/Dart version than the package itself.

--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.10.2+3
 
 * Updates code for stricter lint checks.

--- a/packages/camera/camera_android/example/pubspec.yaml
+++ b/packages/camera/camera_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   camera_android:

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.10.2+3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_avfoundation/CHANGELOG.md
+++ b/packages/camera/camera_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.10+2
 
 * Updates code for stricter lint checks.

--- a/packages/camera/camera_avfoundation/example/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   camera_avfoundation:

--- a/packages/camera/camera_avfoundation/pubspec.yaml
+++ b/packages/camera/camera_avfoundation/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.10+2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.3.4
 
 * Updates code for stricter lint checks.

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.3.4
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cross_file: ^0.3.1

--- a/packages/camera/camera_web/CHANGELOG.md
+++ b/packages/camera/camera_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.3.1+1
 
 * Updates code for stricter lint checks.

--- a/packages/camera/camera_web/example/pubspec.yaml
+++ b/packages/camera/camera_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/camera/camera_web/pubspec.yaml
+++ b/packages/camera/camera_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.3.1+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/camera/camera_windows/CHANGELOG.md
+++ b/packages/camera/camera_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.2.1+4
 
 * Updates code for stricter lint checks.

--- a/packages/camera/camera_windows/example/pubspec.yaml
+++ b/packages/camera/camera_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   camera_platform_interface: ^2.1.2

--- a/packages/camera/camera_windows/pubspec.yaml
+++ b/packages/camera/camera_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.2.1+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/espresso/CHANGELOG.md
+++ b/packages/espresso/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.2.0+6
 
 * Updates espresso-accessibility to 3.5.1.

--- a/packages/espresso/example/pubspec.yaml
+++ b/packages/espresso/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/espresso/pubspec.yaml
+++ b/packages/espresso/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.2.0+6
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector/CHANGELOG.md
+++ b/packages/file_selector/file_selector/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.2+2
 
 * Improves API docs and examples.

--- a/packages/file_selector/file_selector/pubspec.yaml
+++ b/packages/file_selector/file_selector/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.9.2+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_ios/CHANGELOG.md
+++ b/packages/file_selector/file_selector_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.5.0+2
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_ios/pubspec.yaml
+++ b/packages/file_selector/file_selector_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.5.0+2
 
 environment:
   sdk: ">=2.14.4 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_linux/CHANGELOG.md
+++ b/packages/file_selector/file_selector_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.1
 
 * Adds `getDirectoryPaths` implementation.

--- a/packages/file_selector/file_selector_linux/pubspec.yaml
+++ b/packages/file_selector/file_selector_linux/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_macos/CHANGELOG.md
+++ b/packages/file_selector/file_selector_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.0+4
 
 * Converts platform channel to Pigeon.

--- a/packages/file_selector/file_selector_macos/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   file_selector_macos:

--- a/packages/file_selector/file_selector_macos/pubspec.yaml
+++ b/packages/file_selector/file_selector_macos/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.0+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
+++ b/packages/file_selector/file_selector_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.4.0
 
 * Adds `getDirectoryPaths` method to the interface.

--- a/packages/file_selector/file_selector_platform_interface/pubspec.yaml
+++ b/packages/file_selector/file_selector_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cross_file: ^0.3.0

--- a/packages/file_selector/file_selector_web/CHANGELOG.md
+++ b/packages/file_selector/file_selector_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.0+2
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_web/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   file_selector_platform_interface: ^2.2.0

--- a/packages/file_selector/file_selector_web/pubspec.yaml
+++ b/packages/file_selector/file_selector_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.0+2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/file_selector/file_selector_windows/CHANGELOG.md
+++ b/packages/file_selector/file_selector_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.9.1+4
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/file_selector/file_selector_windows/example/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   file_selector_platform_interface: ^2.2.0

--- a/packages/file_selector/file_selector_windows/pubspec.yaml
+++ b/packages/file_selector/file_selector_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.9.1+4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
+++ b/packages/flutter_plugin_android_lifecycle/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.0.7
 

--- a/packages/flutter_plugin_android_lifecycle/pubspec.yaml
+++ b/packages/flutter_plugin_android_lifecycle/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.2.3
 
 * Fixes a minor syntax error in `README.md`.

--- a/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.5

--- a/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.2.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.4.3
 
 * Updates code for stricter lint checks.

--- a/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.5

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.13
 
 * Updates code for stricter lint checks.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.5

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.13
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.2.5
 
 * Updates code for stricter lint checks.

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.2.5
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.4.0+5
 
 * Updates code for stricter lint checks.

--- a/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 # Tests require flutter beta or greater to run.
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.4.0+5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 5.4.3
 
 * Updates code for stricter lint checks.

--- a/packages/google_sign_in/google_sign_in/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in/pubspec.yaml
@@ -8,7 +8,7 @@ version: 5.4.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 6.1.5
 
 * Updates play-services-auth version to 20.4.1.

--- a/packages/google_sign_in/google_sign_in_android/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in_android/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 6.1.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 5.5.1
 
 * Fixes passing `serverClientId` via the channelled `init` call

--- a/packages/google_sign_in/google_sign_in_ios/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 5.5.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.3.0
 

--- a/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
+++ b/packages/google_sign_in/google_sign_in_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.10.2+1
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/google_sign_in/google_sign_in_web/pubspec.yaml
+++ b/packages/google_sign_in/google_sign_in_web/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.10.2+1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker/CHANGELOG.md
+++ b/packages/image_picker/image_picker/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.8.6+1
 
 * Updates code for stricter lint checks.

--- a/packages/image_picker/image_picker/example/pubspec.yaml
+++ b/packages/image_picker/image_picker/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker/pubspec.yaml
+++ b/packages/image_picker/image_picker/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.8.6+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.8.5+5
 
 * Updates code for stricter lint checks.

--- a/packages/image_picker/image_picker_android/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.8.5+5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_for_web/CHANGELOG.md
+++ b/packages/image_picker/image_picker_for_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.10
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.

--- a/packages/image_picker/image_picker_for_web/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_for_web/pubspec.yaml
+++ b/packages/image_picker/image_picker_for_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.10
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_ios/CHANGELOG.md
+++ b/packages/image_picker/image_picker_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.8.6+6
 
 * Updates code for stricter lint checks.

--- a/packages/image_picker/image_picker_ios/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_ios/pubspec.yaml
+++ b/packages/image_picker/image_picker_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.8.6+6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
+++ b/packages/image_picker/image_picker_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.6.2
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/image_picker/image_picker_platform_interface/pubspec.yaml
+++ b/packages/image_picker/image_picker_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.6.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cross_file: ^0.3.1+1

--- a/packages/image_picker/image_picker_windows/CHANGELOG.md
+++ b/packages/image_picker/image_picker_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.1.0+3
 
 * Changes XTypeGroup initialization from final to const.

--- a/packages/image_picker/image_picker_windows/example/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/example/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/image_picker/image_picker_windows/pubspec.yaml
+++ b/packages/image_picker/image_picker_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.1.0+3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 3.1.1
 
 * Adds screenshots to pubspec.yaml.

--- a/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.2.3+9
 
 * Updates `androidx.test.espresso:espresso-core` to 3.5.1.

--- a/packages/in_app_purchase/in_app_purchase_android/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.2.3+9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.3.2
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 1.3.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.3.4+1
 
 * Updates code for stricter lint checks.

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.3.4+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/ios_platform_images/CHANGELOG.md
+++ b/packages/ios_platform_images/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.2.1
 
 * Updates minimum Flutter version to 3.3.0.

--- a/packages/ios_platform_images/example/pubspec.yaml
+++ b/packages/ios_platform_images/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   cupertino_icons: ^1.0.2

--- a/packages/local_auth/local_auth/CHANGELOG.md
+++ b/packages/local_auth/local_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.3
 
 * Updates minimum Flutter version to 2.10.

--- a/packages/local_auth/local_auth/example/pubspec.yaml
+++ b/packages/local_auth/local_auth/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/local_auth/local_auth/pubspec.yaml
+++ b/packages/local_auth/local_auth/pubspec.yaml
@@ -7,7 +7,7 @@ version: 2.1.3
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/local_auth/local_auth_android/CHANGELOG.md
+++ b/packages/local_auth/local_auth_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.17
 
 * Adds compatibility with `intl` 0.18.0.

--- a/packages/local_auth/local_auth_android/example/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/local_auth/local_auth_android/pubspec.yaml
+++ b/packages/local_auth/local_auth_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.17
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/local_auth/local_auth_ios/CHANGELOG.md
+++ b/packages/local_auth/local_auth_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.12
 
 * Adds compatibility with `intl` 0.18.0.

--- a/packages/local_auth/local_auth_ios/example/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/local_auth/local_auth_ios/pubspec.yaml
+++ b/packages/local_auth/local_auth_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/local_auth/local_auth_platform_interface/CHANGELOG.md
+++ b/packages/local_auth/local_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.6
 
 * Removes unused `intl` dependency.

--- a/packages/local_auth/local_auth_platform_interface/pubspec.yaml
+++ b/packages/local_auth/local_auth_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 1.0.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/local_auth/local_auth_windows/CHANGELOG.md
+++ b/packages/local_auth/local_auth_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.5
 
 * Switches internal implementation to Pigeon.

--- a/packages/local_auth/local_auth_windows/example/pubspec.yaml
+++ b/packages/local_auth/local_auth_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/local_auth/local_auth_windows/pubspec.yaml
+++ b/packages/local_auth/local_auth_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider/CHANGELOG.md
+++ b/packages/path_provider/path_provider/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.12
 
 * Switches to the new `path_provider_foundation` implementation package

--- a/packages/path_provider/path_provider/example/pubspec.yaml
+++ b/packages/path_provider/path_provider/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider/pubspec.yaml
+++ b/packages/path_provider/path_provider/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.12
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_android/CHANGELOG.md
+++ b/packages/path_provider/path_provider_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.22
 
 * Removes unused Guava dependency.

--- a/packages/path_provider/path_provider_android/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider_android/pubspec.yaml
+++ b/packages/path_provider/path_provider_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.22
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_foundation/CHANGELOG.md
+++ b/packages/path_provider/path_provider_foundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.0
 
 * Renames the package previously published as

--- a/packages/path_provider/path_provider_foundation/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_foundation/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider_foundation/pubspec.yaml
+++ b/packages/path_provider/path_provider_foundation/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_linux/CHANGELOG.md
+++ b/packages/path_provider/path_provider_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.1.7
 

--- a/packages/path_provider/path_provider_linux/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: "none"
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider_linux/pubspec.yaml
+++ b/packages/path_provider/path_provider_linux/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.7
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
+++ b/packages/path_provider/path_provider_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.5
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/path_provider/path_provider_platform_interface/pubspec.yaml
+++ b/packages/path_provider/path_provider_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.0.5
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/path_provider/path_provider_windows/CHANGELOG.md
+++ b/packages/path_provider/path_provider_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.3
 
 * Updates minimum Flutter version to 2.10.

--- a/packages/path_provider/path_provider_windows/example/pubspec.yaml
+++ b/packages/path_provider/path_provider_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/quick_actions/quick_actions/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.1
 
 * Updates implementaion package versions to current versions.

--- a/packages/quick_actions/quick_actions/example/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/quick_actions/quick_actions/pubspec.yaml
+++ b/packages/quick_actions/quick_actions/pubspec.yaml
@@ -7,7 +7,7 @@ version: 1.0.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/quick_actions/quick_actions_android/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.0
 
 * Updates version to 1.0 to reflect current status.

--- a/packages/quick_actions/quick_actions_android/example/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/quick_actions/quick_actions_android/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.0
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/quick_actions/quick_actions_ios/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.2
 
 * Migrates remaining components to Swift and removes all Objective-C settings.

--- a/packages/quick_actions/quick_actions_ios/example/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/quick_actions/quick_actions_ios/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 1.0.2
 
 environment:
   sdk: ">=2.15.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
+++ b/packages/quick_actions/quick_actions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 1.0.3
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
+++ b/packages/quick_actions/quick_actions_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 1.0.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.17
 
 * Updates code for stricter lint checks.

--- a/packages/shared_preferences/shared_preferences/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -7,7 +7,7 @@ version: 2.0.17
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.15
 
 * Updates code for stricter lint checks.

--- a/packages/shared_preferences/shared_preferences_android/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_android/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.15
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_foundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.2
 
 * Updates code for stricter lint checks.

--- a/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_foundation/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.3
 
 * Updates code for stricter lint checks.

--- a/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.1.0
 

--- a/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_platform_interface/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## NEXT
 
-* Updates minimum Flutter version to 2.10.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.0.4
 

--- a/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_web/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.3
 
 * Updates code for stricter lint checks.

--- a/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.1.3
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 6.1.8
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher/pubspec.yaml
+++ b/packages/url_launcher/url_launcher/pubspec.yaml
@@ -7,7 +7,7 @@ version: 6.1.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_android/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 6.0.23
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_android/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_android/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 6.0.23
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_ios/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 6.0.18
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_ios/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_ios/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_ios/pubspec.yaml
@@ -6,7 +6,7 @@ version: 6.0.18
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_linux/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 3.0.2
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_linux/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_linux/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_macos/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 3.0.2
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_macos/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_macos/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.1.1
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_web/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.14
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_web/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_web/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.14
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/url_launcher/url_launcher_windows/CHANGELOG.md
+++ b/packages/url_launcher/url_launcher_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 3.0.2
 
 * Updates code for stricter lint checks.

--- a/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/url_launcher/url_launcher_windows/pubspec.yaml
+++ b/packages/url_launcher/url_launcher_windows/pubspec.yaml
@@ -6,7 +6,7 @@ version: 3.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.5.1
 
 * Updates code for stricter lint checks.

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -7,7 +7,7 @@ version: 2.5.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.3.10
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.3.10
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.3.8
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_avfoundation/example/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.3.8
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 6.0.1
 
 * Fixes comment describing file URI construction.

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 6.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.13
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.0.13
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:

--- a/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 2.0.1
 
 * Improves error message when a platform interface class is used before `WebViewPlatform.instance` has been set.

--- a/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ version: 2.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 dependencies:
   flutter:

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Updates minimum Flutter version to 3.0.
+
 ## 0.2.1
 
 * Adds auto registration of the `WebViewPlatform` implementation.

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.2.1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=3.0.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
Updates the N-1 and N-2 version tests to 3.0 and 3.3 now that 3.7 is on stable.

Updates all packages to require at least Flutter 3.0 since we won't be testing earlier versions at all.