### PR TITLE
[google_maps_flutter] Markers to respond based on consumeTapEvents parameter

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.4
+
+* Respond to marker tap events based on `consumeTapEvents`
+
 ## 2.3.3
 
 * Update android gradle plugin to 7.3.1.

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/main/java/io/flutter/plugins/googlemaps/MarkersController.java
@@ -97,11 +97,13 @@ class MarkersController {
     if (markerId == null) {
       return false;
     }
-    methodChannel.invokeMethod("marker#onTap", Convert.markerIdToJson(markerId));
-    MarkerController markerController = markerIdToController.get(markerId);
-    if (markerController != null) {
-      return markerController.consumeTapEvents();
+
+    final MarkerController markerController = markerIdToController.get(markerId);
+    if (markerController != null && markerController.consumeTapEvents()) {
+      methodChannel.invokeMethod("marker#onTap", Convert.markerIdToJson(markerId));
+      return true;
     }
+
     return false;
   }
 

--- a/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/MarkersControllerTest.java
+++ b/packages/google_maps_flutter/google_maps_flutter_android/android/src/test/java/io/flutter/plugins/googlemaps/MarkersControllerTest.java
@@ -6,6 +6,7 @@ package io.flutter.plugins.googlemaps;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -123,5 +124,57 @@ public class MarkersControllerTest {
     data.put("markerId", googleMarkerId);
     data.put("position", points);
     Mockito.verify(methodChannel).invokeMethod("marker#onDrag", data);
+  }
+
+  @Test
+  public void controller_OnMarkerTap_Enabled() {
+    final MethodChannel methodChannel =
+        spy(new MethodChannel(mock(BinaryMessenger.class), "no-name", mock(MethodCodec.class)));
+    final MarkersController controller = new MarkersController(methodChannel);
+    final GoogleMap googleMap = mock(GoogleMap.class);
+    controller.setGoogleMap(googleMap);
+
+    final Marker marker = mock(Marker.class);
+    final String googleMarkerId = "abc123";
+    when(marker.getId()).thenReturn(googleMarkerId);
+    when(googleMap.addMarker(any(MarkerOptions.class))).thenReturn(marker);
+
+    final Map<String, Object> markerOptions = new HashMap();
+    markerOptions.put("markerId", googleMarkerId);
+    markerOptions.put("consumeTapEvents", true);
+
+    final List<Object> markers = Arrays.<Object>asList(markerOptions);
+    controller.addMarkers(markers);
+    controller.onMarkerTap(googleMarkerId);
+
+    final Map<String, Object> data = new HashMap<>();
+    data.put("markerId", googleMarkerId);
+    Mockito.verify(methodChannel).invokeMethod("marker#onTap", data);
+  }
+
+  @Test
+  public void controller_OnMarkerTap_Disabled() {
+    final MethodChannel methodChannel =
+        spy(new MethodChannel(mock(BinaryMessenger.class), "no-name", mock(MethodCodec.class)));
+    final MarkersController controller = new MarkersController(methodChannel);
+    final GoogleMap googleMap = mock(GoogleMap.class);
+    controller.setGoogleMap(googleMap);
+
+    final Marker marker = mock(Marker.class);
+    final String googleMarkerId = "abc123";
+    when(marker.getId()).thenReturn(googleMarkerId);
+    when(googleMap.addMarker(any(MarkerOptions.class))).thenReturn(marker);
+
+    final Map<String, Object> markerOptions = new HashMap();
+    markerOptions.put("markerId", googleMarkerId);
+    markerOptions.put("consumeTapEvents", false);
+
+    final List<Object> markers = Arrays.<Object>asList(markerOptions);
+    controller.addMarkers(markers);
+    controller.onMarkerTap(googleMarkerId);
+
+    final Map<String, Object> data = new HashMap<>();
+    data.put("markerId", googleMarkerId);
+    Mockito.verify(methodChannel, never()).invokeMethod("marker#onTap", data);
   }
 }

--- a/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_android
 description: Android implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.3.3
+version: 2.3.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.13
+
+* `Marker.consumeTapEvents` will determine whether to call `Marker.onTap`
+
 ## 2.1.12
 
 * Updates imports for `prefer_relative_imports`.

--- a/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/ios/Classes/GoogleMapMarkerController.m
@@ -288,8 +288,11 @@
   if (!controller) {
     return NO;
   }
-  [self.methodChannel invokeMethod:@"marker#onTap" arguments:@{@"markerId" : identifier}];
-  return controller.consumeTapEvents;
+  if (controller.consumeTapEvents) {
+    [self.methodChannel invokeMethod:@"marker#onTap" arguments:@{@"markerId" : identifier}];
+    return YES;
+  }
+  return NO;
 }
 
 - (void)didStartDraggingMarkerWithIdentifier:(NSString *)identifier

--- a/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/pubspec.yaml
@@ -2,7 +2,7 @@ name: google_maps_flutter_ios
 description: iOS implementation of the google_maps_flutter plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/google_maps_flutter/google_maps_flutter_ios
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+maps%22
-version: 2.1.12
+version: 2.1.13
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_ios/test/google_maps_flutter_ios_test.dart
@@ -103,11 +103,11 @@ void main() {
     maps.ensureChannelInitialized(mapId);
 
     final StreamQueue<MarkerDragStartEvent> markerDragStartStream =
-        StreamQueue<MarkerDragStartEvent>(maps.onMarkerDragStart(mapId: mapId));
+    StreamQueue<MarkerDragStartEvent>(maps.onMarkerDragStart(mapId: mapId));
     final StreamQueue<MarkerDragEvent> markerDragStream =
-        StreamQueue<MarkerDragEvent>(maps.onMarkerDrag(mapId: mapId));
+    StreamQueue<MarkerDragEvent>(maps.onMarkerDrag(mapId: mapId));
     final StreamQueue<MarkerDragEndEvent> markerDragEndStream =
-        StreamQueue<MarkerDragEndEvent>(maps.onMarkerDragEnd(mapId: mapId));
+    StreamQueue<MarkerDragEndEvent>(maps.onMarkerDragEnd(mapId: mapId));
 
     await sendPlatformMessage(
         mapId, 'marker#onDragStart', jsonMarkerDragStartEvent);
@@ -120,5 +120,23 @@ void main() {
     expect((await markerDragStream.next).value.value, equals('drag-marker'));
     expect((await markerDragEndStream.next).value.value,
         equals('drag-end-marker'));
+  });
+
+  test('markers send onTap event to correct streams', () async {
+    const int mapId = 1;
+    final Map<dynamic, dynamic> jsonMarkerOnTapEvent = <dynamic, dynamic>{
+      'mapId': mapId,
+      'markerId': 'on-tap-marker',
+      'position': <double>[1.0, 1.0]
+    };
+
+    final GoogleMapsFlutterIOS maps = GoogleMapsFlutterIOS();
+    maps.ensureChannelInitialized(mapId);
+
+    final StreamQueue<MarkerTapEvent> markerOnTapStream =
+    StreamQueue<MarkerTapEvent>(maps.onMarkerTap(mapId: mapId));
+
+    await sendPlatformMessage(
+        mapId, 'marker#onTap', jsonMarkerOnTapEvent);
   });
 }

--- a/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_platform_interface/lib/src/types/marker.dart
@@ -175,9 +175,10 @@ class Marker implements MapsObject<Marker> {
   /// of (1.0, 1.0) means the bottom right corner of the image.
   final Offset anchor;
 
-  /// True if the marker icon consumes tap events. If not, the map will perform
-  /// default tap handling by centering the map on the marker and displaying its
-  /// info window.
+  /// True if the marker icon consumes tap events.
+  /// If this is false, [onTap] callback will not be triggered the map will
+  /// perform default tap handling by centering the map on the marker and
+  /// displaying its info window.
   final bool consumeTapEvents;
 
   /// True if the marker is draggable by user touch events.

--- a/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
+++ b/packages/google_maps_flutter/google_maps_flutter_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 * Updates code for `no_leading_underscores_for_local_identifiers` lint.
+* `Marker.consumeTapEvents` will determine whether to call `Marker.onTap`
 
 ## 0.4.0+3
 

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/marker.dart
@@ -18,7 +18,7 @@ class MarkerController {
   })  : _marker = marker,
         _infoWindow = infoWindow,
         _consumeTapEvents = consumeTapEvents {
-    if (onTap != null) {
+    if (onTap != null && consumeTapEvents) {
       marker.onClick.listen((gmaps.MapMouseEvent event) {
         onTap.call();
       });

--- a/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
+++ b/packages/google_maps_flutter/google_maps_flutter_web/lib/src/markers.dart
@@ -62,8 +62,11 @@ class MarkersController extends GeometryController {
       infoWindow: gmInfoWindow,
       consumeTapEvents: marker.consumeTapEvents,
       onTap: () {
-        showMarkerInfoWindow(marker.markerId);
-        _onMarkerTap(marker.markerId);
+        if (marker.consumeTapEvents) {
+          _onMarkerTap(marker.markerId);
+        } else {
+          showMarkerInfoWindow(marker.markerId)
+        }
       },
       onDragStart: (gmaps.LatLng latLng) {
         _onMarkerDragStart(marker.markerId, latLng);
@@ -140,11 +143,10 @@ class MarkersController extends GeometryController {
 
   // Handle internal events
 
-  bool _onMarkerTap(MarkerId markerId) {
+  void _onMarkerTap(MarkerId markerId) {
     // Have you ended here on your debugging? Is this wrong?
     // Comment here: https://github.com/flutter/flutter/issues/64084
     _streamController.add(MarkerTapEvent(mapId, markerId));
-    return _markerIdToController[markerId]?.consumeTapEvents ?? false;
   }
 
   void _onInfoWindowTap(MarkerId markerId) {


### PR DESCRIPTION
When you tap a marker in Android it will always show the info window even if the `consumeTapEvents`

https://github.com/flutter/flutter/issues/95296
https://github.com/flutter/flutter/issues/39868

## Pre-launch Checklist

- [/] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [/] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [/] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [/] I signed the [CLA].
- [/] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [/] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [/] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [/] I updated/added relevant documentation (doc comments with `///`).
- [/] I added new tests to check the change I am making, or this PR is [test-exempt].
- [/] All existing and new tests are passing.
