### PR TITLE
[camera_platform_interface] Add support for NV21 image format on android (part 1/3)

### DIFF
--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,7 +1,5 @@
-## NEXT
-* Updates minimum Flutter version to 3.0.
-
 ## 2.4.0
+* Updates minimum Flutter version to 3.0.
 * Adds support for NV21 image format on Android.
 
 ## 2.3.4

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,7 +1,4 @@
 ## NEXT
-
-## 2.4.0
-
 * Updates minimum Flutter version to 3.0.
 * Adds support for NV21 image format on Android.
 

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## NEXT
 
+## 2.4.0
+
 * Updates minimum Flutter version to 3.0.
+* Adds support for NV21 image format on Android.
 
 ## 2.3.4
 

--- a/packages/camera/camera_platform_interface/CHANGELOG.md
+++ b/packages/camera/camera_platform_interface/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 * Updates minimum Flutter version to 3.0.
+
+## 2.4.0
 * Adds support for NV21 image format on Android.
 
 ## 2.3.4

--- a/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
+++ b/packages/camera/camera_platform_interface/lib/src/types/image_format_group.dart
@@ -31,6 +31,12 @@ enum ImageFormatGroup {
   /// On Android, this is `android.graphics.ImageFormat.JPEG`. See
   /// https://developer.android.com/reference/android/graphics/ImageFormat#JPEG
   jpeg,
+
+  /// YCrCb format used for images, which uses the NV21 encoding format.
+  ///
+  /// On Android, this is `android.graphics.ImageFormat.NV21`. See
+  /// https://developer.android.com/reference/android/graphics/ImageFormat#NV21
+  nv21,
 }
 
 /// Extension on [ImageFormatGroup] to stringify the enum
@@ -46,6 +52,8 @@ extension ImageFormatGroupName on ImageFormatGroup {
         return 'yuv420';
       case ImageFormatGroup.jpeg:
         return 'jpeg';
+      case ImageFormatGroup.nv21:
+        return 'nv21';
       case ImageFormatGroup.unknown:
         return 'unknown';
     }

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.4
+version: 2.4.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,10 +4,10 @@ repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.3.4
+version: 2.4.0
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=3.0.0"
 
 dependencies:

--- a/packages/camera/camera_platform_interface/pubspec.yaml
+++ b/packages/camera/camera_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 2.4.0
+version: 2.3.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/camera/camera_platform_interface/test/types/image_group_test.dart
+++ b/packages/camera/camera_platform_interface/test/types/image_group_test.dart
@@ -11,6 +11,7 @@ void main() {
       expect(ImageFormatGroup.bgra8888.name(), 'bgra8888');
       expect(ImageFormatGroup.yuv420.name(), 'yuv420');
       expect(ImageFormatGroup.jpeg.name(), 'jpeg');
+      expect(ImageFormatGroup.nv21.name(), 'nv21');
       expect(ImageFormatGroup.unknown.name(), 'unknown');
     });
   });


### PR DESCRIPTION
This is part 1 of [!6985 ](https://github.com/flutter/plugins/pull/6985) which adds support for NV21 image streaming on Android. It adds NV21 as an option in `ImageFormatGroup`.

This should be merged first because the updates to `camera` and `camera_android` in parts 2/3 both require this change.

*List which issues are fixed by this PR. You must list at least one issue.*
* https://github.com/flutter/flutter/issues/118350

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
