### PR TITLE
[in_app_purchase] Prep for more const widgets

### DIFF
--- a/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3
+
+* Ignores a lint in the example app for backwards compatibility.
+
 ## 3.1.2
 
 * Updates example code for `use_build_context_synchronously` lint.

--- a/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
@@ -164,7 +164,8 @@ class _MyAppState extends State<_MyApp> {
     }
     if (_purchasePending) {
       stack.add(
-        Stack(
+        // TODO(goderbauer): Make this const when that's available on stable.
+        Stack( // ignore: prefer_const_constructors
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase/example/lib/main.dart
@@ -165,7 +165,8 @@ class _MyAppState extends State<_MyApp> {
     if (_purchasePending) {
       stack.add(
         // TODO(goderbauer): Make this const when that's available on stable.
-        Stack( // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors
+        Stack(
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase
 description: A Flutter plugin for in-app purchases. Exposes APIs for making in-app purchases through the App Store and Google Play.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 3.1.2
+version: 3.1.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_android/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.2.4
 
 * Updates minimum Flutter version to 3.0.
+* Ignores a lint in the example app for backwards compatibility.
 
 ## 0.2.3+9
 

--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -157,7 +157,8 @@ class _MyAppState extends State<_MyApp> {
     if (_purchasePending) {
       stack.add(
         // TODO(goderbauer): Make this const when that's available on stable.
-        Stack( // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors
+        Stack(
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_android/example/lib/main.dart
@@ -156,7 +156,8 @@ class _MyAppState extends State<_MyApp> {
     }
     if (_purchasePending) {
       stack.add(
-        Stack(
+        // TODO(goderbauer): Make this const when that's available on stable.
+        Stack( // ignore: prefer_const_constructors
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_android
 description: An implementation for the Android platform of the Flutter `in_app_purchase` plugin. This uses the Android BillingClient APIs.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.2.3+9
+version: 0.2.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,6 +1,7 @@
-## NEXT
+## 0.3.5
 
 * Updates minimum Flutter version to 3.0.
+* Ignores a lint in the example app for backwards compatibility.
 
 ## 0.3.4+1
 

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -157,7 +157,8 @@ class _MyAppState extends State<_MyApp> {
     if (_purchasePending) {
       stack.add(
         // TODO(goderbauer): Make this const when that's available on stable.
-        Stack( // ignore: prefer_const_constructors
+        // ignore: prefer_const_constructors
+        Stack(
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/lib/main.dart
@@ -156,7 +156,8 @@ class _MyAppState extends State<_MyApp> {
     }
     if (_purchasePending) {
       stack.add(
-        Stack(
+        // TODO(goderbauer): Make this const when that's available on stable.
+        Stack( // ignore: prefer_const_constructors
           children: const <Widget>[
             Opacity(
               opacity: 0.3,

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.4+1
+version: 0.3.5
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/119195 will make a few more widgets const. This prepares the examples of the `in_app_purchase` plugin for that change.

I chose to ignore the resulting lint for now to ensure that the examples continue to work on older versions of Flutter. Once the change referenced above is part of the oldest Flutter version supported by the plugins, we can resolve the TODO, remove the ignore, and make the widgets in question const.