### PR TITLE
[ci] Increase timeouts for platform_tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -79,7 +79,7 @@ targets:
   # https://github.com/flutter/plugins/pull/5693#issuecomment-1126011089
   - name: Mac_x64 ios_platform_tests_1_of_4 master
     recipe: plugins/plugins
-    timeout: 30
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
@@ -88,7 +88,7 @@ targets:
 
   - name: Mac_x64 ios_platform_tests_2_of_4 master
     recipe: plugins/plugins
-    timeout: 30
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
@@ -97,7 +97,7 @@ targets:
 
   - name: Mac_x64 ios_platform_tests_3_of_4 master
     recipe: plugins/plugins
-    timeout: 30
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
@@ -106,7 +106,7 @@ targets:
 
   - name: Mac_x64 ios_platform_tests_4_of_4 master
     recipe: plugins/plugins
-    timeout: 30
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       version_file: flutter_master.version
@@ -117,7 +117,7 @@ targets:
   - name: Mac_x64 ios_platform_tests_1_of_4 stable
     recipe: plugins/plugins
     presubmit: false
-    timeout: 30
+    timeout: 60
     properties:
       channel: stable
       add_recipes_cq: "true"
@@ -128,7 +128,7 @@ targets:
   - name: Mac_x64 ios_platform_tests_2_of_4 stable
     recipe: plugins/plugins
     presubmit: false
-    timeout: 30
+    timeout: 60
     properties:
       channel: stable
       add_recipes_cq: "true"
@@ -139,7 +139,7 @@ targets:
   - name: Mac_x64 ios_platform_tests_3_of_4 stable
     recipe: plugins/plugins
     presubmit: false
-    timeout: 30
+    timeout: 60
     properties:
       channel: stable
       add_recipes_cq: "true"
@@ -150,7 +150,7 @@ targets:
   - name: Mac_x64 ios_platform_tests_4_of_4 stable
     recipe: plugins/plugins
     presubmit: false
-    timeout: 30
+    timeout: 60
     properties:
       channel: stable
       add_recipes_cq: "true"
@@ -160,7 +160,7 @@ targets:
 
   - name: Windows win32-platform_tests master
     recipe: plugins/plugins
-    timeout: 30
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml
@@ -173,7 +173,8 @@ targets:
 
   - name: Windows win32-platform_tests stable
     recipe: plugins/plugins
-    timeout: 30
+    presubmit: false
+    timeout: 60
     properties:
       add_recipes_cq: "true"
       target_file: windows_build_and_platform_tests.yaml


### PR DESCRIPTION
`platform_tests` are our most time-consuming tests; 30 minutes isn't always enough to run them. Increase timeouts to 60 minutes so that we aren't getting timeouts from tests that are still running.

Hopefully this will resolve the recent post-submit failures.

Also disables Windows `platform_tests` for stable in presubmit, matching other platforms.