### PR TITLE
[image_picker_android] Adds Android 13 photo picker functionality

### DIFF
--- a/packages/image_picker/image_picker_android/CHANGELOG.md
+++ b/packages/image_picker/image_picker_android/CHANGELOG.md
@@ -1,5 +1,7 @@
-## NEXT
+## 0.8.6
 
+* Adds Android 13 photo picker functionality if SDK version is at least 33.
+* Bumps compileSdkVersion from 31 to 33
 * Updates minimum Flutter version to 3.0.
 
 ## 0.8.5+5

--- a/packages/image_picker/image_picker_android/android/build.gradle
+++ b/packages/image_picker/image_picker_android/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/image_picker/image_picker_android/android/gradle.properties
+++ b/packages/image_picker/image_picker_android/android/gradle.properties
@@ -1,0 +1,14 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Fri Jan 27 08:52:19 CST 2023
+org.gradle.jvmargs=-Xmx1536M -Dkotlin.daemon.jvm.options\="-Xmx1536M"

--- a/packages/image_picker/image_picker_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/image_picker/image_picker_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -253,7 +253,9 @@ public class ImagePickerDelegate
   }
 
   private void launchPickVideoFromGalleryIntent() {
-    Intent pickVideoIntent = new Intent(Intent.ACTION_GET_CONTENT);
+    boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
+
+    Intent pickVideoIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     pickVideoIntent.setType("video/*");
 
     activity.startActivityForResult(pickVideoIntent, REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY);
@@ -325,16 +327,21 @@ public class ImagePickerDelegate
   }
 
   private void launchPickImageFromGalleryIntent() {
-    Intent pickImageIntent = new Intent(Intent.ACTION_GET_CONTENT);
+    boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
+    Intent pickImageIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     pickImageIntent.setType("image/*");
-
     activity.startActivityForResult(pickImageIntent, REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY);
   }
 
   private void launchMultiPickImageFromGalleryIntent() {
-    Intent pickImageIntent = new Intent(Intent.ACTION_GET_CONTENT);
+    boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
+    Intent pickImageIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      pickImageIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+      if (isPhotoPickerAvailable) {
+        pickImageIntent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, ImagePickerUtils.getPickImagesMaxLimit());
+      } else {
+        pickImageIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+      }
     }
     pickImageIntent.setType("image/*");
 

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -75,10 +75,20 @@ enum CameraDevice {
 public class ImagePickerDelegate
     implements PluginRegistry.ActivityResultListener,
         PluginRegistry.RequestPermissionsResultListener {
+  @VisibleForTesting
+  static final int REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER = 2341;
+
   @VisibleForTesting static final int REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY = 2342;
   @VisibleForTesting static final int REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA = 2343;
   @VisibleForTesting static final int REQUEST_CAMERA_IMAGE_PERMISSION = 2345;
   @VisibleForTesting static final int REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY = 2346;
+
+  @VisibleForTesting
+  static final int REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER = 2347;
+
+  @VisibleForTesting
+  static final int REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY_USING_PHOTO_PICKER = 2351;
+
   @VisibleForTesting static final int REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY = 2352;
   @VisibleForTesting static final int REQUEST_CODE_TAKE_VIDEO_WITH_CAMERA = 2353;
   @VisibleForTesting static final int REQUEST_CAMERA_VIDEO_PERMISSION = 2355;
@@ -259,8 +269,12 @@ public class ImagePickerDelegate
         new Intent(
             isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     pickVideoIntent.setType("video/*");
+    int requestCode =
+        isPhotoPickerAvailable
+            ? REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY_USING_PHOTO_PICKER
+            : REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY;
 
-    activity.startActivityForResult(pickVideoIntent, REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY);
+    activity.startActivityForResult(pickVideoIntent, requestCode);
   }
 
   public void takeVideoWithCamera(MethodCall methodCall, MethodChannel.Result result) {
@@ -333,8 +347,12 @@ public class ImagePickerDelegate
     Intent pickImageIntent =
         new Intent(
             isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
+    int requestCode =
+        isPhotoPickerAvailable
+            ? REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER
+            : REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY;
     pickImageIntent.setType("image/*");
-    activity.startActivityForResult(pickImageIntent, REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY);
+    activity.startActivityForResult(pickImageIntent, requestCode);
   }
 
   private void launchMultiPickImageFromGalleryIntent() {
@@ -342,6 +360,7 @@ public class ImagePickerDelegate
     Intent pickImageIntent =
         new Intent(
             isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
+
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       if (isPhotoPickerAvailable) {
         pickImageIntent.putExtra(
@@ -351,8 +370,11 @@ public class ImagePickerDelegate
       }
     }
     pickImageIntent.setType("image/*");
-
-    activity.startActivityForResult(pickImageIntent, REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY);
+    int requestCode =
+        isPhotoPickerAvailable
+            ? REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER
+            : REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY;
+    activity.startActivityForResult(pickImageIntent, requestCode);
   }
 
   public void takeImageWithCamera(MethodCall methodCall, MethodChannel.Result result) {

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerDelegate.java
@@ -255,7 +255,9 @@ public class ImagePickerDelegate
   private void launchPickVideoFromGalleryIntent() {
     boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
 
-    Intent pickVideoIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
+    Intent pickVideoIntent =
+        new Intent(
+            isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     pickVideoIntent.setType("video/*");
 
     activity.startActivityForResult(pickVideoIntent, REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY);
@@ -328,17 +330,22 @@ public class ImagePickerDelegate
 
   private void launchPickImageFromGalleryIntent() {
     boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
-    Intent pickImageIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
+    Intent pickImageIntent =
+        new Intent(
+            isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     pickImageIntent.setType("image/*");
     activity.startActivityForResult(pickImageIntent, REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY);
   }
 
   private void launchMultiPickImageFromGalleryIntent() {
     boolean isPhotoPickerAvailable = ImagePickerUtils.isPhotoPickerAvailable();
-    Intent pickImageIntent = new Intent(isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
+    Intent pickImageIntent =
+        new Intent(
+            isPhotoPickerAvailable ? MediaStore.ACTION_PICK_IMAGES : Intent.ACTION_GET_CONTENT);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       if (isPhotoPickerAvailable) {
-        pickImageIntent.putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, ImagePickerUtils.getPickImagesMaxLimit());
+        pickImageIntent.putExtra(
+            MediaStore.EXTRA_PICK_IMAGES_MAX, ImagePickerUtils.getPickImagesMaxLimit());
       } else {
         pickImageIntent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
       }

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerUtils.java
@@ -12,7 +12,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.MediaStore;
-
 import java.util.Arrays;
 
 final class ImagePickerUtils {
@@ -32,7 +31,8 @@ final class ImagePickerUtils {
   }
 
   static boolean isPhotoPickerAvailable() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
       return getExtensionVersion(Build.VERSION_CODES.R) >= 2;
     } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       return true;

--- a/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerUtils.java
+++ b/packages/image_picker/image_picker_android/android/src/main/java/io/flutter/plugins/imagepicker/ImagePickerUtils.java
@@ -4,11 +4,15 @@
 
 package io.flutter.plugins.imagepicker;
 
+import static android.os.ext.SdkExtensions.getExtensionVersion;
+
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.provider.MediaStore;
+
 import java.util.Arrays;
 
 final class ImagePickerUtils {
@@ -24,6 +28,24 @@ final class ImagePickerUtils {
     } catch (PackageManager.NameNotFoundException e) {
       e.printStackTrace();
       return false;
+    }
+  }
+
+  static boolean isPhotoPickerAvailable() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      return getExtensionVersion(Build.VERSION_CODES.R) >= 2;
+    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  static int getPickImagesMaxLimit() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      return MediaStore.getPickImagesMaxLimit();
+    } else {
+      return 0;
     }
   }
 

--- a/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
+++ b/packages/image_picker/image_picker_android/android/src/test/java/io/flutter/plugins/imagepicker/ImagePickerDelegateTest.java
@@ -35,12 +35,16 @@ import java.util.Map;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+@RunWith(RobolectricTestRunner.class)
 public class ImagePickerDelegateTest {
   private static final Double WIDTH = 10.0;
   private static final Double HEIGHT = 10.0;
@@ -134,6 +138,8 @@ public class ImagePickerDelegateTest {
     verifyNoMoreInteractions(mockResult);
   }
 
+  @Test
+  @Config(sdk = 30)
   public void
       chooseImageFromGallery_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
     when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
@@ -145,6 +151,87 @@ public class ImagePickerDelegateTest {
     verify(mockActivity)
         .startActivityForResult(
             any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY));
+  }
+
+  @Test
+  @Config(minSdk = 33)
+  public void
+      chooseImageFromGallery_WithPhotoPicker_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
+    when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
+        .thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.chooseImageFromGallery(mockMethodCall, mockResult);
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class),
+            eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER));
+  }
+
+  @Test
+  @Config(sdk = 30)
+  public void
+      chooseMultiImageFromGallery_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
+    when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
+        .thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.chooseMultiImageFromGallery(mockMethodCall, mockResult);
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class),
+            eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY));
+  }
+
+  @Test
+  @Config(minSdk = 33)
+  public void
+      chooseMultiImageFromGallery_WithPhotoPicker_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
+    when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
+        .thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.chooseMultiImageFromGallery(mockMethodCall, mockResult);
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class),
+            eq(
+                ImagePickerDelegate
+                    .REQUEST_CODE_CHOOSE_MULTI_IMAGE_FROM_GALLERY_USING_PHOTO_PICKER));
+  }
+
+  @Test
+  @Config(sdk = 30)
+  public void
+      chooseVideoFromGallery_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
+    when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
+        .thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.chooseVideoFromGallery(mockMethodCall, mockResult);
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class), eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY));
+  }
+
+  @Test
+  @Config(minSdk = 33)
+  public void
+      chooseVideoFromGallery_WithPhotoPicker_WhenHasExternalStoragePermission_LaunchesChooseFromGalleryIntent() {
+    when(mockPermissionManager.isPermissionGranted(Manifest.permission.READ_EXTERNAL_STORAGE))
+        .thenReturn(true);
+
+    ImagePickerDelegate delegate = createDelegate();
+    delegate.chooseVideoFromGallery(mockMethodCall, mockResult);
+
+    verify(mockActivity)
+        .startActivityForResult(
+            any(Intent.class),
+            eq(ImagePickerDelegate.REQUEST_CODE_CHOOSE_VIDEO_FROM_GALLERY_USING_PHOTO_PICKER));
   }
 
   @Test
@@ -350,6 +437,7 @@ public class ImagePickerDelegateTest {
   @Test
   public void onActivityResult_WhenImageTakenWithCamera_AndNoResizeNeeded_FinishesWithImagePath() {
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
+    when(cache.retrievePendingCameraMediaUriPath()).thenReturn("testString");
 
     delegate.onActivityResult(
         ImagePickerDelegate.REQUEST_CODE_TAKE_IMAGE_WITH_CAMERA, Activity.RESULT_OK, mockIntent);
@@ -362,6 +450,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenImageTakenWithCamera_AndResizeNeeded_FinishesWithScaledImagePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(cache.retrievePendingCameraMediaUriPath()).thenReturn("testString");
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
@@ -375,6 +464,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenVideoTakenWithCamera_AndResizeParametersSupplied_FinishesWithFilePath() {
     when(mockMethodCall.argument("maxWidth")).thenReturn(WIDTH);
+    when(cache.retrievePendingCameraMediaUriPath()).thenReturn("testString");
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(
@@ -388,6 +478,7 @@ public class ImagePickerDelegateTest {
   public void
       onActivityResult_WhenVideoTakenWithCamera_AndMaxDurationParametersSupplied_FinishesWithFilePath() {
     when(mockMethodCall.argument("maxDuration")).thenReturn(MAX_DURATION);
+    when(cache.retrievePendingCameraMediaUriPath()).thenReturn("testString");
 
     ImagePickerDelegate delegate = createDelegateWithPendingResultAndMethodCall();
     delegate.onActivityResult(

--- a/packages/image_picker/image_picker_android/example/android/app/build.gradle
+++ b/packages/image_picker/image_picker_android/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     testOptions.unitTests.includeAndroidResources = true
 
     lintOptions {

--- a/packages/image_picker/image_picker_android/pubspec.yaml
+++ b/packages/image_picker/image_picker_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: image_picker_android
 description: Android implementation of the image_picker plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/image_picker/image_picker_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+image_picker%22
-version: 0.8.5+5
+version: 0.8.6
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
**NOTE**: This is my first PR in the Flutter repo, I am also not a Java developer so extra scrutiny is likely required :) I'm also not sure what tests should be added. The functionality of the new photo picker is the same as the previous, and all the current tests pass. The only thing I can think of is maybe it would be good to test that devices running < SDK 33 use the old image picker, and devices running > SDK 33 use the new photo picker. I that is the case I'll need a bit of direction as I'm not sure how I can test that.

**Description**
This PR adds the new Android 13 photo picker functionality to Android devices running SDK version 33 or later as well as bumps the compileSdkVersion from 31 to 33. If an Android device is older, it will use the previous standard image picker. Below are two devices, the left running SDK 30 and the right running SDK 33.

SDK 30             |  SDK 33
:-------------------------:|:-------------------------:
![sdk30-photo-picker](https://user-images.githubusercontent.com/16527593/215168722-36c04871-aa5b-46d4-a231-c9bbd6e5bc10.gif)  |  ![sdk33-photo-picker](https://user-images.githubusercontent.com/16527593/215168683-9b1cdf78-ef99-487d-b19c-ebd0ea5b5f77.gif)

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/104250

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].* N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
