### PR TITLE
[ci] Part 1 of swapping iOS platform test arch

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -188,7 +188,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 3 --shardCount 4"
 
-  - name: Mac_arm64 ios_platform_tests_1_of_4 master
+  - name: Mac_arm64 ios_platform_tests_1_of_5 master
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -196,9 +196,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 0 --shardCount 4"
+      package_sharding: "--shardIndex 0 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_2_of_4 master
+  - name: Mac_arm64 ios_platform_tests_2_of_5 master
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -206,9 +206,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 1 --shardCount 4"
+      package_sharding: "--shardIndex 1 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_3_of_4 master
+  - name: Mac_arm64 ios_platform_tests_3_of_5 master
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -216,9 +216,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 2 --shardCount 4"
+      package_sharding: "--shardIndex 2 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_4_of_4 master
+  - name: Mac_arm64 ios_platform_tests_4_of_5 master
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -226,7 +226,17 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_master.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 3 --shardCount 4"
+      package_sharding: "--shardIndex 3 --shardCount 5"
+
+  - name: Mac_arm64 ios_platform_tests_5_of_5 master
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 4 --shardCount 5"
 
   # Don't run full platform tests on both channels in pre-submit.
   - name: Mac_x64 ios_platform_tests_1_of_4 stable

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -283,7 +283,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 3 --shardCount 4"
 
-  - name: Mac_arm64 ios_platform_tests_1_of_4 stable
+  - name: Mac_arm64 ios_platform_tests_shard_1 stable - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     presubmit: false
@@ -293,9 +293,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 0 --shardCount 4"
+      package_sharding: "--shardIndex 0 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_2_of_4 stable
+  - name: Mac_arm64 ios_platform_tests_shard_2 stable - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     presubmit: false
@@ -305,9 +305,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 1 --shardCount 4"
+      package_sharding: "--shardIndex 1 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_3_of_4 stable
+  - name: Mac_arm64 ios_platform_tests_shard_3 stable - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     presubmit: false
@@ -317,9 +317,9 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 2 --shardCount 4"
+      package_sharding: "--shardIndex 2 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_4_of_4 stable
+  - name: Mac_arm64 ios_platform_tests_shard_4 stable - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     presubmit: false
@@ -329,7 +329,19 @@ targets:
       add_recipes_cq: "true"
       version_file: flutter_stable.version
       target_file: ios_platform_tests.yaml
-      package_sharding: "--shardIndex 3 --shardCount 4"
+      package_sharding: "--shardIndex 3 --shardCount 5"
+
+  - name: Mac_arm64 ios_platform_tests_shard_5 stable - plugins
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 4 --shardCount 5"
 
   - name: Windows win32-platform_tests master
     recipe: plugins/plugins

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -129,6 +129,26 @@ targets:
       version_file: flutter_stable.version
       target_file: ios_build_all_plugins.yaml
 
+  - name: Mac_x64 ios_build_all_plugins master
+    bringup: true # New task, replaces ARM version
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      channel: master
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_build_all_plugins.yaml
+
+  - name: Mac_x64 ios_build_all_plugins stable
+    bringup: true # New task, replaces ARM version
+    recipe: plugins/plugins
+    timeout: 30
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_build_all_plugins.yaml
+
   # TODO(stuartmorgan): Swap the architecture of this and ios_build_all_plugins
   # once simulator tests are reliable on the ARM infrastructure. See discussion
   # at https://github.com/flutter/plugins/pull/5693#issuecomment-1126011089
@@ -160,6 +180,46 @@ targets:
       package_sharding: "--shardIndex 2 --shardCount 4"
 
   - name: Mac_x64 ios_platform_tests_4_of_4 master
+    recipe: plugins/plugins
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 3 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_1_of_4 master
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 0 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_2_of_4 master
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 1 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_3_of_4 master
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      version_file: flutter_master.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 2 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_4_of_4 master
+    bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
     properties:
@@ -203,6 +263,54 @@ targets:
       package_sharding: "--shardIndex 2 --shardCount 4"
 
   - name: Mac_x64 ios_platform_tests_4_of_4 stable
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 3 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_1_of_4 stable
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 0 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_2_of_4 stable
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 1 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_3_of_4 stable
+    bringup: true # New task; will replace Intel version
+    recipe: plugins/plugins
+    presubmit: false
+    timeout: 60
+    properties:
+      channel: stable
+      add_recipes_cq: "true"
+      version_file: flutter_stable.version
+      target_file: ios_platform_tests.yaml
+      package_sharding: "--shardIndex 2 --shardCount 4"
+
+  - name: Mac_arm64 ios_platform_tests_4_of_4 stable
+    bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -188,7 +188,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 3 --shardCount 4"
 
-  - name: Mac_arm64 ios_platform_tests_1_of_5 master
+  - name: Mac_arm64 ios_platform_tests_shard_1 master - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -198,7 +198,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 0 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_2_of_5 master
+  - name: Mac_arm64 ios_platform_tests_shard_2 master - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -208,7 +208,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 1 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_3_of_5 master
+  - name: Mac_arm64 ios_platform_tests_shard_3 master - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -218,7 +218,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 2 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_4_of_5 master
+  - name: Mac_arm64 ios_platform_tests_shard_4 master - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60
@@ -228,7 +228,7 @@ targets:
       target_file: ios_platform_tests.yaml
       package_sharding: "--shardIndex 3 --shardCount 5"
 
-  - name: Mac_arm64 ios_platform_tests_5_of_5 master
+  - name: Mac_arm64 ios_platform_tests_shard_5 master - plugins
     bringup: true # New task; will replace Intel version
     recipe: plugins/plugins
     timeout: 60


### PR DESCRIPTION
Adds Intel versions of iOS build-all and ARM versions of iOS platform tests, as part one of swapping them. Once the new tasks propagate, they will be brought out of bringup mode and the old versions removed.

These were on the opposite architectures because of issues with running the platform tests on Cirrus ARM VMs, and then were ported as-is from Cirrus to LUCI, but now that macOS ARM works on LUCI we can switch to the desired configuration.

Also increases sharding from 4 to 5 since the tests have gotten longer over time due to increased testing and more federation, and changes the naming scheme to be more future-proof.