### PR TITLE
[in_app_puchase_storekit] handle `appStoreReceiptURL` is nil

### DIFF
--- a/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
+++ b/packages/in_app_purchase/in_app_purchase_storekit/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5+2
+
+* Fix a crash when `appStoreReceiptURL` is nil.
+
 ## 0.3.5+1
 
 * Uses the new `sharedDarwinSource` flag when available.

--- a/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAPReceiptManager.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/darwin/Classes/FIAPReceiptManager.m
@@ -21,6 +21,9 @@
 
 - (NSString *)retrieveReceiptWithError:(FlutterError **)flutterError {
   NSURL *receiptURL = [[NSBundle mainBundle] appStoreReceiptURL];
+  if (!receiptURL) {
+    return nil;
+  }
   NSError *receiptError;
   NSData *receipt = [self getReceiptData:receiptURL error:&receiptError];
   if (!receipt || receiptError) {

--- a/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchasePluginTests.m
+++ b/packages/in_app_purchase/in_app_purchase_storekit/example/shared/RunnerTests/InAppPurchasePluginTests.m
@@ -313,6 +313,23 @@
   XCTAssert([result isKindOfClass:[NSString class]]);
 }
 
+- (void)testRetrieveReceiptDataNil {
+  NSBundle *mockBundle = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub(mockBundle.appStoreReceiptURL).andReturn(nil);
+  XCTestExpectation *expectation = [self expectationWithDescription:@"nil receipt data retrieved"];
+  FlutterMethodCall *call = [FlutterMethodCall
+      methodCallWithMethodName:@"-[InAppPurchasePlugin retrieveReceiptData:result:]"
+                     arguments:nil];
+  __block NSDictionary *result;
+  [self.plugin handleMethodCall:call
+                         result:^(id r) {
+                           result = r;
+                           [expectation fulfill];
+                         }];
+  [self waitForExpectations:@[ expectation ] timeout:5];
+  XCTAssertNil(result);
+}
+
 - (void)testRetrieveReceiptDataError {
   XCTestExpectation *expectation = [self expectationWithDescription:@"receipt data retrieved"];
   FlutterMethodCall *call = [FlutterMethodCall

--- a/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
+++ b/packages/in_app_purchase/in_app_purchase_storekit/pubspec.yaml
@@ -2,7 +2,7 @@ name: in_app_purchase_storekit
 description: An implementation for the iOS and macOS platforms of the Flutter `in_app_purchase` plugin. This uses the StoreKit Framework.
 repository: https://github.com/flutter/plugins/tree/main/packages/in_app_purchase/in_app_purchase_storekit
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+in_app_purchase%22
-version: 0.3.5+1
+version: 0.3.5+2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Prevent crash when `appStoreReceiptURL` is nil. Retrieve receipt is documented as nullable in https://developer.apple.com/documentation/foundation/nsbundle/1407276-appstorereceipturl

Fixes https://github.com/flutter/flutter/issues/117842

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
