### PR TITLE
[camera_android] Default to legacy recording profile when EncoderProfiles unavailable

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.4
+
+* Temporarily fixes issue with requested video profiles being null by falling back to deprecated behavior in that case.
+
 ## 0.10.3
 
 * Adds back use of Optional type.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -258,8 +258,11 @@ class Camera
 
     MediaRecorderBuilder mediaRecorderBuilder;
 
-    if (Build.VERSION.SDK_INT >= 31) {
-      mediaRecorderBuilder = new MediaRecorderBuilder(getRecordingProfile(), outputFilePath);
+    // TODO(camsim99): Revert changes that allow legacy code to be used when recordingProfile is null
+    // once this has largely been fixed on the Android side.
+    EncoderProfiles recordingProfile = getRecordingProfile();
+    if (Build.VERSION.SDK_INT >= 31 && recordingProfile != null) {
+      mediaRecorderBuilder = new MediaRecorderBuilder(recordingProfile, outputFilePath);
     } else {
       mediaRecorderBuilder = new MediaRecorderBuilder(getRecordingProfileLegacy(), outputFilePath);
     }

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -261,7 +261,7 @@ class Camera
     // TODO(camsim99): Revert changes that allow legacy code to be used when recordingProfile is null
     // once this has largely been fixed on the Android side. https://github.com/flutter/flutter/issues/119668
     EncoderProfiles recordingProfile = getRecordingProfile();
-    if (Build.VERSION.SDK_INT >= 31 && recordingProfile != null) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && recordingProfile != null) {
       mediaRecorderBuilder = new MediaRecorderBuilder(recordingProfile, outputFilePath);
     } else {
       mediaRecorderBuilder = new MediaRecorderBuilder(getRecordingProfileLegacy(), outputFilePath);

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -259,7 +259,7 @@ class Camera
     MediaRecorderBuilder mediaRecorderBuilder;
 
     // TODO(camsim99): Revert changes that allow legacy code to be used when recordingProfile is null
-    // once this has largely been fixed on the Android side.
+    // once this has largely been fixed on the Android side. https://github.com/flutter/flutter/issues/119668
     EncoderProfiles recordingProfile = getRecordingProfile();
     if (Build.VERSION.SDK_INT >= 31 && recordingProfile != null) {
       mediaRecorderBuilder = new MediaRecorderBuilder(recordingProfile, outputFilePath);

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/features/resolution/ResolutionFeature.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/features/resolution/ResolutionFeature.java
@@ -114,7 +114,7 @@ public class ResolutionFeature extends CameraFeature<ResolutionPreset> {
     if (preset.ordinal() > ResolutionPreset.high.ordinal()) {
       preset = ResolutionPreset.high;
     }
-    if (Build.VERSION.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       EncoderProfiles profile =
           getBestAvailableCamcorderProfileForResolutionPreset(cameraId, preset);
       List<EncoderProfiles.VideoProfile> videoProfiles = profile.getVideoProfiles();
@@ -126,6 +126,8 @@ public class ResolutionFeature extends CameraFeature<ResolutionPreset> {
     }
 
     @SuppressWarnings("deprecation")
+    // TODO(camsim99): Suppression is currently safe because legacy code is used as a fallback for SDK >= S.
+    // This should be removed when reverting that fallback behavior: https://github.com/flutter/flutter/issues/119668.
     CamcorderProfile profile =
         getBestAvailableCamcorderProfileForResolutionPresetLegacy(cameraId, preset);
     return new Size(profile.videoFrameWidth, profile.videoFrameHeight);
@@ -238,7 +240,7 @@ public class ResolutionFeature extends CameraFeature<ResolutionPreset> {
     }
     boolean captureSizeCalculated = false;
 
-    if (Build.VERSION.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
       recordingProfileLegacy = null;
       recordingProfile =
           getBestAvailableCamcorderProfileForResolutionPreset(cameraId, resolutionPreset);

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/features/resolution/ResolutionFeature.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/features/resolution/ResolutionFeature.java
@@ -120,13 +120,15 @@ public class ResolutionFeature extends CameraFeature<ResolutionPreset> {
       List<EncoderProfiles.VideoProfile> videoProfiles = profile.getVideoProfiles();
       EncoderProfiles.VideoProfile defaultVideoProfile = videoProfiles.get(0);
 
-      return new Size(defaultVideoProfile.getWidth(), defaultVideoProfile.getHeight());
-    } else {
-      @SuppressWarnings("deprecation")
-      CamcorderProfile profile =
-          getBestAvailableCamcorderProfileForResolutionPresetLegacy(cameraId, preset);
-      return new Size(profile.videoFrameWidth, profile.videoFrameHeight);
+      if (defaultVideoProfile != null) {
+        return new Size(defaultVideoProfile.getWidth(), defaultVideoProfile.getHeight());
+      }
     }
+
+    @SuppressWarnings("deprecation")
+    CamcorderProfile profile =
+        getBestAvailableCamcorderProfileForResolutionPresetLegacy(cameraId, preset);
+    return new Size(profile.videoFrameWidth, profile.videoFrameHeight);
   }
 
   /**
@@ -234,15 +236,24 @@ public class ResolutionFeature extends CameraFeature<ResolutionPreset> {
     if (!checkIsSupported()) {
       return;
     }
+    boolean captureSizeCalculated = false;
 
     if (Build.VERSION.SDK_INT >= 31) {
+      recordingProfileLegacy = null;
       recordingProfile =
           getBestAvailableCamcorderProfileForResolutionPreset(cameraId, resolutionPreset);
       List<EncoderProfiles.VideoProfile> videoProfiles = recordingProfile.getVideoProfiles();
 
       EncoderProfiles.VideoProfile defaultVideoProfile = videoProfiles.get(0);
-      captureSize = new Size(defaultVideoProfile.getWidth(), defaultVideoProfile.getHeight());
-    } else {
+
+      if (defaultVideoProfile != null) {
+        captureSizeCalculated = true;
+        captureSize = new Size(defaultVideoProfile.getWidth(), defaultVideoProfile.getHeight());
+      }
+    }
+
+    if (!captureSizeCalculated) {
+      recordingProfile = null;
       @SuppressWarnings("deprecation")
       CamcorderProfile camcorderProfile =
           getBestAvailableCamcorderProfileForResolutionPresetLegacy(cameraId, resolutionPreset);

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
@@ -75,7 +75,7 @@ public class MediaRecorderBuilder {
     if (enableAudio) mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
     mediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
 
-    if (Build.VERSION.SDK_INT >= 31) {
+    if (Build.VERSION.SDK_INT >= 31 && encoderProfiles != null) {
       EncoderProfiles.VideoProfile videoProfile = encoderProfiles.getVideoProfiles().get(0);
       EncoderProfiles.AudioProfile audioProfile = encoderProfiles.getAudioProfiles().get(0);
 

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/media/MediaRecorderBuilder.java
@@ -75,7 +75,7 @@ public class MediaRecorderBuilder {
     if (enableAudio) mediaRecorder.setAudioSource(MediaRecorder.AudioSource.MIC);
     mediaRecorder.setVideoSource(MediaRecorder.VideoSource.SURFACE);
 
-    if (Build.VERSION.SDK_INT >= 31 && encoderProfiles != null) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && encoderProfiles != null) {
       EncoderProfiles.VideoProfile videoProfile = encoderProfiles.getVideoProfiles().get(0);
       EncoderProfiles.AudioProfile audioProfile = encoderProfiles.getAudioProfiles().get(0);
 

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/features/resolution/ResolutionFeatureTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/features/resolution/ResolutionFeatureTest.java
@@ -362,23 +362,22 @@ public class ResolutionFeatureTest {
                   });
 
       mockedResolutionFeature
-        .when(
-          () ->
-          ResolutionFeature.getBestAvailableCamcorderProfileForResolutionPresetLegacy(
-            anyInt(), any(ResolutionPreset.class)))
-        .thenAnswer(
-          (Answer<CamcorderProfile>)
-          invocation -> {
-            CamcorderProfile mockCamcorderProfile = mock(CamcorderProfile.class);
-            mockCamcorderProfile.videoFrameWidth = 10;
-            mockCamcorderProfile.videoFrameHeight = 50;
-            return mockCamcorderProfile;
-          }
-        );
+          .when(
+              () ->
+                  ResolutionFeature.getBestAvailableCamcorderProfileForResolutionPresetLegacy(
+                      anyInt(), any(ResolutionPreset.class)))
+          .thenAnswer(
+              (Answer<CamcorderProfile>)
+                  invocation -> {
+                    CamcorderProfile mockCamcorderProfile = mock(CamcorderProfile.class);
+                    mockCamcorderProfile.videoFrameWidth = 10;
+                    mockCamcorderProfile.videoFrameHeight = 50;
+                    return mockCamcorderProfile;
+                  });
 
-        Size testPreviewSize = ResolutionFeature.computeBestPreviewSize(1, ResolutionPreset.max);
-        assertEquals(testPreviewSize.getWidth(), 10);
-        assertEquals(testPreviewSize.getHeight(), 50);
+      Size testPreviewSize = ResolutionFeature.computeBestPreviewSize(1, ResolutionPreset.max);
+      assertEquals(testPreviewSize.getWidth(), 10);
+      assertEquals(testPreviewSize.getHeight(), 50);
     }
   }
 

--- a/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/features/resolution/ResolutionFeatureTest.java
+++ b/packages/camera/camera_android/android/src/test/java/io/flutter/plugins/camera/features/resolution/ResolutionFeatureTest.java
@@ -360,7 +360,6 @@ public class ResolutionFeatureTest {
                     when(mockEncoderProfiles.getVideoProfiles()).thenReturn(videoProfiles);
                     return mockEncoderProfiles;
                   });
-
       mockedResolutionFeature
           .when(
               () ->
@@ -374,6 +373,9 @@ public class ResolutionFeatureTest {
                     mockCamcorderProfile.videoFrameHeight = 50;
                     return mockCamcorderProfile;
                   });
+      mockedResolutionFeature
+          .when(() -> ResolutionFeature.computeBestPreviewSize(1, ResolutionPreset.max))
+          .thenCallRealMethod();
 
       Size testPreviewSize = ResolutionFeature.computeBestPreviewSize(1, ResolutionPreset.max);
       assertEquals(testPreviewSize.getWidth(), 10);
@@ -383,7 +385,8 @@ public class ResolutionFeatureTest {
 
   @Config(minSdk = 31)
   @Test
-  public void resolutionFeatureShouldUseLegacyBehaviorWhenEconderProfilesNull() {
+  public void resolutionFeatureShouldUseLegacyBehaviorWhenEncoderProfilesNull() {
+    beforeLegacy();
     try (MockedStatic<ResolutionFeature> mockedResolutionFeature =
         mockStatic(ResolutionFeature.class)) {
       mockedResolutionFeature
@@ -404,11 +407,21 @@ public class ResolutionFeatureTest {
                     when(mockEncoderProfiles.getVideoProfiles()).thenReturn(videoProfiles);
                     return mockEncoderProfiles;
                   });
+      mockedResolutionFeature
+          .when(
+              () ->
+                  ResolutionFeature.getBestAvailableCamcorderProfileForResolutionPresetLegacy(
+                      anyInt(), any(ResolutionPreset.class)))
+          .thenAnswer(
+              (Answer<CamcorderProfile>)
+                  invocation -> {
+                    CamcorderProfile mockCamcorderProfile = mock(CamcorderProfile.class);
+                    return mockCamcorderProfile;
+                  });
 
       CameraProperties mockCameraProperties = mock(CameraProperties.class);
-      ResolutionPreset mockResolutionPreset = mock(ResolutionPreset.class);
       ResolutionFeature resolutionFeature =
-          new ResolutionFeature(mockCameraProperties, mockResolutionPreset, "testCameraName");
+          new ResolutionFeature(mockCameraProperties, ResolutionPreset.max, cameraName);
 
       assertNotNull(resolutionFeature.getRecordingProfileLegacy());
       assertNull(resolutionFeature.getRecordingProfile());

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android
 description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.3
+version: 0.10.4
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
Lets the resolution feature default to legacy behavior when new behavior using `EncoderProfiles` fails. This is an Android issue that has been fixed in recent build releases, but this temporarily fix the issue while folks are still using older versions.

Loosely based on https://github.com/flutter/plugins/pull/6867 by @MbIXjkee.

Fixes https://github.com/flutter/flutter/issues/109769.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
