### PR TITLE
[various] prepare for more const widgets

### DIFF
--- a/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
+++ b/packages/google_maps_flutter/google_maps_flutter/test/map_creation_test.dart
@@ -29,8 +29,12 @@ void main() {
   ) async {
     // Inject two map widgets...
     await tester.pumpWidget(
+      // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+      // ignore: prefer_const_constructors
       Directionality(
         textDirection: TextDirection.ltr,
+        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+        // ignore: prefer_const_constructors
         child: Column(
           children: const <Widget>[
             GoogleMap(

--- a/packages/local_auth/local_auth/example/lib/main.dart
+++ b/packages/local_auth/local_auth/example/lib/main.dart
@@ -183,6 +183,8 @@ class _MyAppState extends State<MyApp> {
                 if (_isAuthenticating)
                   ElevatedButton(
                     onPressed: _cancelAuthentication,
+                    // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                    // ignore: prefer_const_constructors
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: const <Widget>[
@@ -196,6 +198,8 @@ class _MyAppState extends State<MyApp> {
                     children: <Widget>[
                       ElevatedButton(
                         onPressed: _authenticate,
+                        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                        // ignore: prefer_const_constructors
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[

--- a/packages/local_auth/local_auth_android/example/lib/main.dart
+++ b/packages/local_auth/local_auth_android/example/lib/main.dart
@@ -188,6 +188,8 @@ class _MyAppState extends State<MyApp> {
                 if (_isAuthenticating)
                   ElevatedButton(
                     onPressed: _cancelAuthentication,
+                    // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                    // ignore: prefer_const_constructors
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: const <Widget>[
@@ -201,6 +203,8 @@ class _MyAppState extends State<MyApp> {
                     children: <Widget>[
                       ElevatedButton(
                         onPressed: _authenticate,
+                        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                        // ignore: prefer_const_constructors
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[

--- a/packages/local_auth/local_auth_ios/example/lib/main.dart
+++ b/packages/local_auth/local_auth_ios/example/lib/main.dart
@@ -187,6 +187,8 @@ class _MyAppState extends State<MyApp> {
                 if (_isAuthenticating)
                   ElevatedButton(
                     onPressed: _cancelAuthentication,
+                    // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                    // ignore: prefer_const_constructors
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: const <Widget>[
@@ -200,6 +202,8 @@ class _MyAppState extends State<MyApp> {
                     children: <Widget>[
                       ElevatedButton(
                         onPressed: _authenticate,
+                        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                        // ignore: prefer_const_constructors
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[

--- a/packages/local_auth/local_auth_windows/example/lib/main.dart
+++ b/packages/local_auth/local_auth_windows/example/lib/main.dart
@@ -150,6 +150,8 @@ class _MyAppState extends State<MyApp> {
                 if (_isAuthenticating)
                   ElevatedButton(
                     onPressed: _cancelAuthentication,
+                    // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                    // ignore: prefer_const_constructors
                     child: Row(
                       mainAxisSize: MainAxisSize.min,
                       children: const <Widget>[
@@ -163,6 +165,8 @@ class _MyAppState extends State<MyApp> {
                     children: <Widget>[
                       ElevatedButton(
                         onPressed: _authenticate,
+                        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+                        // ignore: prefer_const_constructors
                         child: Row(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[

--- a/packages/url_launcher/url_launcher/example/lib/encoding.dart
+++ b/packages/url_launcher/url_launcher/example/lib/encoding.dart
@@ -22,8 +22,14 @@ String? encodeQueryParameters(Map<String, String> params) {
 // #enddocregion encode-query-parameters
 
 void main() => runApp(
+      // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+      // ignore: prefer_const_constructors
       MaterialApp(
+        // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+        // ignore: prefer_const_constructors
         home: Material(
+          // TODO(goderbauer): Make this const when this package requires Flutter 3.8 or later.
+          // ignore: prefer_const_constructors
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: const <Widget>[


### PR DESCRIPTION
Similar to https://github.com/flutter/plugins/pull/7030.

https://github.com/flutter/flutter/pull/119673 will make a few more widgets const. This prepares the plugins repo for that change.

I chose to ignore the resulting lint for now to ensure that the plugins continue to work on older versions of Flutter. Once the change referenced above is part of the oldest Flutter version supported by the plugins, we can resolve the TODO, remove the ignore, and make the widgets in question const.