### PR TITLE
[ci] Roll Docker base image to 3.7.0

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -23,7 +23,10 @@ RUN apt-get install -y clang-format
 # - build tools.
 RUN apt-get install -y clang cmake ninja-build file pkg-config
 # - libraries.
-RUN apt-get install -y libgtk-3-dev libblkid-dev liblzma-dev libgcrypt20-dev
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libgtk-3-dev
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libblkid-dev
+RUN apt-get -o Debug::pkgProblemResolver=true install -y liblzma-dev
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libgcrypt20-dev
 # - xvfb to allow running headless.
 RUN apt-get install -y xvfb libegl1-mesa
 

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get install -y clang-format
 # - build tools.
 RUN apt-get install -y clang cmake ninja-build file pkg-config
 # - libraries.
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libegl-mesa0
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libegl1-mesa-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libgtk-3-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libblkid-dev

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get install -y clang-format
 # - build tools.
 RUN apt-get install -y clang cmake ninja-build file pkg-config
 # - libraries.
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libgbm1
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libglapi-mesa
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libegl-mesa0
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libegl1-mesa-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libgtk-3-dev

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get install -y clang-format
 # - build tools.
 RUN apt-get install -y clang cmake ninja-build file pkg-config
 # - libraries.
+RUN apt-get -o Debug::pkgProblemResolver=true install -y libegl1-mesa-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libgtk-3-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y libblkid-dev
 RUN apt-get -o Debug::pkgProblemResolver=true install -y liblzma-dev

--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,8 +1,8 @@
 # The Flutter version is not important here, since the CI scripts update Flutter
 # before running. What matters is that the base image is pinned to minimize
 # unintended changes when modifying this file.
-# This is the hash for the 3.0.0 image.
-FROM cirrusci/flutter@sha256:0224587bba33241cf908184283ec2b544f1b672d87043ead1c00521c368cf844
+# This is the hash for the 3.7.0 image.
+FROM cirrusci/flutter@sha256:5f3e4afb7487351e6dca2659e021c12ee7f74014b87616d982f912322b164c08
 
 RUN apt-get update -y
 


### PR DESCRIPTION
Rolls the Dockerfile's base image forward, so that we're on a newer system image.