### PR TITLE
[webview_flutter_web] Avoids XHR when possible.

### DIFF
--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,6 +1,8 @@
-## NEXT
+## 0.2.2
 
 * Updates minimum Flutter version to 3.0.
+* Updates `WebWebViewController.loadRequest` to only set the src of the iFrame when
+  `LoadRequestParams.headers` is empty and is using the HTTP GET request method.
 
 ## 0.2.1
 

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -5,6 +5,8 @@
   using the HTTP GET request method. [#118573](https://github.com/flutter/flutter/issues/118573).
 * Parses the `content-type` header of XHR responses to extract the correct
   MIME-type and charset. [#118090](https://github.com/flutter/flutter/issues/118090).
+* Sets `width` and `height` of widget the way the Engine wants, to remove distracting
+  warnings from the development console.
 * Updates minimum Flutter version to 3.0.
 
 ## 0.2.1

--- a/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
+++ b/packages/webview_flutter/webview_flutter_web/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## 0.2.2
 
+* Updates `WebWebViewController.loadRequest` to only set the src of the iFrame
+  when `LoadRequestParams.headers` and `LoadRequestParams.body` are empty and is
+  using the HTTP GET request method. [#118573](https://github.com/flutter/flutter/issues/118573).
+* Parses the `content-type` header of XHR responses to extract the correct
+  MIME-type and charset. [#118090](https://github.com/flutter/flutter/issues/118090).
 * Updates minimum Flutter version to 3.0.
-* Updates `WebWebViewController.loadRequest` to only set the src of the iFrame when
-  `LoadRequestParams.headers` is empty and is using the HTTP GET request method.
 
 ## 0.2.1
 

--- a/packages/webview_flutter/webview_flutter_web/README.md
+++ b/packages/webview_flutter/webview_flutter_web/README.md
@@ -21,3 +21,19 @@ yet, so it currently requires extra setup to use:
 
 Once the step above is complete, the APIs from `webview_flutter` listed
 above can be used as normal on web.
+
+## Tests
+
+Tests are contained in the `test` directory. You can run all tests from the root
+of the package with the following command:
+
+```
+$ flutter test --platform chrome
+```
+
+This package uses `package:mockito` in some tests. Mock files can be updated
+from the root of the package like so:
+
+```
+$ flutter pub run build_runner build --delete-conflicting-outputs
+```

--- a/packages/webview_flutter/webview_flutter_web/README.md
+++ b/packages/webview_flutter/webview_flutter_web/README.md
@@ -27,13 +27,13 @@ above can be used as normal on web.
 Tests are contained in the `test` directory. You can run all tests from the root
 of the package with the following command:
 
-```
+```bash
 $ flutter test --platform chrome
 ```
 
 This package uses `package:mockito` in some tests. Mock files can be updated
 from the root of the package like so:
 
-```
+```bash
 $ flutter pub run build_runner build --delete-conflicting-outputs
 ```

--- a/packages/webview_flutter/webview_flutter_web/example/integration_test/webview_flutter_test.dart
+++ b/packages/webview_flutter/webview_flutter_web/example/integration_test/webview_flutter_test.dart
@@ -5,6 +5,10 @@
 import 'dart:html' as html;
 import 'dart:io';
 
+// FIX (dit): Remove these integration tests, or make them run. They currently never fail.
+// (They won't run because they use `dart:io`. If you remove all `dart:io` bits from
+// this file, they start failing with `fail()`, for example.)
+
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/webview_flutter/webview_flutter_web/example/run_test.sh
+++ b/packages/webview_flutter/webview_flutter_web/example/run_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if pgrep -lf chromedriver > /dev/null; then
+  echo "chromedriver is running."
+
+  if [ $# -eq 0 ]; then
+    echo "No target specified, running all tests..."
+    find integration_test/ -iname *_test.dart | xargs -n1 -i -t flutter drive -d web-server --web-port=7357 --browser-name=chrome --driver=test_driver/integration_test.dart --target='{}'
+  else
+    echo "Running test target: $1..."
+    set -x
+    flutter drive -d web-server --web-port=7357 --browser-name=chrome --driver=test_driver/integration_test.dart --target=$1
+  fi
+
+  else
+    echo "chromedriver is not running."
+    echo "Please, check the README.md for instructions on how to use run_test.sh"
+fi
+

--- a/packages/webview_flutter/webview_flutter_web/lib/src/content_type.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/content_type.dart
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Class to represent a content-type header value.
+class ContentType {
+  /// Creates a [ContentType] instance by parsing a "content-type" response [header].
+  ///
+  /// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type
+  /// See: https://httpwg.org/specs/rfc9110.html#media.type
+  ContentType.parse(String header) {
+    final Iterable<String> chunks =
+        header.split(';').map((String e) => e.trim().toLowerCase());
+
+    for (final String chunk in chunks) {
+      if (!chunk.contains('=')) {
+        _mimeType = chunk;
+      } else {
+        final List<String> bits =
+            chunk.split('=').map((String e) => e.trim()).toList();
+        assert(bits.length == 2);
+        switch (bits[0]) {
+          case 'charset':
+            _charset = bits[1];
+            break;
+          case 'boundary':
+            _boundary = bits[1];
+            break;
+          default:
+            throw StateError('Unable to parse "$chunk" in content-type.');
+        }
+      }
+    }
+  }
+
+  String? _mimeType;
+  String? _charset;
+  String? _boundary;
+
+  /// The MIME-type of the resource or the data.
+  String? get mimeType => _mimeType;
+
+  /// The character encoding standard.
+  String? get charset => _charset;
+
+  /// The separation boundary for multipart entities.
+  String? get boundary => _boundary;
+}

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -72,21 +72,27 @@ class WebWebViewController extends PlatformWebViewController {
       throw ArgumentError(
           'LoadRequestParams#uri is required to have a scheme.');
     }
-    final HttpRequest httpReq =
-        await _webWebViewParams.httpRequestFactory.request(
-      params.uri.toString(),
-      method: params.method.serialize(),
-      requestHeaders: params.headers,
-      sendData: params.body,
-    );
-    final String contentType =
-        httpReq.getResponseHeader('content-type') ?? 'text/html';
-    // ignore: unsafe_html
-    _webWebViewParams.iFrame.src = Uri.dataFromString(
-      httpReq.responseText ?? '',
-      mimeType: contentType,
-      encoding: utf8,
-    ).toString();
+
+    if (params.headers.isEmpty && params.method == LoadRequestMethod.get) {
+      // ignore: unsafe_html
+      _webWebViewParams.iFrame.src = params.uri.toString();
+    } else {
+      final HttpRequest httpReq =
+          await _webWebViewParams.httpRequestFactory.request(
+        params.uri.toString(),
+        method: params.method.serialize(),
+        requestHeaders: params.headers,
+        sendData: params.body,
+      );
+      final String contentType =
+          httpReq.getResponseHeader('content-type') ?? 'text/html';
+      // ignore: unsafe_html
+      _webWebViewParams.iFrame.src = Uri.dataFromString(
+        httpReq.responseText ?? '',
+        mimeType: contentType,
+        encoding: utf8,
+      ).toString();
+    }
   }
 }
 

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
-import 'dart:html';
+import 'dart:html' as html;
 
 import 'package:flutter/cupertino.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
@@ -37,7 +37,7 @@ class WebWebViewControllerCreationParams
 
   /// The underlying element used as the WebView.
   @visibleForTesting
-  final IFrameElement iFrame = IFrameElement()
+  final html.IFrameElement iFrame = html.IFrameElement()
     ..id = 'webView${_nextIFrameId++}'
     ..width = '100%'
     ..height = '100%'
@@ -73,7 +73,9 @@ class WebWebViewController extends PlatformWebViewController {
           'LoadRequestParams#uri is required to have a scheme.');
     }
 
-    if (params.headers.isEmpty && params.method == LoadRequestMethod.get) {
+    if (params.headers.isEmpty &&
+        (params.body == null || params.body!.isEmpty) &&
+        params.method == LoadRequestMethod.get) {
       // ignore: unsafe_html
       _webWebViewParams.iFrame.src = params.uri.toString();
     } else {

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -40,8 +40,8 @@ class WebWebViewControllerCreationParams
   @visibleForTesting
   final html.IFrameElement iFrame = html.IFrameElement()
     ..id = 'webView${_nextIFrameId++}'
-    ..width = '100%'
-    ..height = '100%'
+    ..style.width = '100%'
+    ..style.height = '100%'
     ..style.border = 'none';
 }
 

--- a/packages/webview_flutter/webview_flutter_web/pubspec.yaml
+++ b/packages/webview_flutter/webview_flutter_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: webview_flutter_web
 description: A Flutter plugin that provides a WebView widget on web.
 repository: https://github.com/flutter/plugins/tree/main/packages/webview_flutter/webview_flutter_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+webview%22
-version: 0.2.1
+version: 0.2.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/webview_flutter/webview_flutter_web/test/content_type_test.dart
+++ b/packages/webview_flutter/webview_flutter_web/test/content_type_test.dart
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter_web/src/content_type.dart';
+
+void main() {
+  group('ContentType.parse', () {
+    test('basic content-type (lowers case)', () {
+      final ContentType contentType = ContentType.parse('text/pLaIn');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, isNull);
+      expect(contentType.charset, isNull);
+    });
+
+    test('with charset', () {
+      final ContentType contentType =
+          ContentType.parse('text/pLaIn; charset=utf-8');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, isNull);
+      expect(contentType.charset, 'utf-8');
+    });
+
+    test('with boundary', () {
+      final ContentType contentType =
+          ContentType.parse('text/pLaIn; boundary=---xyz');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, '---xyz');
+      expect(contentType.charset, isNull);
+    });
+
+    test('with charset and boundary', () {
+      final ContentType contentType =
+          ContentType.parse('text/pLaIn; charset=utf-8; boundary=---xyz');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, '---xyz');
+      expect(contentType.charset, 'utf-8');
+    });
+
+    test('with boundary and charset', () {
+      final ContentType contentType =
+          ContentType.parse('text/pLaIn; boundary=---xyz; charset=utf-8');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, '---xyz');
+      expect(contentType.charset, 'utf-8');
+    });
+
+    test('with a bunch of whitespace, boundary and charset', () {
+      final ContentType contentType = ContentType.parse(
+          '     text/pLaIn   ; boundary=---xyz;    charset=utf-8    ');
+
+      expect(contentType.mimeType, 'text/plain');
+      expect(contentType.boundary, '---xyz');
+      expect(contentType.charset, 'utf-8');
+    });
+
+    test('empty string', () {
+      final ContentType contentType = ContentType.parse('');
+
+      expect(contentType.mimeType, '');
+      expect(contentType.boundary, isNull);
+      expect(contentType.charset, isNull);
+    });
+
+    test('unknown parameter (throws)', () {
+      expect(() {
+        ContentType.parse('text/pLaIn; wrong=utf-8');
+      }, throwsStateError);
+    });
+  });
+}

--- a/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.dart
+++ b/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.dart
@@ -32,8 +32,8 @@ void main() {
             WebWebViewControllerCreationParams();
 
         expect(params.iFrame.id, contains('webView'));
-        expect(params.iFrame.width, '100%');
-        expect(params.iFrame.height, '100%');
+        expect(params.iFrame.style.width, '100%');
+        expect(params.iFrame.style.height, '100%');
         expect(params.iFrame.style.border, 'none');
       });
     });

--- a/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.mocks.dart
+++ b/packages/webview_flutter/webview_flutter_web/test/web_webview_controller_test.mocks.dart
@@ -55,24 +55,23 @@ class _FakeHttpRequest_2 extends _i1.SmartFake implements _i2.HttpRequest {
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
-  MockHttpRequest() {
-    _i1.throwOnMissingStub(this);
-  }
-
   @override
   Map<String, String> get responseHeaders => (super.noSuchMethod(
         Invocation.getter(#responseHeaders),
         returnValue: <String, String>{},
+        returnValueForMissingStub: <String, String>{},
       ) as Map<String, String>);
   @override
   int get readyState => (super.noSuchMethod(
         Invocation.getter(#readyState),
         returnValue: 0,
+        returnValueForMissingStub: 0,
       ) as int);
   @override
   String get responseType => (super.noSuchMethod(
         Invocation.getter(#responseType),
         returnValue: '',
+        returnValueForMissingStub: '',
       ) as String);
   @override
   set responseType(String? value) => super.noSuchMethod(
@@ -97,6 +96,10 @@ class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
           this,
           Invocation.getter(#upload),
         ),
+        returnValueForMissingStub: _FakeHttpRequestUpload_0(
+          this,
+          Invocation.getter(#upload),
+        ),
       ) as _i2.HttpRequestUpload);
   @override
   set withCredentials(bool? value) => super.noSuchMethod(
@@ -110,46 +113,58 @@ class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
   _i3.Stream<_i2.Event> get onReadyStateChange => (super.noSuchMethod(
         Invocation.getter(#onReadyStateChange),
         returnValue: _i3.Stream<_i2.Event>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.Event>.empty(),
       ) as _i3.Stream<_i2.Event>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onAbort => (super.noSuchMethod(
         Invocation.getter(#onAbort),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onError => (super.noSuchMethod(
         Invocation.getter(#onError),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onLoad => (super.noSuchMethod(
         Invocation.getter(#onLoad),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onLoadEnd => (super.noSuchMethod(
         Invocation.getter(#onLoadEnd),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onLoadStart => (super.noSuchMethod(
         Invocation.getter(#onLoadStart),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onProgress => (super.noSuchMethod(
         Invocation.getter(#onProgress),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i3.Stream<_i2.ProgressEvent> get onTimeout => (super.noSuchMethod(
         Invocation.getter(#onTimeout),
         returnValue: _i3.Stream<_i2.ProgressEvent>.empty(),
+        returnValueForMissingStub: _i3.Stream<_i2.ProgressEvent>.empty(),
       ) as _i3.Stream<_i2.ProgressEvent>);
   @override
   _i2.Events get on => (super.noSuchMethod(
         Invocation.getter(#on),
         returnValue: _FakeEvents_1(
+          this,
+          Invocation.getter(#on),
+        ),
+        returnValueForMissingStub: _FakeEvents_1(
           this,
           Invocation.getter(#on),
         ),
@@ -192,13 +207,16 @@ class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
           [],
         ),
         returnValue: '',
+        returnValueForMissingStub: '',
       ) as String);
   @override
-  String? getResponseHeader(String? name) =>
-      (super.noSuchMethod(Invocation.method(
-        #getResponseHeader,
-        [name],
-      )) as String?);
+  String? getResponseHeader(String? name) => (super.noSuchMethod(
+        Invocation.method(
+          #getResponseHeader,
+          [name],
+        ),
+        returnValueForMissingStub: null,
+      ) as String?);
   @override
   void overrideMimeType(String? mime) => super.noSuchMethod(
         Invocation.method(
@@ -271,6 +289,7 @@ class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
           [event],
         ),
         returnValue: false,
+        returnValueForMissingStub: false,
       ) as bool);
 }
 
@@ -279,10 +298,6 @@ class MockHttpRequest extends _i1.Mock implements _i2.HttpRequest {
 /// See the documentation for Mockito's code generation for more information.
 class MockHttpRequestFactory extends _i1.Mock
     implements _i4.HttpRequestFactory {
-  MockHttpRequestFactory() {
-    _i1.throwOnMissingStub(this);
-  }
-
   @override
   _i3.Future<_i2.HttpRequest> request(
     String? url, {
@@ -309,6 +324,23 @@ class MockHttpRequestFactory extends _i1.Mock
           },
         ),
         returnValue: _i3.Future<_i2.HttpRequest>.value(_FakeHttpRequest_2(
+          this,
+          Invocation.method(
+            #request,
+            [url],
+            {
+              #method: method,
+              #withCredentials: withCredentials,
+              #responseType: responseType,
+              #mimeType: mimeType,
+              #requestHeaders: requestHeaders,
+              #sendData: sendData,
+              #onProgress: onProgress,
+            },
+          ),
+        )),
+        returnValueForMissingStub:
+            _i3.Future<_i2.HttpRequest>.value(_FakeHttpRequest_2(
           this,
           Invocation.method(
             #request,


### PR DESCRIPTION
This PR:

* Updates `WebWebViewController.loadRequest` to only set the src of the iFrame when `LoadRequestParams.headers` and `LoadRequestParams.body` are empty and is using the HTTP GET request method.
* Parses the `content-type` header of XHR responses to extract the correct MIME-type and charset.
* Sets `width` and `height` of widget the way the Flutter engine wants, to remove distracting warnings from the development console.

Fixes https://github.com/flutter/flutter/issues/118573
Fixes https://github.com/flutter/flutter/issues/118090

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
