### PR TITLE
[local_auth_android] update java complie sdk version to green tree

### DIFF
--- a/packages/local_auth/local_auth/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/local_auth/local_auth_android/example/android/app/build.gradle
+++ b/packages/local_auth/local_auth_android/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
androidx now requires Java compile version 33. This is currently blocking all pr's and keeping the tree red. This should fix the issue.