### PR TITLE
[ci] Update iOS simulator

### DIFF
--- a/.ci/targets/ios_platform_tests.yaml
+++ b/.ci/targets/ios_platform_tests.yaml
@@ -15,7 +15,7 @@ tasks:
     args: ["xcode-analyze", "--ios", "--ios-min-version=13.0"]
   - name: native test
     script: script/tool_runner.sh
-    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=iPhone 11,OS=latest"]
+    args: ["native-test", "--ios", "--ios-destination", "platform=iOS Simulator,name=iPhone 13,OS=latest"]
   - name: drive examples
     # `drive-examples` contains integration tests, which changes the UI of the application.
     # This UI change sometimes affects `xctest`.


### PR DESCRIPTION
Updates the iOS simulator used in CI from an iPhone 11 to an iPhone 13.

Part of alignment with flutter/packages in preparation for merging repositories.