### PR TITLE
fix npe in closeCaptureSession

### DIFF
--- a/packages/camera/camera_android/CHANGELOG.md
+++ b/packages/camera/camera_android/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.4+1
+* Fixes `NullPointerException` in `CameraCaptureSession.close()`
+
 ## 0.10.4
 
 * Temporarily fixes issue with requested video profiles being null by falling back to deprecated behavior in that case.

--- a/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
+++ b/packages/camera/camera_android/android/src/main/java/io/flutter/plugins/camera/Camera.java
@@ -687,10 +687,11 @@ class Camera
 
   /** Stops the background thread and its {@link Handler}. */
   public void stopBackgroundThread() {
+    HandlerThread backgroundHandlerThread = this.backgroundHandlerThread;
     if (backgroundHandlerThread != null) {
       backgroundHandlerThread.quitSafely();
     }
-    backgroundHandlerThread = null;
+    this.backgroundHandlerThread = null;
     backgroundHandler = null;
   }
 
@@ -1189,20 +1190,26 @@ class Camera
   }
 
   private void closeCaptureSession() {
-    if (captureSession != null) {
+    CameraCaptureSession session = this.captureSession;
+    if (session != null) {
       Log.i(TAG, "closeCaptureSession");
 
-      captureSession.close();
-      captureSession = null;
+      session.close();
+      this.captureSession = null;
     }
   }
 
   public void close() {
     Log.i(TAG, "close");
 
+    final CameraDeviceWrapper cameraDevice = this.cameraDevice;
+    final ImageReader pictureImageReader = this.pictureImageReader;
+    final ImageReader imageStreamReader = this.imageStreamReader;
+    final MediaRecorder mediaRecorder = this.mediaRecorder;
+
     if (cameraDevice != null) {
       cameraDevice.close();
-      cameraDevice = null;
+      this.cameraDevice = null;
 
       // Closing the CameraDevice without closing the CameraCaptureSession is recommended
       // for quickly closing the camera:
@@ -1214,16 +1221,16 @@ class Camera
 
     if (pictureImageReader != null) {
       pictureImageReader.close();
-      pictureImageReader = null;
+      this.pictureImageReader = null;
     }
     if (imageStreamReader != null) {
       imageStreamReader.close();
-      imageStreamReader = null;
+      this.imageStreamReader = null;
     }
     if (mediaRecorder != null) {
       mediaRecorder.reset();
       mediaRecorder.release();
-      mediaRecorder = null;
+      this.mediaRecorder = null;
     }
 
     stopBackgroundThread();

--- a/packages/camera/camera_android/pubspec.yaml
+++ b/packages/camera/camera_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: camera_android
 description: Android implementation of the camera plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/camera/camera_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+camera%22
-version: 0.10.4
+version: 0.10.4+1
 
 environment:
   sdk: ">=2.14.0 <3.0.0"


### PR DESCRIPTION
This is a resubmission of #6620

We have such npe:
```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.hardware.camera2.CameraCaptureSession.close()' on a null object reference
	at io.flutter.plugins.camera.Camera.closeCaptureSession(Camera.java:1244)
	at io.flutter.plugins.camera.Camera$1.onClosed(Camera.java:372)
	at android.hardware.camera2.impl.CameraDeviceImpl$5.run(CameraDeviceImpl.java:234)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:210)
	at android.os.Looper.loop(Looper.java:299)
	at android.os.HandlerThread.run(HandlerThread.java:67)
```

This code is racy, so I've added a simple protection to it and similar places.

Fixes flutter/flutter#121079.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests