### PR TITLE
[video_player] synchronize isPlaying state

### DIFF
--- a/packages/video_player/video_player/AUTHORS
+++ b/packages/video_player/video_player/AUTHORS
@@ -65,3 +65,4 @@ Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
 Koen Van Looveren <vanlooverenkoen.dev@gmail.com>
+Márton Matuz <matuzmarci@gmail.com>

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum Flutter version to 3.0.
 
+## 2.5.2
+
+* Synchronize `VideoPlayerValue.isPlaying` with underlying video player.
+
 ## 2.5.1
 
 * Updates code for stricter lint checks.

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,10 +1,7 @@
-## NEXT
-
-* Updates minimum Flutter version to 3.0.
-
 ## 2.5.2
 
 * Synchronize `VideoPlayerValue.isPlaying` with underlying video player.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.5.1
 

--- a/packages/video_player/video_player/CHANGELOG.md
+++ b/packages/video_player/video_player/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.5.2
 
-* Synchronize `VideoPlayerValue.isPlaying` with underlying video player.
+* Synchronizes `VideoPlayerValue.isPlaying` with underlying video player.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.5.1

--- a/packages/video_player/video_player/example/pubspec.yaml
+++ b/packages/video_player/video_player/example/pubspec.yaml
@@ -37,3 +37,8 @@ flutter:
     - assets/bumble_bee_captions.srt
     - assets/bumble_bee_captions.vtt
     - assets/Audio.mp3
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface

--- a/packages/video_player/video_player/lib/src/closed_caption_file.dart
+++ b/packages/video_player/video_player/lib/src/closed_caption_file.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show objectRuntimeType;
+import 'package:flutter/foundation.dart' show immutable, objectRuntimeType;
 
 import 'sub_rip.dart';
 import 'web_vtt.dart';
@@ -32,6 +32,7 @@ abstract class ClosedCaptionFile {
 ///
 /// A typical closed captioning file will include several [Caption]s, each
 /// linked to a start and end time.
+@immutable
 class Caption {
   /// Creates a new [Caption] object.
   ///
@@ -74,4 +75,22 @@ class Caption {
         'end: $end, '
         'text: $text)';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Caption &&
+          runtimeType == other.runtimeType &&
+          number == other.number &&
+          start == other.start &&
+          end == other.end &&
+          text == other.text;
+
+  @override
+  int get hashCode => Object.hash(
+        number,
+        start,
+        end,
+        text,
+      );
 }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -400,7 +400,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isBuffering: false);
           break;
         case VideoEventType.playingUpdate:
-          // TODO(maRci002): make VideoPlayerController immutable and provide equals / hash
+          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
           if (event.isPlaying! != value.isPlaying) {
             value = value.copyWith(isPlaying: event.isPlaying);
           }

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -33,10 +33,11 @@ VideoPlayerPlatform get _videoPlayerPlatform {
 
 /// The duration, current position, buffering state, error state and settings
 /// of a [VideoPlayerController].
+@immutable
 class VideoPlayerValue {
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
-  VideoPlayerValue({
+  const VideoPlayerValue({
     required this.duration,
     this.size = Size.zero,
     this.position = Duration.zero,
@@ -54,11 +55,11 @@ class VideoPlayerValue {
   });
 
   /// Returns an instance for a video that hasn't been loaded.
-  VideoPlayerValue.uninitialized()
+  const VideoPlayerValue.uninitialized()
       : this(duration: Duration.zero, isInitialized: false);
 
   /// Returns an instance with the given [errorDescription].
-  VideoPlayerValue.erroneous(String errorDescription)
+  const VideoPlayerValue.erroneous(String errorDescription)
       : this(
             duration: Duration.zero,
             isInitialized: false,
@@ -195,6 +196,44 @@ class VideoPlayerValue {
         'playbackSpeed: $playbackSpeed, '
         'errorDescription: $errorDescription)';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VideoPlayerValue &&
+          runtimeType == other.runtimeType &&
+          duration == other.duration &&
+          position == other.position &&
+          caption == other.caption &&
+          captionOffset == other.captionOffset &&
+          listEquals(buffered, other.buffered) &&
+          isPlaying == other.isPlaying &&
+          isLooping == other.isLooping &&
+          isBuffering == other.isBuffering &&
+          volume == other.volume &&
+          playbackSpeed == other.playbackSpeed &&
+          errorDescription == other.errorDescription &&
+          size == other.size &&
+          rotationCorrection == other.rotationCorrection &&
+          isInitialized == other.isInitialized;
+
+  @override
+  int get hashCode => Object.hash(
+        duration,
+        position,
+        caption,
+        captionOffset,
+        buffered,
+        isPlaying,
+        isLooping,
+        isBuffering,
+        volume,
+        playbackSpeed,
+        errorDescription,
+        size,
+        rotationCorrection,
+        isInitialized,
+      );
 }
 
 /// Controls a platform video player, and provides updates when the state is
@@ -221,7 +260,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         dataSourceType = DataSourceType.asset,
         formatHint = null,
         httpHeaders = const <String, String>{},
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from obtained from
   /// the network.
@@ -241,7 +280,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   })  : _closedCaptionFileFuture = closedCaptionFile,
         dataSourceType = DataSourceType.network,
         package = null,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from a file.
   ///
@@ -254,7 +293,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         package = null,
         formatHint = null,
         httpHeaders = const <String, String>{},
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [VideoPlayerController] playing a video from a contentUri.
   ///
@@ -270,7 +309,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         package = null,
         formatHint = null,
         httpHeaders = const <String, String>{},
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -400,10 +439,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isBuffering: false);
           break;
         case VideoEventType.isPlayingStateUpdate:
-          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
-          if (event.isPlaying! != value.isPlaying) {
-            value = value.copyWith(isPlaying: event.isPlaying);
-          }
+          value = value.copyWith(isPlaying: event.isPlaying);
           break;
         case VideoEventType.unknown:
           break;

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -399,7 +399,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
-        case VideoEventType.playingUpdate:
+        case VideoEventType.isPlayingStateUpdate:
           // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
           if (event.isPlaying! != value.isPlaying) {
             value = value.copyWith(isPlaying: event.isPlaying);

--- a/packages/video_player/video_player/lib/video_player.dart
+++ b/packages/video_player/video_player/lib/video_player.dart
@@ -399,6 +399,12 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
+        case VideoEventType.playingUpdate:
+          // TODO(maRci002): make VideoPlayerController immutable and provide equals / hash
+          if (event.isPlaying! != value.isPlaying) {
+            value = value.copyWith(isPlaying: event.isPlaying);
+          }
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -31,3 +31,14 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_android:
+    path: ../video_player_android
+  video_player_avfoundation:
+    path: ../video_player_avfoundation
+  video_player_platform_interface:
+    path: ../video_player_platform_interface
+  video_player_web:
+    path: ../video_player_web

--- a/packages/video_player/video_player/pubspec.yaml
+++ b/packages/video_player/video_player/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for displaying inline video with other Flutter
   widgets on Android, iOS, and web.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.5.1
+version: 2.5.2
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player/test/video_player_test.dart
+++ b/packages/video_player/video_player/test/video_player_test.dart
@@ -16,7 +16,7 @@ import 'package:video_player_platform_interface/video_player_platform_interface.
 
 class FakeController extends ValueNotifier<VideoPlayerValue>
     implements VideoPlayerController {
-  FakeController() : super(VideoPlayerValue(duration: Duration.zero));
+  FakeController() : super(const VideoPlayerValue(duration: Duration.zero));
 
   FakeController.value(VideoPlayerValue value) : super(value);
 
@@ -164,7 +164,8 @@ void main() {
   testWidgets('non-zero rotationCorrection value is used',
       (WidgetTester tester) async {
     final FakeController controller = FakeController.value(
-        VideoPlayerValue(duration: Duration.zero, rotationCorrection: 180));
+        const VideoPlayerValue(
+            duration: Duration.zero, rotationCorrection: 180));
     controller.textureId = 1;
     await tester.pumpWidget(VideoPlayer(controller));
     final Transform actualRotationCorrection =
@@ -184,7 +185,7 @@ void main() {
   testWidgets('no transform when rotationCorrection is zero',
       (WidgetTester tester) async {
     final FakeController controller =
-        FakeController.value(VideoPlayerValue(duration: Duration.zero));
+        FakeController.value(const VideoPlayerValue(duration: Duration.zero));
     controller.textureId = 1;
     await tester.pumpWidget(VideoPlayer(controller));
     expect(find.byType(Transform), findsNothing);
@@ -849,7 +850,7 @@ void main() {
 
   group('VideoPlayerValue', () {
     test('uninitialized()', () {
-      final VideoPlayerValue uninitialized = VideoPlayerValue.uninitialized();
+      const VideoPlayerValue uninitialized = VideoPlayerValue.uninitialized();
 
       expect(uninitialized.duration, equals(Duration.zero));
       expect(uninitialized.position, equals(Duration.zero));
@@ -870,7 +871,7 @@ void main() {
 
     test('erroneous()', () {
       const String errorMessage = 'foo';
-      final VideoPlayerValue error = VideoPlayerValue.erroneous(errorMessage);
+      const VideoPlayerValue error = VideoPlayerValue.erroneous(errorMessage);
 
       expect(error.duration, equals(Duration.zero));
       expect(error.position, equals(Duration.zero));
@@ -940,26 +941,26 @@ void main() {
 
     group('copyWith()', () {
       test('exact copy', () {
-        final VideoPlayerValue original = VideoPlayerValue.uninitialized();
+        const VideoPlayerValue original = VideoPlayerValue.uninitialized();
         final VideoPlayerValue exactCopy = original.copyWith();
 
         expect(exactCopy.toString(), original.toString());
       });
       test('errorDescription is not persisted when copy with null', () {
-        final VideoPlayerValue original = VideoPlayerValue.erroneous('error');
+        const VideoPlayerValue original = VideoPlayerValue.erroneous('error');
         final VideoPlayerValue copy = original.copyWith(errorDescription: null);
 
         expect(copy.errorDescription, null);
       });
       test('errorDescription is changed when copy with another error', () {
-        final VideoPlayerValue original = VideoPlayerValue.erroneous('error');
+        const VideoPlayerValue original = VideoPlayerValue.erroneous('error');
         final VideoPlayerValue copy =
             original.copyWith(errorDescription: 'new error');
 
         expect(copy.errorDescription, 'new error');
       });
       test('errorDescription is changed when copy with error', () {
-        final VideoPlayerValue original = VideoPlayerValue.uninitialized();
+        const VideoPlayerValue original = VideoPlayerValue.uninitialized();
         final VideoPlayerValue copy =
             original.copyWith(errorDescription: 'new error');
 
@@ -969,45 +970,45 @@ void main() {
 
     group('aspectRatio', () {
       test('640x480 -> 4:3', () {
-        final VideoPlayerValue value = VideoPlayerValue(
+        const VideoPlayerValue value = VideoPlayerValue(
           isInitialized: true,
-          size: const Size(640, 480),
-          duration: const Duration(seconds: 1),
+          size: Size(640, 480),
+          duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 4 / 3);
       });
 
       test('no size -> 1.0', () {
-        final VideoPlayerValue value = VideoPlayerValue(
+        const VideoPlayerValue value = VideoPlayerValue(
           isInitialized: true,
-          duration: const Duration(seconds: 1),
+          duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
       });
 
       test('height = 0 -> 1.0', () {
-        final VideoPlayerValue value = VideoPlayerValue(
+        const VideoPlayerValue value = VideoPlayerValue(
           isInitialized: true,
-          size: const Size(640, 0),
-          duration: const Duration(seconds: 1),
+          size: Size(640, 0),
+          duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
       });
 
       test('width = 0 -> 1.0', () {
-        final VideoPlayerValue value = VideoPlayerValue(
+        const VideoPlayerValue value = VideoPlayerValue(
           isInitialized: true,
-          size: const Size(0, 480),
-          duration: const Duration(seconds: 1),
+          size: Size(0, 480),
+          duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
       });
 
       test('negative aspect ratio -> 1.0', () {
-        final VideoPlayerValue value = VideoPlayerValue(
+        const VideoPlayerValue value = VideoPlayerValue(
           isInitialized: true,
-          size: const Size(640, -480),
-          duration: const Duration(seconds: 1),
+          size: Size(640, -480),
+          duration: Duration(seconds: 1),
         );
         expect(value.aspectRatio, 1.0);
       });

--- a/packages/video_player/video_player_android/AUTHORS
+++ b/packages/video_player/video_player_android/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Márton Matuz <matuzmarci@gmail.com>

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,10 +1,7 @@
-## NEXT
-
-* Updates minimum Flutter version to 3.0.
-
 ## 2.3.11
 
 * Synchronize `VideoPlayerValue.isPlaying` with `ExoPlayer`.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.3.10
 

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.11
 
-* Synchronize `VideoPlayerValue.isPlaying` with `ExoPlayer`.
+* Synchronizes `VideoPlayerValue.isPlaying` with `ExoPlayer`.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.3.10

--- a/packages/video_player/video_player_android/CHANGELOG.md
+++ b/packages/video_player/video_player_android/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum Flutter version to 3.0.
 
+## 2.3.11
+
+* Synchronize `VideoPlayerValue.isPlaying` with `ExoPlayer`.
+
 ## 2.3.10
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -237,7 +237,7 @@ final class VideoPlayer {
           public void onIsPlayingChanged(boolean isPlaying) {
             if (eventSink != null) {
               Map<String, Object> event = new HashMap<>();
-              event.put("event", "playingUpdate");
+              event.put("event", "isPlayingStateUpdate");
               event.put("isPlaying", isPlaying);
               eventSink.success(event);
             }

--- a/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
+++ b/packages/video_player/video_player_android/android/src/main/java/io/flutter/plugins/videoplayer/VideoPlayer.java
@@ -232,6 +232,16 @@ final class VideoPlayer {
               eventSink.error("VideoError", "Video player had error " + error, null);
             }
           }
+
+          @Override
+          public void onIsPlayingChanged(boolean isPlaying) {
+            if (eventSink != null) {
+              Map<String, Object> event = new HashMap<>();
+              event.put("event", "playingUpdate");
+              event.put("isPlaying", isPlaying);
+              eventSink.success(event);
+            }
+          }
         });
   }
 

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -243,7 +243,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
-        case VideoEventType.playingUpdate:
+        case VideoEventType.isPlayingStateUpdate:
           // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
           if (event.isPlaying! != value.isPlaying) {
             value = value.copyWith(isPlaying: event.isPlaying);

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -243,6 +243,12 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
+        case VideoEventType.playingUpdate:
+          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
+          if (event.isPlaying! != value.isPlaying) {
+            value = value.copyWith(isPlaying: event.isPlaying);
+          }
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player_android/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_android/example/lib/mini_controller.dart
@@ -8,6 +8,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
@@ -24,10 +25,11 @@ VideoPlayerPlatform get _platform {
 
 /// The duration, current position, buffering state, error state and settings
 /// of a [MiniController].
+@immutable
 class VideoPlayerValue {
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
-  VideoPlayerValue({
+  const VideoPlayerValue({
     required this.duration,
     this.size = Size.zero,
     this.position = Duration.zero,
@@ -40,11 +42,11 @@ class VideoPlayerValue {
   });
 
   /// Returns an instance for a video that hasn't been loaded.
-  VideoPlayerValue.uninitialized()
+  const VideoPlayerValue.uninitialized()
       : this(duration: Duration.zero, isInitialized: false);
 
   /// Returns an instance with the given [errorDescription].
-  VideoPlayerValue.erroneous(String errorDescription)
+  const VideoPlayerValue.erroneous(String errorDescription)
       : this(
             duration: Duration.zero,
             isInitialized: false,
@@ -127,6 +129,34 @@ class VideoPlayerValue {
       errorDescription: errorDescription ?? this.errorDescription,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VideoPlayerValue &&
+          runtimeType == other.runtimeType &&
+          duration == other.duration &&
+          position == other.position &&
+          listEquals(buffered, other.buffered) &&
+          isPlaying == other.isPlaying &&
+          isBuffering == other.isBuffering &&
+          playbackSpeed == other.playbackSpeed &&
+          errorDescription == other.errorDescription &&
+          size == other.size &&
+          isInitialized == other.isInitialized;
+
+  @override
+  int get hashCode => Object.hash(
+        duration,
+        position,
+        buffered,
+        isPlaying,
+        isBuffering,
+        playbackSpeed,
+        errorDescription,
+        size,
+        isInitialized,
+      );
 }
 
 /// A very minimal version of `VideoPlayerController` for running the example
@@ -139,21 +169,21 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// package and null otherwise.
   MiniController.asset(this.dataSource, {this.package})
       : dataSourceType = DataSourceType.asset,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from
   /// the network.
   MiniController.network(this.dataSource)
       : dataSourceType = DataSourceType.network,
         package = null,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from a file.
   MiniController.file(File file)
       : dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -244,10 +274,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isBuffering: false);
           break;
         case VideoEventType.isPlayingStateUpdate:
-          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
-          if (event.isPlaying! != value.isPlaying) {
-            value = value.copyWith(isPlaying: event.isPlaying);
-          }
+          value = value.copyWith(isPlaying: event.isPlaying);
           break;
         case VideoEventType.unknown:
           break;

--- a/packages/video_player/video_player_android/example/pubspec.yaml
+++ b/packages/video_player/video_player_android/example/pubspec.yaml
@@ -33,3 +33,8 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -147,6 +147,11 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
+        case 'playingUpdate':
+          return VideoEvent(
+            eventType: VideoEventType.playingUpdate,
+            isPlaying: map['isPlaying'] as bool,
+          );
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/video_player_android/lib/src/android_video_player.dart
+++ b/packages/video_player/video_player_android/lib/src/android_video_player.dart
@@ -147,9 +147,9 @@ class AndroidVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
-        case 'playingUpdate':
+        case 'isPlayingStateUpdate':
           return VideoEvent(
-            eventType: VideoEventType.playingUpdate,
+            eventType: VideoEventType.isPlayingStateUpdate,
             isPlaying: map['isPlaying'] as bool,
           );
         default:

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_android
 description: Android implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_android
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.10
+version: 2.3.11
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_android/pubspec.yaml
+++ b/packages/video_player/video_player_android/pubspec.yaml
@@ -26,3 +26,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^2.0.1
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../video_player_platform_interface

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -234,10 +234,11 @@ void main() {
     });
 
     test('videoEventsFor', () async {
+      const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
       _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
           .defaultBinaryMessenger
           .setMockMessageHandler(
-        'flutter.io/videoPlayer/videoEvents123',
+        mockChannel,
         (ByteData? message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
@@ -245,7 +246,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'initialized',
@@ -258,7 +259,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'initialized',
@@ -272,7 +273,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'completed',
@@ -282,7 +283,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingUpdate',
@@ -296,7 +297,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingStart',
@@ -306,10 +307,32 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingEnd',
+                    }),
+                    (ByteData? data) {});
+
+            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+                .defaultBinaryMessenger
+                .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'playingUpdate',
+                      'isPlaying': true,
+                    }),
+                    (ByteData? data) {});
+
+            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+                .defaultBinaryMessenger
+                .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'playingUpdate',
+                      'isPlaying': false,
                     }),
                     (ByteData? data) {});
 
@@ -351,6 +374,14 @@ void main() {
                 ]),
             VideoEvent(eventType: VideoEventType.bufferingStart),
             VideoEvent(eventType: VideoEventType.bufferingEnd),
+            VideoEvent(
+              eventType: VideoEventType.playingUpdate,
+              isPlaying: true,
+            ),
+            VideoEvent(
+              eventType: VideoEventType.playingUpdate,
+              isPlaying: false,
+            ),
           ]));
     });
   });

--- a/packages/video_player/video_player_android/test/android_video_player_test.dart
+++ b/packages/video_player/video_player_android/test/android_video_player_test.dart
@@ -320,7 +320,7 @@ void main() {
                     mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
-                      'event': 'playingUpdate',
+                      'event': 'isPlayingStateUpdate',
                       'isPlaying': true,
                     }),
                     (ByteData? data) {});
@@ -331,7 +331,7 @@ void main() {
                     mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
-                      'event': 'playingUpdate',
+                      'event': 'isPlayingStateUpdate',
                       'isPlaying': false,
                     }),
                     (ByteData? data) {});
@@ -375,11 +375,11 @@ void main() {
             VideoEvent(eventType: VideoEventType.bufferingStart),
             VideoEvent(eventType: VideoEventType.bufferingEnd),
             VideoEvent(
-              eventType: VideoEventType.playingUpdate,
+              eventType: VideoEventType.isPlayingStateUpdate,
               isPlaying: true,
             ),
             VideoEvent(
-              eventType: VideoEventType.playingUpdate,
+              eventType: VideoEventType.isPlayingStateUpdate,
               isPlaying: false,
             ),
           ]));

--- a/packages/video_player/video_player_avfoundation/AUTHORS
+++ b/packages/video_player/video_player_avfoundation/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Márton Matuz <matuzmarci@gmail.com>

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.9
 
-* Synchronize `VideoPlayerValue.isPlaying` with `AVPlayer`.
+* Synchronizes `VideoPlayerValue.isPlaying` with `AVPlayer`.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.3.8

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum Flutter version to 3.0.
 
+## 2.3.9
+
+* Synchronize `VideoPlayerValue.isPlaying` with `AVPlayer`.
+
 ## 2.3.8
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_avfoundation/CHANGELOG.md
+++ b/packages/video_player/video_player_avfoundation/CHANGELOG.md
@@ -1,10 +1,7 @@
-## NEXT
-
-* Updates minimum Flutter version to 3.0.
-
 ## 2.3.9
 
 * Synchronize `VideoPlayerValue.isPlaying` with `AVPlayer`.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.3.8
 

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -243,7 +243,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
-        case VideoEventType.playingUpdate:
+        case VideoEventType.isPlayingStateUpdate:
           // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
           if (event.isPlaying! != value.isPlaying) {
             value = value.copyWith(isPlaying: event.isPlaying);

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -243,6 +243,12 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
         case VideoEventType.bufferingEnd:
           value = value.copyWith(isBuffering: false);
           break;
+        case VideoEventType.playingUpdate:
+          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
+          if (event.isPlaying! != value.isPlaying) {
+            value = value.copyWith(isPlaying: event.isPlaying);
+          }
+          break;
         case VideoEventType.unknown:
           break;
       }

--- a/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
+++ b/packages/video_player/video_player_avfoundation/example/lib/mini_controller.dart
@@ -8,6 +8,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:video_player_platform_interface/video_player_platform_interface.dart';
@@ -24,10 +25,11 @@ VideoPlayerPlatform get _platform {
 
 /// The duration, current position, buffering state, error state and settings
 /// of a [MiniController].
+@immutable
 class VideoPlayerValue {
   /// Constructs a video with the given values. Only [duration] is required. The
   /// rest will initialize with default values when unset.
-  VideoPlayerValue({
+  const VideoPlayerValue({
     required this.duration,
     this.size = Size.zero,
     this.position = Duration.zero,
@@ -40,11 +42,11 @@ class VideoPlayerValue {
   });
 
   /// Returns an instance for a video that hasn't been loaded.
-  VideoPlayerValue.uninitialized()
+  const VideoPlayerValue.uninitialized()
       : this(duration: Duration.zero, isInitialized: false);
 
   /// Returns an instance with the given [errorDescription].
-  VideoPlayerValue.erroneous(String errorDescription)
+  const VideoPlayerValue.erroneous(String errorDescription)
       : this(
             duration: Duration.zero,
             isInitialized: false,
@@ -127,6 +129,34 @@ class VideoPlayerValue {
       errorDescription: errorDescription ?? this.errorDescription,
     );
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is VideoPlayerValue &&
+          runtimeType == other.runtimeType &&
+          duration == other.duration &&
+          position == other.position &&
+          listEquals(buffered, other.buffered) &&
+          isPlaying == other.isPlaying &&
+          isBuffering == other.isBuffering &&
+          playbackSpeed == other.playbackSpeed &&
+          errorDescription == other.errorDescription &&
+          size == other.size &&
+          isInitialized == other.isInitialized;
+
+  @override
+  int get hashCode => Object.hash(
+        duration,
+        position,
+        buffered,
+        isPlaying,
+        isBuffering,
+        playbackSpeed,
+        errorDescription,
+        size,
+        isInitialized,
+      );
 }
 
 /// A very minimal version of `VideoPlayerController` for running the example
@@ -139,21 +169,21 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
   /// package and null otherwise.
   MiniController.asset(this.dataSource, {this.package})
       : dataSourceType = DataSourceType.asset,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from
   /// the network.
   MiniController.network(this.dataSource)
       : dataSourceType = DataSourceType.network,
         package = null,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// Constructs a [MiniController] playing a video from obtained from a file.
   MiniController.file(File file)
       : dataSource = Uri.file(file.absolute.path).toString(),
         dataSourceType = DataSourceType.file,
         package = null,
-        super(VideoPlayerValue(duration: Duration.zero));
+        super(const VideoPlayerValue(duration: Duration.zero));
 
   /// The URI to the video file. This will be in different formats depending on
   /// the [DataSourceType] of the original video.
@@ -244,10 +274,7 @@ class MiniController extends ValueNotifier<VideoPlayerValue> {
           value = value.copyWith(isBuffering: false);
           break;
         case VideoEventType.isPlayingStateUpdate:
-          // TODO(maRci002): make VideoPlayerValue immutable and provide equals / hash
-          if (event.isPlaying! != value.isPlaying) {
-            value = value.copyWith(isPlaying: event.isPlaying);
-          }
+          value = value.copyWith(isPlaying: event.isPlaying);
           break;
         case VideoEventType.unknown:
           break;

--- a/packages/video_player/video_player_avfoundation/example/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/example/pubspec.yaml
@@ -33,3 +33,8 @@ flutter:
   assets:
     - assets/flutter-mark-square-64.png
     - assets/Butterfly-209.mp4
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -100,9 +100,9 @@ static void *rateContext = &rateContext;
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
   [_player addObserver:self
-         forKeyPath:@"rate"
-            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
-            context:rateContext];
+            forKeyPath:@"rate"
+               options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+               context:rateContext];
 
   // Add an observer that will respond to itemDidPlayToEndTime
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -325,10 +325,7 @@ NS_INLINE UIViewController *rootViewController() {
   } else if (context == rateContext) {
     AVPlayer *player = (AVPlayer *)object;
     if (_eventSink != nil) {
-      _eventSink(@{
-        @"event" : @"playingUpdate",
-        @"isPlaying" : player.rate > 0 ? @YES : @NO
-      });
+      _eventSink(@{@"event" : @"playingUpdate", @"isPlaying" : player.rate > 0 ? @YES : @NO});
     }
   }
 }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -100,9 +100,9 @@ static void *rateContext = &rateContext;
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
   [player addObserver:self
-            forKeyPath:@"rate"
-               options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
-               context:rateContext];
+           forKeyPath:@"rate"
+              options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+              context:rateContext];
 
   // Add an observer that will respond to itemDidPlayToEndTime
   [[NSNotificationCenter defaultCenter] addObserver:self

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -99,7 +99,7 @@ static void *rateContext = &rateContext;
          forKeyPath:@"playbackBufferFull"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
-  [_player addObserver:self
+  [player addObserver:self
             forKeyPath:@"rate"
                options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
                context:rateContext];

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -70,7 +70,7 @@ static void *rateContext = &rateContext;
   return [self initWithURL:[NSURL fileURLWithPath:path] frameUpdater:frameUpdater httpHeaders:@{}];
 }
 
-- (void)addObservers:(AVPlayerItem *)item {
+- (void)addObservers:(AVPlayerItem *)item player:(AVPlayer *)player {
   [item addObserver:self
          forKeyPath:@"loadedTimeRanges"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
@@ -99,7 +99,7 @@ static void *rateContext = &rateContext;
          forKeyPath:@"playbackBufferFull"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
-  [item addObserver:self
+  [_player addObserver:self
          forKeyPath:@"rate"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:rateContext];
@@ -257,7 +257,7 @@ NS_INLINE UIViewController *rootViewController() {
 
   [self createVideoOutputAndDisplayLink:frameUpdater];
 
-  [self addObservers:item];
+  [self addObservers:item player:_player];
 
   [asset loadValuesAsynchronouslyForKeys:@[ @"tracks" ] completionHandler:assetCompletionHandler];
 
@@ -323,11 +323,11 @@ NS_INLINE UIViewController *rootViewController() {
       _eventSink(@{@"event" : @"bufferingEnd"});
     }
   } else if (context == rateContext) {
-    AVPlayerItem *item = (AVPlayerItem *)object;
+    AVPlayer *player = (AVPlayer *)object;
     if (_eventSink != nil) {
       _eventSink(@{
         @"event" : @"playingUpdate",
-        @"isPlaying" : item.rate > 0 ? @YES : @NO
+        @"isPlaying" : player.rate > 0 ? @YES : @NO
       });
     }
   }

--- a/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player_avfoundation/ios/Classes/FLTVideoPlayerPlugin.m
@@ -62,6 +62,7 @@ static void *durationContext = &durationContext;
 static void *playbackLikelyToKeepUpContext = &playbackLikelyToKeepUpContext;
 static void *playbackBufferEmptyContext = &playbackBufferEmptyContext;
 static void *playbackBufferFullContext = &playbackBufferFullContext;
+static void *rateContext = &rateContext;
 
 @implementation FLTVideoPlayer
 - (instancetype)initWithAsset:(NSString *)asset frameUpdater:(FLTFrameUpdater *)frameUpdater {
@@ -98,6 +99,10 @@ static void *playbackBufferFullContext = &playbackBufferFullContext;
          forKeyPath:@"playbackBufferFull"
             options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
             context:playbackBufferFullContext];
+  [item addObserver:self
+         forKeyPath:@"rate"
+            options:NSKeyValueObservingOptionInitial | NSKeyValueObservingOptionNew
+            context:rateContext];
 
   // Add an observer that will respond to itemDidPlayToEndTime
   [[NSNotificationCenter defaultCenter] addObserver:self
@@ -316,6 +321,14 @@ NS_INLINE UIViewController *rootViewController() {
   } else if (context == playbackBufferFullContext) {
     if (_eventSink != nil) {
       _eventSink(@{@"event" : @"bufferingEnd"});
+    }
+  } else if (context == rateContext) {
+    AVPlayerItem *item = (AVPlayerItem *)object;
+    if (_eventSink != nil) {
+      _eventSink(@{
+        @"event" : @"playingUpdate",
+        @"isPlaying" : item.rate > 0 ? @YES : @NO
+      });
     }
   }
 }

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -146,9 +146,9 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
-        case 'playingUpdate':
+        case 'isPlayingStateUpdate':
           return VideoEvent(
-            eventType: VideoEventType.playingUpdate,
+            eventType: VideoEventType.isPlayingStateUpdate,
             isPlaying: map['isPlaying'] as bool,
           );
         default:

--- a/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
+++ b/packages/video_player/video_player_avfoundation/lib/src/avfoundation_video_player.dart
@@ -146,6 +146,11 @@ class AVFoundationVideoPlayer extends VideoPlayerPlatform {
           return VideoEvent(eventType: VideoEventType.bufferingStart);
         case 'bufferingEnd':
           return VideoEvent(eventType: VideoEventType.bufferingEnd);
+        case 'playingUpdate':
+          return VideoEvent(
+            eventType: VideoEventType.playingUpdate,
+            isPlaying: map['isPlaying'] as bool,
+          );
         default:
           return VideoEvent(eventType: VideoEventType.unknown);
       }

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -25,3 +25,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pigeon: ^2.0.1
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../video_player_platform_interface

--- a/packages/video_player/video_player_avfoundation/pubspec.yaml
+++ b/packages/video_player/video_player_avfoundation/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_avfoundation
 description: iOS implementation of the video_player plugin.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_avfoundation
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.3.8
+version: 2.3.9
 
 environment:
   sdk: ">=2.14.0 <3.0.0"

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -234,10 +234,11 @@ void main() {
     });
 
     test('videoEventsFor', () async {
+      const String mockChannel = 'flutter.io/videoPlayer/videoEvents123';
       _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
           .defaultBinaryMessenger
           .setMockMessageHandler(
-        'flutter.io/videoPlayer/videoEvents123',
+        mockChannel,
         (ByteData? message) async {
           final MethodCall methodCall =
               const StandardMethodCodec().decodeMethodCall(message);
@@ -245,7 +246,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'initialized',
@@ -258,7 +259,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'completed',
@@ -268,7 +269,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingUpdate',
@@ -282,7 +283,7 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingStart',
@@ -292,10 +293,32 @@ void main() {
             await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
                 .defaultBinaryMessenger
                 .handlePlatformMessage(
-                    'flutter.io/videoPlayer/videoEvents123',
+                    mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
                       'event': 'bufferingEnd',
+                    }),
+                    (ByteData? data) {});
+
+            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+                .defaultBinaryMessenger
+                .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'playingUpdate',
+                      'isPlaying': true,
+                    }),
+                    (ByteData? data) {});
+
+            await _ambiguate(TestDefaultBinaryMessengerBinding.instance)!
+                .defaultBinaryMessenger
+                .handlePlatformMessage(
+                    mockChannel,
+                    const StandardMethodCodec()
+                        .encodeSuccessEnvelope(<String, dynamic>{
+                      'event': 'playingUpdate',
+                      'isPlaying': false,
                     }),
                     (ByteData? data) {});
 
@@ -330,6 +353,14 @@ void main() {
                 ]),
             VideoEvent(eventType: VideoEventType.bufferingStart),
             VideoEvent(eventType: VideoEventType.bufferingEnd),
+            VideoEvent(
+              eventType: VideoEventType.playingUpdate,
+              isPlaying: true,
+            ),
+            VideoEvent(
+              eventType: VideoEventType.playingUpdate,
+              isPlaying: false,
+            ),
           ]));
     });
   });

--- a/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
+++ b/packages/video_player/video_player_avfoundation/test/avfoundation_video_player_test.dart
@@ -306,7 +306,7 @@ void main() {
                     mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
-                      'event': 'playingUpdate',
+                      'event': 'isPlayingStateUpdate',
                       'isPlaying': true,
                     }),
                     (ByteData? data) {});
@@ -317,7 +317,7 @@ void main() {
                     mockChannel,
                     const StandardMethodCodec()
                         .encodeSuccessEnvelope(<String, dynamic>{
-                      'event': 'playingUpdate',
+                      'event': 'isPlayingStateUpdate',
                       'isPlaying': false,
                     }),
                     (ByteData? data) {});
@@ -354,11 +354,11 @@ void main() {
             VideoEvent(eventType: VideoEventType.bufferingStart),
             VideoEvent(eventType: VideoEventType.bufferingEnd),
             VideoEvent(
-              eventType: VideoEventType.playingUpdate,
+              eventType: VideoEventType.isPlayingStateUpdate,
               isPlaying: true,
             ),
             VideoEvent(
-              eventType: VideoEventType.playingUpdate,
+              eventType: VideoEventType.isPlayingStateUpdate,
               isPlaying: false,
             ),
           ]));

--- a/packages/video_player/video_player_platform_interface/AUTHORS
+++ b/packages/video_player/video_player_platform_interface/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Márton Matuz <matuzmarci@gmail.com>

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Updates minimum Flutter version to 3.0.
 
+## 6.0.2
+
+* Add the `VideoEventType.playingUpdate` event to track changes in play / pause status with the
+underlying video player.
+
 ## 6.0.1
 
 * Fixes comment describing file URI construction.

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,11 +1,8 @@
-## NEXT
-
-* Updates minimum Flutter version to 3.0.
-
 ## 6.0.2
 
 * Add the `VideoEventType.playingUpdate` event to track changes in play / pause status with the
 underlying video player.
+* Updates minimum Flutter version to 3.0.
 
 ## 6.0.1
 

--- a/packages/video_player/video_player_platform_interface/CHANGELOG.md
+++ b/packages/video_player/video_player_platform_interface/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 6.0.2
 
-* Add the `VideoEventType.playingUpdate` event to track changes in play / pause status with the
-underlying video player.
+* Add the `VideoEventType.isPlayingStateUpdate` event to track changes in play / pause state with
+the underlying video player.
 * Updates minimum Flutter version to 3.0.
 
 ## 6.0.1

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -212,6 +212,7 @@ class VideoEvent {
     this.size,
     this.rotationCorrection,
     this.buffered,
+    this.isPlaying,
   });
 
   /// The type of the event.
@@ -237,6 +238,11 @@ class VideoEvent {
   /// Only used if [eventType] is [VideoEventType.bufferingUpdate].
   final List<DurationRange>? buffered;
 
+  /// Play state changed.
+  ///
+  /// Only used if [eventType] is [VideoEventType.playingUpdate].
+  final bool? isPlaying;
+
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
@@ -246,7 +252,8 @@ class VideoEvent {
             duration == other.duration &&
             size == other.size &&
             rotationCorrection == other.rotationCorrection &&
-            listEquals(buffered, other.buffered);
+            listEquals(buffered, other.buffered) &&
+            isPlaying == other.isPlaying;
   }
 
   @override
@@ -256,13 +263,14 @@ class VideoEvent {
         size,
         rotationCorrection,
         buffered,
+        isPlaying,
       );
 }
 
 /// Type of the event.
 ///
 /// Emitted by the platform implementation when the video is initialized or
-/// completed or to communicate buffering events.
+/// completed or to communicate buffering events or play state changed.
 enum VideoEventType {
   /// The video has been initialized.
   initialized,
@@ -278,6 +286,10 @@ enum VideoEventType {
 
   /// The video stopped to buffer.
   bufferingEnd,
+
+  /// The video started to play (for instance by user or phone call ended)
+  /// or the video has been paused (for instance by user or phone call ended)
+  playingUpdate,
 
   /// An unknown event has been received.
   unknown,

--- a/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
+++ b/packages/video_player/video_player_platform_interface/lib/video_player_platform_interface.dart
@@ -240,7 +240,7 @@ class VideoEvent {
 
   /// Play state changed.
   ///
-  /// Only used if [eventType] is [VideoEventType.playingUpdate].
+  /// Only used if [eventType] is [VideoEventType.isPlayingStateUpdate].
   final bool? isPlaying;
 
   @override
@@ -287,9 +287,13 @@ enum VideoEventType {
   /// The video stopped to buffer.
   bufferingEnd,
 
-  /// The video started to play (for instance by user or phone call ended)
-  /// or the video has been paused (for instance by user or phone call ended)
-  playingUpdate,
+  /// Represents an event type emitted by the platform implementation when the
+  /// video playback state is updated, for example, when the video starts or
+  /// pauses due to user actions or phone calls, or other app media such as
+  /// music players.
+  /// Note that when [VideoPlayerOptions.mixWithOthers] is true, the video may
+  /// continue playing even during a phone call.
+  isPlayingStateUpdate,
 
   /// An unknown event has been received.
   unknown,

--- a/packages/video_player/video_player_platform_interface/pubspec.yaml
+++ b/packages/video_player/video_player_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ repository: https://github.com/flutter/plugins/tree/main/packages/video_player/v
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 6.0.1
+version: 6.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/video_player/video_player_web/AUTHORS
+++ b/packages/video_player/video_player_web/AUTHORS
@@ -64,3 +64,4 @@ Aleksandr Yurkovskiy <sanekyy@gmail.com>
 Anton Borries <mail@antonborri.es>
 Alex Li <google@alexv525.com>
 Rahul Raj <64.rahulraj@gmail.com>
+Márton Matuz <matuzmarci@gmail.com>

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.14
 
-* Synchronize `VideoPlayerValue.isPlaying` with `VideoElement`.
+* Synchronizes `VideoPlayerValue.isPlaying` with `VideoElement`.
 * Updates minimum Flutter version to 3.0.
 
 ## 2.0.13

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Updates minimum Flutter version to 3.0.
 
+## 2.0.14
+
+* Synchronize `VideoPlayerValue.isPlaying` with `VideoElement`.
+
 ## 2.0.13
 
 * Adds compatibilty with version 6.0 of the platform interface.

--- a/packages/video_player/video_player_web/CHANGELOG.md
+++ b/packages/video_player/video_player_web/CHANGELOG.md
@@ -1,10 +1,7 @@
-## NEXT
-
-* Updates minimum Flutter version to 3.0.
-
 ## 2.0.14
 
 * Synchronize `VideoPlayerValue.isPlaying` with `VideoElement`.
+* Updates minimum Flutter version to 3.0.
 
 ## 2.0.13
 

--- a/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
@@ -169,7 +169,8 @@ void main() {
       expect(VideoPlayerPlatform.instance.setMixWithOthers(false), completes);
     });
 
-    testWidgets('double call to play emit singe playingUpdate',
+    testWidgets(
+        'double call to play will emit a single isPlayingStateUpdate event',
         (WidgetTester tester) async {
       final int videoPlayerId = await textureId;
       final Stream<VideoEvent> eventStream =
@@ -192,11 +193,11 @@ void main() {
       await VideoPlayerPlatform.instance.pause(videoPlayerId);
 
       expect(
-          events.where(
-              (VideoEvent e) => e.eventType == VideoEventType.playingUpdate),
+          events.where((VideoEvent e) =>
+              e.eventType == VideoEventType.isPlayingStateUpdate),
           equals(<VideoEvent>[
             VideoEvent(
-              eventType: VideoEventType.playingUpdate,
+              eventType: VideoEventType.isPlayingStateUpdate,
               isPlaying: true,
             )
           ]));
@@ -223,7 +224,7 @@ void main() {
       await VideoPlayerPlatform.instance.pause(videoPlayerId);
 
       // The expected list of event types should look like this:
-      // 1. playingUpdate (videoElement.onPlaying)
+      // 1. isPlayingStateUpdate (videoElement.onPlaying)
       // 2. bufferingStart,
       // 3. bufferingUpdate (videoElement.onWaiting),
       // 4. initialized (videoElement.onCanPlay),
@@ -231,7 +232,7 @@ void main() {
       expect(
           events.map((VideoEvent e) => e.eventType),
           equals(<VideoEventType>[
-            VideoEventType.playingUpdate,
+            VideoEventType.isPlayingStateUpdate,
             VideoEventType.bufferingStart,
             VideoEventType.bufferingUpdate,
             VideoEventType.initialized,

--- a/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
+++ b/packages/video_player/video_player_web/example/integration_test/video_player_web_test.dart
@@ -175,7 +175,7 @@ void main() {
           VideoPlayerPlatform.instance.videoEventsFor(videoPlayerId);
 
       final Future<List<VideoEvent>> stream = eventStream.timeout(
-        const Duration(seconds: 1),
+        const Duration(seconds: 2),
         onTimeout: (EventSink<VideoEvent> sink) {
           sink.close();
         },
@@ -184,23 +184,25 @@ void main() {
       await VideoPlayerPlatform.instance.setVolume(videoPlayerId, 0);
       await VideoPlayerPlatform.instance.play(videoPlayerId);
 
-      // Let the video play, until we stop seeing events for a second
+      // Let the video play, until we stop seeing events for two seconds
       final List<VideoEvent> events = await stream;
 
       await VideoPlayerPlatform.instance.pause(videoPlayerId);
 
       // The expected list of event types should look like this:
-      // 1. bufferingStart,
-      // 2. bufferingUpdate (videoElement.onWaiting),
-      // 3. initialized (videoElement.onCanPlay),
-      // 4. bufferingEnd (videoElement.onCanPlayThrough),
+      // 1. playingUpdate (videoElement.onPlaying)
+      // 2. bufferingStart,
+      // 3. bufferingUpdate (videoElement.onWaiting),
+      // 4. initialized (videoElement.onCanPlay),
+      // 5. bufferingEnd (videoElement.onCanPlayThrough),
       expect(
           events.map((VideoEvent e) => e.eventType),
           equals(<VideoEventType>[
+            VideoEventType.playingUpdate,
             VideoEventType.bufferingStart,
             VideoEventType.bufferingUpdate,
             VideoEventType.initialized,
-            VideoEventType.bufferingEnd
+            VideoEventType.bufferingEnd,
           ]));
     });
   });

--- a/packages/video_player/video_player_web/example/pubspec.yaml
+++ b/packages/video_player/video_player_web/example/pubspec.yaml
@@ -20,3 +20,8 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../../video_player_platform_interface

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -104,14 +104,14 @@ class VideoPlayer {
 
     _videoElement.onPlay.listen((dynamic _) {
       _eventController.add(VideoEvent(
-        eventType: VideoEventType.playingUpdate,
+        eventType: VideoEventType.isPlayingStateUpdate,
         isPlaying: true,
       ));
     });
 
     _videoElement.onPause.listen((dynamic _) {
       _eventController.add(VideoEvent(
-        eventType: VideoEventType.playingUpdate,
+        eventType: VideoEventType.isPlayingStateUpdate,
         isPlaying: false,
       ));
     });

--- a/packages/video_player/video_player_web/lib/src/video_player.dart
+++ b/packages/video_player/video_player_web/lib/src/video_player.dart
@@ -102,6 +102,20 @@ class VideoPlayer {
       ));
     });
 
+    _videoElement.onPlay.listen((dynamic _) {
+      _eventController.add(VideoEvent(
+        eventType: VideoEventType.playingUpdate,
+        isPlaying: true,
+      ));
+    });
+
+    _videoElement.onPause.listen((dynamic _) {
+      _eventController.add(VideoEvent(
+        eventType: VideoEventType.playingUpdate,
+        isPlaying: false,
+      ));
+    });
+
     _videoElement.onEnded.listen((dynamic _) {
       setBuffering(false);
       _eventController.add(VideoEvent(eventType: VideoEventType.completed));

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -26,3 +26,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+
+# FOR TESTING ONLY. DO NOT MERGE.
+dependency_overrides:
+  video_player_platform_interface:
+    path: ../video_player_platform_interface

--- a/packages/video_player/video_player_web/pubspec.yaml
+++ b/packages/video_player/video_player_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: video_player_web
 description: Web platform implementation of video_player.
 repository: https://github.com/flutter/plugins/tree/main/packages/video_player/video_player_web
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+video_player%22
-version: 2.0.13
+version: 2.0.14
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Resolves flutter/flutter#49081.
Resolves flutter/flutter#120872.

This PR synchronizes `isPlaying` state between native and dart code, for example if a headset is unplugged or a phone call interrupts the video.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
